### PR TITLE
refactor: loosen trait bounds on Clone

### DIFF
--- a/rstsr-core/src/dev_utilities/mod.rs
+++ b/rstsr-core/src/dev_utilities/mod.rs
@@ -13,8 +13,8 @@ pub fn allclose_f64<RA, RB, DA, DB, BA, BB>(
     b: &TensorAny<RB, f64, BB, DB>,
 ) -> bool
 where
-    RA: DataAPI<Data = <BA as DeviceRawAPI<f64>>::Raw>,
-    RB: DataAPI<Data = <BB as DeviceRawAPI<f64>>::Raw>,
+    RA: DataCloneAPI<Data = <BA as DeviceRawAPI<f64>>::Raw>,
+    RB: DataCloneAPI<Data = <BB as DeviceRawAPI<f64>>::Raw>,
     DA: DimAPI,
     DB: DimAPI,
     BA: DeviceAPI<f64, Raw = Vec<f64>>,
@@ -60,7 +60,8 @@ where
         + OpAssignArbitaryAPI<T, IxD, D>
         + OpAssignArbitaryAPI<T, D, D>
         + DeviceMatMulAPI<T, T, T, IxD, IxD, IxD>,
-    R: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
+    R: DataCloneAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
+    <B as DeviceRawAPI<T>>::Raw: Clone,
     for<'a> R: DataIntoCowAPI<'a>,
 {
     let range = linspace((T::zero(), T::from(a.size()).unwrap(), a.size(), false, a.device()));

--- a/rstsr-core/src/device_cpu_serial/creation.rs
+++ b/rstsr-core/src/device_cpu_serial/creation.rs
@@ -3,7 +3,6 @@ use num::{complex::ComplexFloat, Num};
 
 impl<T> DeviceCreationAnyAPI<T> for DeviceCpuSerial
 where
-    T: Clone,
     DeviceCpuSerial: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     unsafe fn empty_impl(
@@ -18,7 +17,10 @@ where
         &self,
         len: usize,
         fill: T,
-    ) -> Result<Storage<DataOwned<Vec<T>>, T, DeviceCpuSerial>> {
+    ) -> Result<Storage<DataOwned<Vec<T>>, T, DeviceCpuSerial>>
+    where
+        T: Clone,
+    {
         let raw = vec![fill; len];
         Ok(Storage::new(raw.into(), self.clone()))
     }
@@ -27,7 +29,10 @@ where
         Ok(Storage::new(vec.into(), self.clone()))
     }
 
-    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, DeviceCpuSerial>> {
+    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, DeviceCpuSerial>>
+    where
+        T: Clone,
+    {
         Ok(Storage::new(vec.to_vec().into(), self.clone()))
     }
 }

--- a/rstsr-core/src/device_cpu_serial/device.rs
+++ b/rstsr-core/src/device_cpu_serial/device.rs
@@ -16,17 +16,11 @@ impl DeviceBaseAPI for DeviceCpuSerial {
     }
 }
 
-impl<T> DeviceRawAPI<T> for DeviceCpuSerial
-where
-    T: Clone,
-{
+impl<T> DeviceRawAPI<T> for DeviceCpuSerial {
     type Raw = Vec<T>;
 }
 
-impl<T> DeviceStorageAPI<T> for DeviceCpuSerial
-where
-    T: Clone,
-{
+impl<T> DeviceStorageAPI<T> for DeviceCpuSerial {
     fn len<R>(storage: &Storage<R, T, Self>) -> usize
     where
         R: DataAPI<Data = Self::Raw>,
@@ -36,14 +30,16 @@ where
 
     fn to_cpu_vec<R>(storage: &Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         Ok(storage.raw().clone())
     }
 
     fn into_cpu_vec<R>(storage: Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         let (raw, _) = storage.into_raw_parts();
         Ok(raw.into_owned().into_raw())
@@ -52,6 +48,7 @@ where
     #[inline]
     fn get_index<R>(storage: &Storage<R, T, Self>, index: usize) -> T
     where
+        T: Clone,
         R: DataAPI<Data = Self::Raw>,
     {
         storage.raw()[index].clone()
@@ -82,7 +79,7 @@ where
     }
 }
 
-impl<T> DeviceAPI<T> for DeviceCpuSerial where T: Clone {}
+impl<T> DeviceAPI<T> for DeviceCpuSerial {}
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceCpuSerial
 where
     T: ComplexFloat,

--- a/rstsr-core/src/device_faer/conversion.rs
+++ b/rstsr-core/src/device_faer/conversion.rs
@@ -124,7 +124,7 @@ impl<'a, R, T, D> DeviceChangeAPI<'a, DeviceCpuSerial, R, T, D> for DeviceFaer
 where
     T: Clone + Send + Sync + 'a,
     D: DimAPI,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
 {
     type Repr = R;
     type ReprTo = DataRef<'a, Vec<T>>;
@@ -161,7 +161,7 @@ impl<'a, R, T, D> DeviceChangeAPI<'a, DeviceFaer, R, T, D> for DeviceCpuSerial
 where
     T: Clone + Send + Sync + 'a,
     D: DimAPI,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
 {
     type Repr = R;
     type ReprTo = DataRef<'a, Vec<T>>;

--- a/rstsr-core/src/device_faer/creation.rs
+++ b/rstsr-core/src/device_faer/creation.rs
@@ -4,7 +4,6 @@ use num::{complex::ComplexFloat, Num};
 // for creation, we use most of the functions from DeviceCpuSerial
 impl<T> DeviceCreationAnyAPI<T> for DeviceFaer
 where
-    T: Clone,
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
@@ -13,7 +12,10 @@ where
         Ok(Storage::new(data, self.clone()))
     }
 
-    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
         let storage = DeviceCpuSerial.full_impl(len, fill)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
@@ -23,7 +25,10 @@ where
         Ok(Storage::new(DataOwned::from(vec), self.clone()))
     }
 
-    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
         let raw = vec.to_vec();
         Ok(Storage::new(DataOwned::from(raw), self.clone()))
     }

--- a/rstsr-core/src/device_faer/device.rs
+++ b/rstsr-core/src/device_faer/device.rs
@@ -48,17 +48,11 @@ impl DeviceBaseAPI for DeviceFaer {
     }
 }
 
-impl<T> DeviceRawAPI<T> for DeviceFaer
-where
-    T: Clone,
-{
+impl<T> DeviceRawAPI<T> for DeviceFaer {
     type Raw = Vec<T>;
 }
 
-impl<T> DeviceStorageAPI<T> for DeviceFaer
-where
-    T: Clone,
-{
+impl<T> DeviceStorageAPI<T> for DeviceFaer {
     fn len<R>(storage: &Storage<R, T, Self>) -> usize
     where
         R: DataAPI<Data = Self::Raw>,
@@ -68,14 +62,16 @@ where
 
     fn to_cpu_vec<R>(storage: &Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         Ok(storage.raw().clone())
     }
 
     fn into_cpu_vec<R>(storage: Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         let (raw, _) = storage.into_raw_parts();
         Ok(raw.into_owned().into_raw())
@@ -84,6 +80,7 @@ where
     #[inline]
     fn get_index<R>(storage: &Storage<R, T, Self>, index: usize) -> T
     where
+        T: Clone,
         R: DataAPI<Data = Self::Raw>,
     {
         storage.raw()[index].clone()
@@ -114,7 +111,7 @@ where
     }
 }
 
-impl<T> DeviceAPI<T> for DeviceFaer where T: Clone {}
+impl<T> DeviceAPI<T> for DeviceFaer {}
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceFaer
 where
     T: ComplexFloat + Send + Sync,

--- a/rstsr-core/src/docs/api_specification.md
+++ b/rstsr-core/src/docs/api_specification.md
@@ -81,6 +81,7 @@ Device is designed to be able extended by other crates. The above devices [`Devi
 | enum | [`DataCow<'l, C>`][crate::storage::data::DataCow] | Enum wrapper for mutable reference of raw data (or manually-dropped data). |
 | struct | [`DataArc<C>`][crate::storage::data::DataArc] | Struct wrapper for atomic reference-counted raw data pointer. |
 | trait | [`DataAPI`] | Interface of immutable operations for data representations. |
+| trait | [`DataCloneAPI`] | Interface of underlying data cloning for data representations. |
 | trait | [`DataMutAPI`] | Interface of mutable operations for data representations. |
 | trait | [`DataIntoCowAPI<'l>`][DataIntoCowAPI] | Interface for generating [`DataCow<'l, C>`][crate::storage::data::DataCow]. |
 | trait | [`DataForceMutAPI`] | Interface for generating mutable reference, ignoring lifetime and borrow checks. |

--- a/rstsr-core/src/docs/lib.md
+++ b/rstsr-core/src/docs/lib.md
@@ -35,7 +35,7 @@ For NumPy users, in this meantime, [fullfillment for Array API standard](`array_
 | `B` | Backend (device) type (applies [`DeviceAPI`]) |
 | `D` | Dimensional (applies [`DimAPI`]) |
 | `S` | Storage (struct [`storage::Storage`]) |
-| `R` | Data with lifetime and mutability (applies [`DataAPI`]) |
+| `R` | Data with lifetime and mutability (applies [`DataCloneAPI`]) |
 | `C` | Content (usually `Vec<T>` for CPU devices) |
 
 ### Variable or Names

--- a/rstsr-core/src/format/format_tensor.rs
+++ b/rstsr-core/src/format/format_tensor.rs
@@ -212,8 +212,9 @@ impl<R, T, B, D> Display for TensorAny<R, T, B, D>
 where
     T: Clone + Display,
     B: DeviceAPI<T>,
+    B::Raw: Clone,
     D: DimAPI,
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let vec = self.storage().to_cpu_vec().unwrap();
@@ -422,8 +423,9 @@ impl<R, T, B, D> Debug for TensorAny<R, T, B, D>
 where
     T: Clone + Debug,
     B: DeviceAPI<T> + Debug,
+    B::Raw: Clone,
     D: DimAPI,
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         writeln!(f, "\n=== Debug Tensor Print ===")?;

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -5,7 +5,7 @@ pub mod rstsr_traits {
     };
     pub use crate::storage::conversion::DeviceChangeAPI;
     pub use crate::storage::data::{
-        DataAPI, DataForceMutAPI, DataIntoCowAPI, DataMutAPI, DataOwnedAPI,
+        DataAPI, DataCloneAPI, DataForceMutAPI, DataIntoCowAPI, DataMutAPI, DataOwnedAPI,
     };
     pub use crate::storage::device::{DeviceAPI, DeviceBaseAPI, DeviceRawAPI, DeviceStorageAPI};
     pub use crate::tensor::asarray::AsArrayAPI;

--- a/rstsr-core/src/storage/creation.rs
+++ b/rstsr-core/src/storage/creation.rs
@@ -9,10 +9,14 @@ where
     ///
     /// This function is unsafe because it does not initialize the memory.
     unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>;
-    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>;
+    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>
+    where
+        T: Clone;
     fn outof_cpu_vec(&self, vec: Vec<T>) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>;
     #[allow(clippy::wrong_self_convention)]
-    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>;
+    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Self::Raw>, T, Self>>
+    where
+        T: Clone;
 }
 
 pub trait DeviceCreationNumAPI<T>

--- a/rstsr-core/src/storage/device.rs
+++ b/rstsr-core/src/storage/device.rs
@@ -5,7 +5,7 @@ pub trait DeviceBaseAPI: Default + Clone {
 }
 
 pub trait DeviceRawAPI<T>: DeviceBaseAPI {
-    type Raw: Clone;
+    type Raw;
 }
 
 #[derive(Debug)]
@@ -30,12 +30,15 @@ pub trait DeviceStorageAPI<T>: DeviceRawAPI<T> {
     }
     fn to_cpu_vec<R>(storage: &Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>;
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>;
     fn into_cpu_vec<R>(storage: Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>;
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>;
     fn get_index<R>(storage: &Storage<R, T, Self>, index: usize) -> T
     where
+        T: Clone,
         R: DataAPI<Data = Self::Raw>;
     fn get_index_ptr<R>(storage: &Storage<R, T, Self>, index: usize) -> *const T
     where
@@ -81,16 +84,27 @@ where
         B::is_empty(self)
     }
 
-    pub fn to_cpu_vec(&self) -> Result<Vec<T>> {
+    pub fn to_cpu_vec(&self) -> Result<Vec<T>>
+    where
+        B::Raw: Clone,
+        R: DataCloneAPI<Data = B::Raw>,
+    {
         B::to_cpu_vec(self)
     }
 
-    pub fn into_cpu_vec(self) -> Result<Vec<T>> {
+    pub fn into_cpu_vec(self) -> Result<Vec<T>>
+    where
+        B::Raw: Clone,
+        R: DataCloneAPI<Data = B::Raw>,
+    {
         B::into_cpu_vec(self)
     }
 
     #[inline]
-    pub fn get_index(&self, index: usize) -> T {
+    pub fn get_index(&self, index: usize) -> T
+    where
+        T: Clone,
+    {
         B::get_index(self, index)
     }
 

--- a/rstsr-core/src/tensor/creation.rs
+++ b/rstsr-core/src/tensor/creation.rs
@@ -214,7 +214,6 @@ impl<T, D, L> EmptyAPI<(T, D)> for L
 where
     L: Into<Layout<D>>,
     D: DimAPI,
-    T: Clone,
 {
     type Out = Tensor<T, DeviceCpu, IxD>;
 
@@ -321,7 +320,6 @@ where
 impl<R, T, B, D> EmptyLikeAPI<()> for &TensorAny<R, T, B, D>
 where
     R: DataAPI<Data = B::Raw>,
-    T: Clone,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
 {
@@ -493,6 +491,7 @@ where
 
 impl<T, D, B, L> FullAPI<(T, D)> for (L, T, &B)
 where
+    T: Clone,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
     L: Into<Layout<D>>,
@@ -561,6 +560,7 @@ where
 
 impl<R, T, B, D> FullLikeAPI<()> for (&TensorAny<R, T, B, D>, T, TensorIterOrder, &B)
 where
+    T: Clone,
     R: DataAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
@@ -578,6 +578,7 @@ where
 
 impl<R, T, B, D> FullLikeAPI<()> for (&TensorAny<R, T, B, D>, T, &B)
 where
+    T: Clone,
     R: DataAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
@@ -592,6 +593,7 @@ where
 
 impl<R, T, B, D> FullLikeAPI<()> for (&TensorAny<R, T, B, D>, T, TensorIterOrder)
 where
+    T: Clone,
     R: DataAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
@@ -607,6 +609,7 @@ where
 
 impl<R, T, B, D> FullLikeAPI<()> for (&TensorAny<R, T, B, D>, T)
 where
+    T: Clone,
     R: DataAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
@@ -1155,6 +1158,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1177,6 +1181,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1263,6 +1268,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1282,6 +1288,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1335,6 +1342,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1357,6 +1365,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1443,6 +1452,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 
@@ -1462,6 +1472,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, D, D>
         + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     type Out = Tensor<T, B, D>;
 

--- a/rstsr-core/src/tensor/iterator_axes.rs
+++ b/rstsr-core/src/tensor/iterator_axes.rs
@@ -73,7 +73,7 @@ where
 impl<'a, R, T, B, D> TensorAny<R, T, B, D>
 where
     T: Clone,
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T, Raw = Vec<T>> + 'a,
 {
@@ -417,7 +417,7 @@ where
 impl<'a, R, T, B, D> TensorAny<R, T, B, D>
 where
     T: Clone,
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
     D: DimAPI,
     B: DeviceAPI<T, Raw = Vec<T>> + 'a,
 {

--- a/rstsr-core/src/tensor/manuplication.rs
+++ b/rstsr-core/src/tensor/manuplication.rs
@@ -1134,7 +1134,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, IxD, D>
         + OpAssignAPI<T, IxD>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     change_shape_f(tensor, shape).map(|v| v.into_owned())
 }
@@ -1150,7 +1150,7 @@ where
         + DeviceCreationAnyAPI<T>
         + OpAssignArbitaryAPI<T, IxD, D>
         + OpAssignAPI<T, IxD>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     into_shape_f(tensor, shape).unwrap()
 }
@@ -1241,7 +1241,7 @@ where
     where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_shape_f(self, shape)
     }
@@ -1250,7 +1250,7 @@ where
     where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_shape(self, shape)
     }
@@ -1368,7 +1368,7 @@ where
     D2: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D2, D> + OpAssignAPI<T, D2>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     change_layout_f(tensor, layout).map(|v| v.into_owned())
 }
@@ -1383,7 +1383,7 @@ where
     D2: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D2, D> + OpAssignAPI<T, D2>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     into_layout_f(tensor, layout).unwrap()
 }
@@ -1433,7 +1433,7 @@ where
     where
         D2: DimAPI,
         B: OpAssignArbitaryAPI<T, D2, D> + OpAssignAPI<T, D2>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_layout_f(self, layout)
     }
@@ -1442,7 +1442,7 @@ where
     where
         D2: DimAPI,
         B: OpAssignArbitaryAPI<T, D2, D> + OpAssignAPI<T, D2>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_layout(self, layout)
     }
@@ -1506,7 +1506,7 @@ where
     D: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     change_contig_f(tensor, order).map(|v| v.into_owned())
 }
@@ -1544,7 +1544,7 @@ where
     D: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     into_contig_f(tensor, order).unwrap()
 }
@@ -1574,7 +1574,7 @@ where
     pub fn into_contig_f(self, order: TensorOrder) -> Result<Tensor<T, B, D>>
     where
         B: OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_contig_f(self, order)
     }
@@ -1582,7 +1582,7 @@ where
     pub fn into_contig(self, order: TensorOrder) -> Tensor<T, B, D>
     where
         B: OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_contig(self, order)
     }
@@ -1645,7 +1645,7 @@ where
     D: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     change_prefer_f(tensor, order).map(|v| v.into_owned())
 }
@@ -1683,7 +1683,7 @@ where
     D: DimAPI,
     T: Clone,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-    B::Raw: 'a,
+    B::Raw: Clone + 'a,
 {
     into_prefer_f(tensor, order).unwrap()
 }
@@ -1713,7 +1713,7 @@ where
     pub fn into_prefer_f(self, order: TensorOrder) -> Result<Tensor<T, B, D>>
     where
         B: OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_prefer_f(self, order)
     }
@@ -1721,7 +1721,7 @@ where
     pub fn into_prefer(self, order: TensorOrder) -> Tensor<T, B, D>
     where
         B: OpAssignArbitaryAPI<T, D, D> + OpAssignAPI<T, D>,
-        B::Raw: 'a,
+        B::Raw: Clone + 'a,
     {
         into_prefer(self, order)
     }

--- a/rstsr-core/src/tensor/ownership_conversion.rs
+++ b/rstsr-core/src/tensor/ownership_conversion.rs
@@ -51,7 +51,11 @@ where
     /// [`Tensor::into_owned`] keep data in some conditions, otherwise clone.
     /// This function can avoid cases where data memory bulk is large, but
     /// tensor view is small.
-    pub fn into_owned_keep_layout(self) -> Tensor<T, B, D> {
+    pub fn into_owned_keep_layout(self) -> Tensor<T, B, D>
+    where
+        R::Data: Clone,
+        R: DataCloneAPI,
+    {
         let (storage, layout) = self.into_raw_parts();
         let (data, device) = storage.into_raw_parts();
         let storage = Storage::new(data.into_owned(), device);
@@ -69,7 +73,11 @@ where
     /// [`Tensor::into_shared`] keep data in some conditions, otherwise clone.
     /// This function can avoid cases where data memory bulk is large, but
     /// tensor view is small.
-    pub fn into_shared_keep_layout(self) -> TensorArc<T, B, D> {
+    pub fn into_shared_keep_layout(self) -> TensorArc<T, B, D>
+    where
+        R::Data: Clone,
+        R: DataCloneAPI,
+    {
         let (storage, layout) = self.into_raw_parts();
         let (data, device) = storage.into_raw_parts();
         let storage = Storage::new(data.into_shared(), device);
@@ -79,7 +87,7 @@ where
 
 impl<R, T, B, D> TensorAny<R, T, B, D>
 where
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
     R::Data: Clone,
     D: DimAPI,
     T: Clone,
@@ -197,7 +205,8 @@ where
 
 impl<R, T, B, D> TensorAny<R, T, B, D>
 where
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
+    B::Raw: Clone,
     T: Clone,
     D: DimAPI,
     B: DeviceAPI<T>,
@@ -325,7 +334,8 @@ where
 
 impl<R, T, B, D> TensorIntoOwnedAPI<T, B, D> for TensorAny<R, T, B, D>
 where
-    R: DataAPI<Data = B::Raw>,
+    R: DataCloneAPI<Data = B::Raw>,
+    B::Raw: Clone,
     T: Clone,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignAPI<T, D>,

--- a/rstsr-core/src/tensor/tensor_mutable.rs
+++ b/rstsr-core/src/tensor/tensor_mutable.rs
@@ -55,6 +55,7 @@ where
     T: Clone,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignAPI<T, D>,
+    B::Raw: Clone,
 {
     fn into_owned(self) -> Tensor<T, B, D> {
         match self {

--- a/rstsr-core/src/tensorbase.rs
+++ b/rstsr-core/src/tensorbase.rs
@@ -2,7 +2,6 @@ use crate::prelude_dev::*;
 
 pub trait TensorBaseAPI {}
 
-#[derive(Clone)]
 pub struct TensorBase<S, D>
 where
     D: DimAPI,

--- a/rstsr-openblas/src/conversion.rs
+++ b/rstsr-openblas/src/conversion.rs
@@ -6,7 +6,7 @@ macro_rules! impl_change_device {
         where
             T: Clone + Send + Sync + 'a,
             D: DimAPI,
-            R: DataAPI<Data = Vec<T>>,
+            R: DataCloneAPI<Data = Vec<T>>,
         {
             type Repr = R;
             type ReprTo = DataRef<'a, Vec<T>>;
@@ -43,7 +43,7 @@ macro_rules! impl_change_device {
         where
             T: Clone + Send + Sync + 'a,
             D: DimAPI,
-            R: DataAPI<Data = Vec<T>>,
+            R: DataCloneAPI<Data = Vec<T>>,
         {
             type Repr = R;
             type ReprTo = DataRef<'a, Vec<T>>;

--- a/rstsr-openblas/src/creation.rs
+++ b/rstsr-openblas/src/creation.rs
@@ -4,7 +4,6 @@ use num::{complex::ComplexFloat, Num};
 // for creation, we use most of the functions from DeviceCpuSerial
 impl<T> DeviceCreationAnyAPI<T> for DeviceBLAS
 where
-    T: Clone,
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
@@ -13,7 +12,10 @@ where
         Ok(Storage::new(data, self.clone()))
     }
 
-    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
         let storage = DeviceCpuSerial.full_impl(len, fill)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
@@ -23,7 +25,10 @@ where
         Ok(Storage::new(DataOwned::from(vec), self.clone()))
     }
 
-    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
         let raw = vec.to_vec();
         Ok(Storage::new(DataOwned::from(raw), self.clone()))
     }

--- a/rstsr-openblas/src/device.rs
+++ b/rstsr-openblas/src/device.rs
@@ -41,17 +41,11 @@ impl DeviceBaseAPI for DeviceBLAS {
     }
 }
 
-impl<T> DeviceRawAPI<T> for DeviceBLAS
-where
-    T: Clone,
-{
+impl<T> DeviceRawAPI<T> for DeviceBLAS {
     type Raw = Vec<T>;
 }
 
-impl<T> DeviceStorageAPI<T> for DeviceBLAS
-where
-    T: Clone,
-{
+impl<T> DeviceStorageAPI<T> for DeviceBLAS {
     fn len<R>(storage: &Storage<R, T, Self>) -> usize
     where
         R: DataAPI<Data = Self::Raw>,
@@ -61,14 +55,16 @@ where
 
     fn to_cpu_vec<R>(storage: &Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         Ok(storage.raw().clone())
     }
 
     fn into_cpu_vec<R>(storage: Storage<R, T, Self>) -> Result<Vec<T>>
     where
-        R: DataAPI<Data = Self::Raw>,
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
     {
         let (raw, _) = storage.into_raw_parts();
         Ok(raw.into_owned().into_raw())
@@ -77,6 +73,7 @@ where
     #[inline]
     fn get_index<R>(storage: &Storage<R, T, Self>, index: usize) -> T
     where
+        T: Clone,
         R: DataAPI<Data = Self::Raw>,
     {
         storage.raw()[index].clone()
@@ -107,7 +104,7 @@ where
     }
 }
 
-impl<T> DeviceAPI<T> for DeviceBLAS where T: Clone {}
+impl<T> DeviceAPI<T> for DeviceBLAS {}
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
     T: ComplexFloat + Send + Sync,

--- a/rstsr-openblas/src/impl_linalg_traits/cholesky.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/cholesky.rs
@@ -6,7 +6,7 @@ use rstsr_linalg_traits::prelude_dev::*;
 impl<R, T> LinalgCholeskyAPI<DeviceBLAS> for (&TensorAny<R, T, DeviceBLAS, Ix2>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, Ix2> + POTRFDriverAPI<T>,
 {
     type Out = Tensor<T, DeviceBLAS, Ix2>;

--- a/rstsr-openblas/src/impl_linalg_traits/eigh.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/eigh.rs
@@ -6,7 +6,7 @@ use rstsr_linalg_traits::prelude_dev::*;
 impl<R, T> LinalgEighAPI<DeviceBLAS> for &TensorAny<R, T, DeviceBLAS, Ix2>
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: BlasThreadAPI
         + DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<T::Real, Raw = Vec<T::Real>>
@@ -53,8 +53,8 @@ impl<Ra, Rb, T> LinalgEighAPI<DeviceBLAS>
     for (&TensorAny<Ra, T, DeviceBLAS, Ix2>, &TensorAny<Rb, T, DeviceBLAS, Ix2>)
 where
     T: BlasFloat + Send + Sync,
-    Ra: DataAPI<Data = Vec<T>>,
-    Rb: DataAPI<Data = Vec<T>>,
+    Ra: DataCloneAPI<Data = Vec<T>>,
+    Rb: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: BlasThreadAPI
         + DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<T::Real, Raw = Vec<T::Real>>

--- a/rstsr-openblas/src/impl_linalg_traits/inv.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/inv.rs
@@ -6,7 +6,7 @@ use rstsr_linalg_traits::prelude_dev::*;
 impl<R, T> LinalgInvAPI<DeviceBLAS> for &TensorAny<R, T, DeviceBLAS, Ix2>
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + GETRIDriverAPI<T>
         + GETRFDriverAPI<T>

--- a/rstsr-openblas/src/impl_linalg_traits/solve_general.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_general.rs
@@ -7,8 +7,8 @@ impl<Ra, Rb, T> LinalgSolveGeneralAPI<DeviceBLAS>
     for (&TensorAny<Ra, T, DeviceBLAS, Ix2>, &TensorAny<Rb, T, DeviceBLAS, Ix2>)
 where
     T: BlasFloat + Send + Sync,
-    Ra: DataAPI<Data = Vec<T>>,
-    Rb: DataAPI<Data = Vec<T>>,
+    Ra: DataCloneAPI<Data = Vec<T>>,
+    Rb: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -45,7 +45,7 @@ impl<R, T> LinalgSolveGeneralAPI<DeviceBLAS>
     for (&TensorAny<R, T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>)
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>

--- a/rstsr-openblas/src/impl_linalg_traits/solve_symmetric.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_symmetric.rs
@@ -7,8 +7,8 @@ impl<Ra, Rb, T> LinalgSolveSymmetricAPI<DeviceBLAS>
     for (&TensorAny<Ra, T, DeviceBLAS, Ix2>, &TensorAny<Rb, T, DeviceBLAS, Ix2>, bool, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
-    Ra: DataAPI<Data = Vec<T>>,
-    Rb: DataAPI<Data = Vec<T>>,
+    Ra: DataCloneAPI<Data = Vec<T>>,
+    Rb: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -47,7 +47,7 @@ impl<R, T> LinalgSolveSymmetricAPI<DeviceBLAS>
     for (&TensorAny<R, T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>, bool, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>

--- a/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
@@ -7,8 +7,8 @@ impl<Ra, Rb, T> LinalgSolveTriangularAPI<DeviceBLAS>
     for (&TensorAny<Ra, T, DeviceBLAS, Ix2>, &TensorAny<Rb, T, DeviceBLAS, Ix2>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
-    Ra: DataAPI<Data = Vec<T>>,
-    Rb: DataAPI<Data = Vec<T>>,
+    Ra: DataCloneAPI<Data = Vec<T>>,
+    Rb: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -45,7 +45,7 @@ impl<R, T> LinalgSolveTriangularAPI<DeviceBLAS>
     for (&TensorAny<R, T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
-    R: DataAPI<Data = Vec<T>>,
+    R: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>


### PR DESCRIPTION
This is a somehow large refactor.

This commit explicitly loosen some `Clone` trait bounds on data type `T` and device storage `B::Raw`.
As a result, now we can generate tensors with type that is not cloneable, such as
```rust
let a: Tensor<MaybeUninit<Vec<usize>>, _> = unsafe { rt::empty([12]) };
```
As previous issue https://github.com/RESTGroup/rstsr/issues/7 states, using `empty` for types other than `MaybeUninit` can cause UB; so using empty function is not best practice. However, at least we have made `Tensor<MaybeUninit<Vec<usize>>, _>` accessible for RSTSR, since `MaybeUninit<Vec<usize>>` is not cloneable.