### PR TITLE
Reduction operation enhancement and refactor

### DIFF
--- a/rstsr-core/benches/tensor_sum.rs
+++ b/rstsr-core/benches/tensor_sum.rs
@@ -45,7 +45,7 @@ fn rstsr_serial_4096(criterion: &mut Criterion) {
     criterion.bench_function("rstsr serial simple sum 4096 leading dimension", |bencher| {
         bencher.iter(|| {
             // let c = b.i(0) + b.i(1) + b.i(2) + b.i(3);
-            let c = b.sum(0);
+            let c = b.sum_axes(0);
             black_box(c);
         })
     });
@@ -54,7 +54,7 @@ fn rstsr_serial_4096(criterion: &mut Criterion) {
     let b = b_full.reshape([4, n, n]);
     criterion.bench_function("rstsr serial simple sum 4096 last dimension", |bencher| {
         bencher.iter(|| {
-            let c = b.sum([-1, -2]);
+            let c = b.sum_axes([-1, -2]);
             black_box(c);
         })
     });
@@ -102,7 +102,7 @@ fn rstsr_rayon_4096(criterion: &mut Criterion) {
     criterion.bench_function("rstsr rayon simple sum 4096 leading dimension", |bencher| {
         bencher.iter(|| {
             // let c = b.i(0) + b.i(1) + b.i(2) + b.i(3);
-            let c = b.sum(0);
+            let c = b.sum_axes(0);
             black_box(c);
         })
     });
@@ -111,7 +111,7 @@ fn rstsr_rayon_4096(criterion: &mut Criterion) {
     let b = b_full.reshape([4, n, n]);
     criterion.bench_function("rstsr serial simple sum 4096 last dimension", |bencher| {
         bencher.iter(|| {
-            let c = b.sum([-1, -2]);
+            let c = b.sum_axes([-1, -2]);
             black_box(c);
         })
     });

--- a/rstsr-core/src/dev_utilities/mod.rs
+++ b/rstsr-core/src/dev_utilities/mod.rs
@@ -47,7 +47,7 @@ where
 /// # See also
 ///
 /// PySCF `pyscf.lib.misc.fingerprint`
-/// https://github.com/pyscf/pyscf/blob/6f6d3741bf42543e02ccaa1d4ef43d9bf83b3dda/pyscf/lib/misc.py#L1249-L1253
+/// <https://github.com/pyscf/pyscf/blob/6f6d3741bf42543e02ccaa1d4ef43d9bf83b3dda/pyscf/lib/misc.py#L1249-L1253>
 pub fn fingerprint<R, T, B, D>(a: &TensorAny<R, T, B, D>) -> T
 where
     T: ComplexFloat,

--- a/rstsr-core/src/device_cpu_serial/operators/reduction.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/reduction.rs
@@ -334,12 +334,14 @@ where
     T: Clone + PartialOrd,
     D: DimAPI,
 {
+    type TOut = usize;
+
     fn argmin_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
         axes: &[isize],
-    ) -> Result<(Storage<DataOwned<Vec<IxD>>, IxD, Self>, Layout<IxD>)> {
+    ) -> Result<(Storage<DataOwned<Vec<usize>>, Self::TOut, Self>, Layout<IxD>)> {
         let f_comp = |x: Option<T>, y: T| -> Option<bool> {
             if let Some(x) = x {
                 Some(y < x)
@@ -354,11 +356,11 @@ where
                 Some(false)
             }
         };
-        let (out, layout_out) = reduce_axes_arg_cpu_serial(a, la, axes, f_comp, f_eq)?;
+        let (out, layout_out) = reduce_axes_arg_cpu_serial(a, la, axes, f_comp, f_eq, RowMajor)?;
         Ok((Storage::new(out.into(), self.clone()), layout_out))
     }
 
-    fn argmin_all(&self, a: &<Self as DeviceRawAPI<T>>::Raw, la: &Layout<D>) -> Result<D> {
+    fn argmin_all(&self, a: &Vec<T>, la: &Layout<D>) -> Result<Self::TOut> {
         let f_comp = |x: Option<T>, y: T| -> Option<bool> {
             if let Some(x) = x {
                 Some(y < x)
@@ -373,7 +375,7 @@ where
                 Some(false)
             }
         };
-        let result = reduce_arg_all_cpu_serial(a, la, f_comp, f_eq)?;
+        let result = reduce_all_arg_cpu_serial(a, la, f_comp, f_eq, RowMajor)?;
         Ok(result)
     }
 }
@@ -383,7 +385,111 @@ where
     T: Clone + PartialOrd,
     D: DimAPI,
 {
+    type TOut = usize;
+
     fn argmax_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<usize>>, Self::TOut, Self>, Layout<IxD>)> {
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) = reduce_axes_arg_cpu_serial(a, la, axes, f_comp, f_eq, RowMajor)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn argmax_all(&self, a: &Vec<T>, la: &Layout<D>) -> Result<Self::TOut> {
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_arg_cpu_serial(a, la, f_comp, f_eq, RowMajor)?;
+        Ok(result)
+    }
+}
+
+impl<T, D> OpUnraveledArgMinAPI<T, D> for DeviceCpuSerial
+where
+    T: Clone + PartialOrd,
+    D: DimAPI,
+{
+    fn unraveled_argmin_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<IxD>>, IxD, Self>, Layout<IxD>)> {
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) = reduce_axes_unraveled_arg_cpu_serial(a, la, axes, f_comp, f_eq)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn unraveled_argmin_all(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+    ) -> Result<D> {
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_unraveled_arg_cpu_serial(a, la, f_comp, f_eq)?;
+        Ok(result)
+    }
+}
+
+impl<T, D> OpUnraveledArgMaxAPI<T, D> for DeviceCpuSerial
+where
+    T: Clone + PartialOrd,
+    D: DimAPI,
+{
+    fn unraveled_argmax_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -403,11 +509,15 @@ where
                 Some(false)
             }
         };
-        let (out, layout_out) = reduce_axes_arg_cpu_serial(a, la, axes, f_comp, f_eq)?;
+        let (out, layout_out) = reduce_axes_unraveled_arg_cpu_serial(a, la, axes, f_comp, f_eq)?;
         Ok((Storage::new(out.into(), self.clone()), layout_out))
     }
 
-    fn argmax_all(&self, a: &<Self as DeviceRawAPI<T>>::Raw, la: &Layout<D>) -> Result<D> {
+    fn unraveled_argmax_all(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+    ) -> Result<D> {
         let f_comp = |x: Option<T>, y: T| -> Option<bool> {
             if let Some(x) = x {
                 Some(y > x)
@@ -422,7 +532,7 @@ where
                 Some(false)
             }
         };
-        let result = reduce_arg_all_cpu_serial(a, la, f_comp, f_eq)?;
+        let result = reduce_all_unraveled_arg_cpu_serial(a, la, f_comp, f_eq)?;
         Ok(result)
     }
 }

--- a/rstsr-core/src/device_cpu_serial/operators/reduction.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/reduction.rs
@@ -21,7 +21,7 @@ where
         reduce_all_cpu_serial(a, la, f_init, f, f_sum, f_out)
     }
 
-    fn sum(
+    fn sum_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -57,7 +57,7 @@ where
         reduce_all_cpu_serial(a, la, f_init, f, f_sum, f_out)
     }
 
-    fn min(
+    fn min_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -98,7 +98,7 @@ where
         reduce_all_cpu_serial(a, la, f_init, f, f_sum, f_out)
     }
 
-    fn max(
+    fn max_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -135,7 +135,7 @@ where
         reduce_all_cpu_serial(a, la, f_init, f, f_sum, f_out)
     }
 
-    fn prod(
+    fn prod_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -170,7 +170,7 @@ where
         Ok(sum)
     }
 
-    fn mean(
+    fn mean_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -214,7 +214,7 @@ where
         Ok(result)
     }
 
-    fn var(
+    fn var_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -266,7 +266,7 @@ where
         Ok(result)
     }
 
-    fn std(
+    fn std_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -311,7 +311,7 @@ where
         Ok(result)
     }
 
-    fn l2_norm(
+    fn l2_norm_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -334,7 +334,7 @@ where
     T: Clone + PartialOrd,
     D: DimAPI,
 {
-    fn argmin(
+    fn argmin_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -383,7 +383,7 @@ where
     T: Clone + PartialOrd,
     D: DimAPI,
 {
-    fn argmax(
+    fn argmax_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,

--- a/rstsr-core/src/device_cpu_serial/reduction.rs
+++ b/rstsr-core/src/device_cpu_serial/reduction.rs
@@ -49,6 +49,8 @@ where
     acc
 }
 
+/* #region reduce */
+
 pub fn reduce_all_cpu_serial<TI, TS, TO, D, I, F, FSum, FOut>(
     a: &[TI],
     la: &Layout<D>,
@@ -83,57 +85,6 @@ where
         let acc = iter_a.fold(init(), |acc, idx| f(acc, a[idx].clone()));
         return Ok(f_out(acc));
     }
-}
-
-pub fn reduce_arg_all_cpu_serial<T, D, Fcomp, Feq>(
-    a: &[T],
-    la: &Layout<D>,
-    f_comp: Fcomp,
-    f_eq: Feq,
-) -> Result<D>
-where
-    T: Clone,
-    D: DimAPI,
-    Fcomp: Fn(Option<T>, T) -> Option<bool>,
-    Feq: Fn(Option<T>, T) -> Option<bool>,
-{
-    rstsr_assert!(la.size() > 0, InvalidLayout, "empty sequence is not allowed for reduce_arg.")?;
-
-    let fold_func = |acc: Option<(D, T)>, (cur_idx, cur_offset): (D, usize)| {
-        let cur_val = a[cur_offset].clone();
-
-        let comp = f_comp(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
-        if let Some(comp) = comp {
-            if comp {
-                // cond 1: current value is accepted
-                Some((cur_idx, cur_val))
-            } else {
-                let comp_eq = f_eq(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
-                if comp_eq.is_some_and(|x| x) {
-                    // cond 2: current value is same with previous value, return smaller index
-                    if let Some(acc_idx) = acc.as_ref().map(|(idx, _)| idx.clone()) {
-                        if cur_idx < acc_idx {
-                            Some((cur_idx, cur_val))
-                        } else {
-                            acc
-                        }
-                    } else {
-                        Some((cur_idx, cur_val))
-                    }
-                } else {
-                    // cond 3: current value is not accepted
-                    acc
-                }
-            }
-        } else {
-            // cond 4: current comparasion is not valid
-            acc
-        }
-    };
-
-    let iter_a = IndexedIterLayout::new(la, RowMajor)?;
-    let acc = iter_a.into_iter().fold(None, fold_func);
-    return Ok(acc.unwrap().0);
 }
 
 pub fn reduce_axes_cpu_serial<TI, TS, I, F, FSum, FOut>(
@@ -213,56 +164,6 @@ where
         op_muta_func_cpu_serial(&mut out, &layout_out, fin_inplace)?;
         return Ok((out, layout_out));
     }
-}
-
-pub fn reduce_axes_arg_cpu_serial<T, D, Fcomp, Feq>(
-    a: &[T],
-    la: &Layout<D>,
-    axes: &[isize],
-    f_comp: Fcomp,
-    f_eq: Feq,
-) -> Result<(Vec<IxD>, Layout<IxD>)>
-where
-    T: Clone,
-    D: DimAPI,
-    Fcomp: Fn(Option<T>, T) -> Option<bool>,
-    Feq: Fn(Option<T>, T) -> Option<bool>,
-{
-    rstsr_assert!(la.size() > 0, InvalidLayout, "empty sequence is not allowed for reduce_arg.")?;
-
-    // split the layout into axes (to be summed) and the rest
-    let (layout_axes, layout_rest) = la.dim_split_axes(axes)?;
-
-    // generate layout for result (from layout_rest)
-    let layout_out = layout_for_array_copy(&layout_rest, TensorIterOrder::default())?;
-
-    // generate layouts for actual evaluation
-    let layouts_swapped =
-        translate_to_col_major(&[&layout_out, &layout_rest], TensorIterOrder::default())?;
-    let layout_out_swapped = &layouts_swapped[0];
-    let layout_rest_swapped = &layouts_swapped[1];
-
-    // iterate both layout_rest and layout_out
-    let iter_out_swapped = IterLayoutRowMajor::new(layout_out_swapped)?;
-    let iter_rest_swapped = IterLayoutRowMajor::new(layout_rest_swapped)?;
-
-    // inner layout is axes to be summed
-    let mut layout_inner = layout_axes.clone();
-
-    // prepare output
-    let len_out = layout_out.size();
-    let mut out = vec![IxD::default(); len_out];
-
-    // actual evaluation
-    izip!(iter_out_swapped, iter_rest_swapped).try_for_each(
-        |(idx_out, idx_rest)| -> Result<()> {
-            unsafe { layout_inner.set_offset(idx_rest) };
-            let acc = reduce_arg_all_cpu_serial(a, &layout_inner, &f_comp, &f_eq)?;
-            out[idx_out] = acc;
-            Ok(())
-        },
-    )?;
-    return Ok((out, layout_out));
 }
 
 pub fn reduce_axes_difftype_cpu_serial<TI, TS, TO, I, F, FSum, FOut>(
@@ -345,3 +246,162 @@ where
         return Ok((out_converted, layout_out));
     }
 }
+
+/* #endregion */
+
+/* #region reduce unraveled axes */
+
+pub fn reduce_all_unraveled_arg_cpu_serial<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    f_comp: Fcomp,
+    f_eq: Feq,
+) -> Result<D>
+where
+    T: Clone,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool>,
+    Feq: Fn(Option<T>, T) -> Option<bool>,
+{
+    rstsr_assert!(la.size() > 0, InvalidLayout, "empty sequence is not allowed for reduce_arg.")?;
+
+    let fold_func = |acc: Option<(D, T)>, (cur_idx, cur_offset): (D, usize)| {
+        let cur_val = a[cur_offset].clone();
+
+        let comp = f_comp(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
+        if let Some(comp) = comp {
+            if comp {
+                // cond 1: current value is accepted
+                Some((cur_idx, cur_val))
+            } else {
+                let comp_eq = f_eq(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
+                if comp_eq.is_some_and(|x| x) {
+                    // cond 2: current value is same with previous value, return smaller index
+                    if let Some(acc_idx) = acc.as_ref().map(|(idx, _)| idx.clone()) {
+                        if cur_idx < acc_idx {
+                            Some((cur_idx, cur_val))
+                        } else {
+                            acc
+                        }
+                    } else {
+                        Some((cur_idx, cur_val))
+                    }
+                } else {
+                    // cond 3: current value is not accepted
+                    acc
+                }
+            }
+        } else {
+            // cond 4: current comparasion is not valid
+            acc
+        }
+    };
+
+    let iter_a = IndexedIterLayout::new(la, RowMajor)?;
+    let acc = iter_a.into_iter().fold(None, fold_func);
+    if acc.is_none() {
+        rstsr_raise!(InvalidValue, "reduce_arg seems not returning a valid value.")?;
+    }
+    return Ok(acc.unwrap().0);
+}
+
+pub fn reduce_axes_unraveled_arg_cpu_serial<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    axes: &[isize],
+    f_comp: Fcomp,
+    f_eq: Feq,
+) -> Result<(Vec<IxD>, Layout<IxD>)>
+where
+    T: Clone,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool>,
+    Feq: Fn(Option<T>, T) -> Option<bool>,
+{
+    rstsr_assert!(la.size() > 0, InvalidLayout, "empty sequence is not allowed for reduce_arg.")?;
+
+    // split the layout into axes (to be summed) and the rest
+    let (layout_axes, layout_rest) = la.dim_split_axes(axes)?;
+
+    // generate layout for result (from layout_rest)
+    let layout_out = layout_for_array_copy(&layout_rest, TensorIterOrder::default())?;
+
+    // generate layouts for actual evaluation
+    let layouts_swapped =
+        translate_to_col_major(&[&layout_out, &layout_rest], TensorIterOrder::default())?;
+    let layout_out_swapped = &layouts_swapped[0];
+    let layout_rest_swapped = &layouts_swapped[1];
+
+    // iterate both layout_rest and layout_out
+    let iter_out_swapped = IterLayoutRowMajor::new(layout_out_swapped)?;
+    let iter_rest_swapped = IterLayoutRowMajor::new(layout_rest_swapped)?;
+
+    // inner layout is axes to be summed
+    let mut layout_inner = layout_axes.clone();
+
+    // prepare output
+    let len_out = layout_out.size();
+    let mut out = vec![IxD::default(); len_out];
+
+    // actual evaluation
+    izip!(iter_out_swapped, iter_rest_swapped).try_for_each(
+        |(idx_out, idx_rest)| -> Result<()> {
+            unsafe { layout_inner.set_offset(idx_rest) };
+            let acc = reduce_all_unraveled_arg_cpu_serial(a, &layout_inner, &f_comp, &f_eq)?;
+            out[idx_out] = acc;
+            Ok(())
+        },
+    )?;
+    return Ok((out, layout_out));
+}
+
+pub fn reduce_all_arg_cpu_serial<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    f_comp: Fcomp,
+    f_eq: Feq,
+    order: FlagOrder,
+) -> Result<usize>
+where
+    T: Clone,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool>,
+    Feq: Fn(Option<T>, T) -> Option<bool>,
+{
+    let idx = reduce_all_unraveled_arg_cpu_serial(a, la, f_comp, f_eq)?;
+    let pseudo_shape = la.shape();
+    let pseudo_layout = match order {
+        RowMajor => pseudo_shape.c(),
+        ColMajor => pseudo_shape.f(),
+    };
+    unsafe { Ok(pseudo_layout.index_uncheck(idx.as_ref()) as usize) }
+}
+
+pub fn reduce_axes_arg_cpu_serial<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    axes: &[isize],
+    f_comp: Fcomp,
+    f_eq: Feq,
+    order: FlagOrder,
+) -> Result<(Vec<usize>, Layout<IxD>)>
+where
+    T: Clone,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool>,
+    Feq: Fn(Option<T>, T) -> Option<bool>,
+{
+    let (idx, layout) = reduce_axes_unraveled_arg_cpu_serial(a, la, axes, f_comp, f_eq)?;
+    let pseudo_shape = layout.shape();
+    let pseudo_layout = match order {
+        RowMajor => pseudo_shape.c(),
+        ColMajor => pseudo_shape.f(),
+    };
+    let out = idx
+        .into_iter()
+        .map(|x| unsafe { pseudo_layout.index_uncheck(x.as_ref()) as usize })
+        .collect();
+    return Ok((out, layout));
+}
+
+/* #endregion */

--- a/rstsr-core/src/docs/api_specification.md
+++ b/rstsr-core/src/docs/api_specification.md
@@ -90,8 +90,8 @@ Device is designed to be able extended by other crates. The above devices [`Devi
 
 | Type | Identifier | Minimal Description |
 |--|--|--|
-| assoc/fn | [`slice`][crate::tensor::indexing::slice] <br/> [`slice_mut`][crate::tensor::indexing::slice_mut] | Basic slicing to tensor, generating view of smaller tensor. |
-| assoc | [`i`][Tensor::i] <br/> [`i_mut`][Tensor::i_mut] | Alias to [`slice`][crate::tensor::indexing::slice] and [`slice_mut`][crate::tensor::indexing::slice_mut]. |
+| assoc/fn | [`slice`][prim@slice] <br/> [`slice_mut`] | Basic slicing to tensor, generating view of smaller tensor. |
+| assoc | [`i`][Tensor::i] <br/> [`i_mut`][Tensor::i_mut] | Alias to [`slice`][prim@slice] and [`slice_mut`]. |
 | core ops | operator `[]` <br/> [`Index`] <br/> [`IndexMut`] | Indexing tensor element, giving reference of scalar value (not efficient due to boundary check). |
 | assoc | [`index_uncheck`][Tensor::index_uncheck] <br/>[`index_mut_uncheck`][Tensor::index_mut_uncheck] | Indexing tensor element, giving reference of scalar value. |
 
@@ -267,6 +267,10 @@ Trait function calls like associated methods, so we also do not recommend usage 
 ### Statistical functions
 
 [`max`], [`mean`], [`min`], [`prod`], [`std`], [`sum`], [`var`]
+
+### Sorting, searching and counting functions
+
+[`argmin`], [`argmax`], [`unraveled_argmin`], [`unraveled_argmax`]
 
 ## Developer Area
 

--- a/rstsr-core/src/docs/array_api_standard.md
+++ b/rstsr-core/src/docs/array_api_standard.md
@@ -307,8 +307,8 @@ For this part, we refer to [`num`] crate, where data type conversion and promoti
 
 | status | implementation | Python API | description |
 |-|-|-|-|
-| | | `argmax` | Returns the indices of the maximum values along a specified axis. |
-| | | `argmin` | Returns the indices of the minimum values along a specified axis. |
+| Y | [`argmax`], [`argmax_axes`] | `argmax` | Returns the indices of the maximum values along a specified axis. |
+| Y | [`argmin`], [`argmin_axes`] | `argmin` | Returns the indices of the minimum values along a specified axis. |
 | | | `nonzero` | Returns the indices of the array elements which are non-zero. |
 | | | `searchsorted` | Finds the indices into x1 such that, if the corresponding elements in x2 were inserted before the indices, the order of x1, when sorted in ascending order, would be preserved. |
 | | | `where` | Returns elements chosen from x1 or x2 depending on condition. |
@@ -334,13 +334,13 @@ For this part, we refer to [`num`] crate, where data type conversion and promoti
 | status | implementation | Python API | description |
 |-|-|-|-|
 | | | `cumulative_sum` | Calculates the cumulative sum of elements in the input array x. |
-| Y | [`max`] | `max` | Calculates the maximum value of the input array x. |
-| Y | [`mean`] | `mean` | Calculates the arithmetic mean of the input array x. |
-| Y | [`min`] | `min` | Calculates the minimum value of the input array x. |
-| Y | [`prod`] | `prod` | Calculates the product of input array x elements. |
-| Y | [`std`] | `std` | Calculates the standard deviation of the input array x. |
-| Y | [`sum`] | `sum` | Calculates the sum of the input array x. |
-| Y | [`var`] | `var` | Calculates the variance of the input array x. |
+| Y | [`max`], [`max_axes`] | `max` | Calculates the maximum value of the input array x. |
+| Y | [`mean`], [`mean_axes`] | `mean` | Calculates the arithmetic mean of the input array x. |
+| Y | [`min`], [`min_axes`] | `min` | Calculates the minimum value of the input array x. |
+| Y | [`prod`], [`prod_axes`] | `prod` | Calculates the product of input array x elements. |
+| Y | [`std`], [`std_axes`] | `std` | Calculates the standard deviation of the input array x. |
+| Y | [`sum`], [`sum_axes`] | `sum` | Calculates the sum of the input array x. |
+| Y | [`var`], [`var_axes`] | `var` | Calculates the variance of the input array x. |
 
 ## Utility Functions
 

--- a/rstsr-core/src/feature_rayon/auto_impl/reduction.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/reduction.rs
@@ -23,7 +23,7 @@ where
         reduce_all_cpu_rayon(a, la, f_init, f, f_sum, f_out, pool)
     }
 
-    fn sum(
+    fn sum_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -64,7 +64,7 @@ where
         reduce_all_cpu_rayon(a, la, f_init, f, f_sum, f_out, pool)
     }
 
-    fn min(
+    fn min_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -109,7 +109,7 @@ where
         reduce_all_cpu_rayon(a, la, f_init, f, f_sum, f_out, pool)
     }
 
-    fn max(
+    fn max_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -150,7 +150,7 @@ where
         reduce_all_cpu_rayon(a, la, f_init, f, f_sum, f_out, pool)
     }
 
-    fn prod(
+    fn prod_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -189,7 +189,7 @@ where
         Ok(sum)
     }
 
-    fn mean(
+    fn mean_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -237,7 +237,7 @@ where
         Ok(result)
     }
 
-    fn var(
+    fn var_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -293,7 +293,7 @@ where
         Ok(result)
     }
 
-    fn std(
+    fn std_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,
@@ -342,7 +342,7 @@ where
         Ok(result)
     }
 
-    fn l2_norm(
+    fn l2_norm_axes(
         &self,
         a: &Vec<T>,
         la: &Layout<D>,

--- a/rstsr-core/src/feature_rayon/auto_impl/reduction.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/reduction.rs
@@ -361,3 +361,231 @@ where
         Ok((Storage::new(out.into(), self.clone()), layout_out))
     }
 }
+
+impl<T, D> OpArgMinAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + PartialOrd + Send + Sync,
+    D: DimAPI,
+{
+    type TOut = usize;
+
+    fn argmin_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<usize>>, Self::TOut, Self>, Layout<IxD>)> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) =
+            reduce_axes_arg_cpu_rayon(a, la, axes, f_comp, f_eq, RowMajor, pool)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn argmin_all(&self, a: &Vec<T>, la: &Layout<D>) -> Result<Self::TOut> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_arg_cpu_rayon(a, la, f_comp, f_eq, RowMajor, pool)?;
+        Ok(result)
+    }
+}
+
+impl<T, D> OpArgMaxAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + PartialOrd + Send + Sync,
+    D: DimAPI,
+{
+    type TOut = usize;
+
+    fn argmax_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<usize>>, Self::TOut, Self>, Layout<IxD>)> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) =
+            reduce_axes_arg_cpu_rayon(a, la, axes, f_comp, f_eq, RowMajor, pool)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn argmax_all(&self, a: &Vec<T>, la: &Layout<D>) -> Result<Self::TOut> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_arg_cpu_rayon(a, la, f_comp, f_eq, RowMajor, pool)?;
+        Ok(result)
+    }
+}
+
+impl<T, D> OpUnraveledArgMinAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + PartialOrd + Send + Sync,
+    D: DimAPI,
+{
+    fn unraveled_argmin_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<IxD>>, IxD, Self>, Layout<IxD>)> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) =
+            reduce_axes_unraveled_arg_cpu_rayon(a, la, axes, f_comp, f_eq, pool)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn unraveled_argmin_all(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+    ) -> Result<D> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y < x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_unraveled_arg_cpu_rayon(a, la, f_comp, f_eq, pool)?;
+        Ok(result)
+    }
+}
+
+impl<T, D> OpUnraveledArgMaxAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + PartialOrd + Send + Sync,
+    D: DimAPI,
+{
+    fn unraveled_argmax_axes(
+        &self,
+        a: &Vec<T>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<IxD>>, IxD, Self>, Layout<IxD>)> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let (out, layout_out) =
+            reduce_axes_unraveled_arg_cpu_rayon(a, la, axes, f_comp, f_eq, pool)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+
+    fn unraveled_argmax_all(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+    ) -> Result<D> {
+        let pool = self.get_pool();
+
+        let f_comp = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y > x)
+            } else {
+                Some(true)
+            }
+        };
+        let f_eq = |x: Option<T>, y: T| -> Option<bool> {
+            if let Some(x) = x {
+                Some(y == x)
+            } else {
+                Some(false)
+            }
+        };
+        let result = reduce_all_unraveled_arg_cpu_rayon(a, la, f_comp, f_eq, pool)?;
+        Ok(result)
+    }
+}

--- a/rstsr-core/src/feature_rayon/par_iter.rs
+++ b/rstsr-core/src/feature_rayon/par_iter.rs
@@ -77,7 +77,7 @@ macro_rules! impl_par_iter_layout {
         where
             D: DimDevAPI,
         {
-            type Item = usize;
+            type Item = <$IterLayout<D> as Iterator>::Item;
             type Iter = ParIterRSTSR<Self>;
 
             fn into_par_iter(self) -> Self::Iter {
@@ -90,19 +90,20 @@ macro_rules! impl_par_iter_layout {
 impl_par_iter_layout!(IterLayoutColMajor);
 impl_par_iter_layout!(IterLayoutRowMajor);
 impl_par_iter_layout!(IterLayout);
+impl_par_iter_layout!(IndexedIterLayout);
 
 /* #endregion */
 
 /* #region tensor iterator */
 
 macro_rules! impl_par_iter_tensor {
-    ($IterTensor: ident, $item_type: ty) => {
+    ($IterTensor: ident) => {
         impl<'a, T, D> IntoParallelIterator for $IterTensor<'a, T, D>
         where
             D: DimDevAPI,
             T: Send + Sync,
         {
-            type Item = $item_type;
+            type Item = <$IterTensor<'a, T, D> as Iterator>::Item;
             type Iter = ParIterRSTSR<Self>;
 
             fn into_par_iter(self) -> Self::Iter {
@@ -112,20 +113,20 @@ macro_rules! impl_par_iter_tensor {
     };
 }
 
-impl_par_iter_tensor!(IterVecView, &'a T);
-impl_par_iter_tensor!(IterVecMut, &'a mut T);
-impl_par_iter_tensor!(IndexedIterVecView, (D, &'a T));
-impl_par_iter_tensor!(IndexedIterVecMut, (D, &'a mut T));
+impl_par_iter_tensor!(IterVecView);
+impl_par_iter_tensor!(IterVecMut);
+impl_par_iter_tensor!(IndexedIterVecView);
+impl_par_iter_tensor!(IndexedIterVecMut);
 
 macro_rules! impl_par_axes_iter_tensor {
-    ($IterTensor: ident, $item_type: ty) => {
+    ($IterTensor: ident) => {
         impl<'a, T, B> IntoParallelIterator for $IterTensor<'a, T, B>
         where
             T: Send + Sync,
             B::Raw: Send,
             B: DeviceAPI<T> + Send,
         {
-            type Item = $item_type;
+            type Item = <$IterTensor<'a, T, B> as Iterator>::Item;
             type Iter = ParIterRSTSR<Self>;
 
             fn into_par_iter(self) -> Self::Iter {
@@ -135,10 +136,10 @@ macro_rules! impl_par_axes_iter_tensor {
     };
 }
 
-impl_par_axes_iter_tensor!(IterAxesView, TensorView<'a, T, B, IxD>);
-impl_par_axes_iter_tensor!(IterAxesMut, TensorMut<'a, T, B, IxD>);
-impl_par_axes_iter_tensor!(IndexedIterAxesView, (IxD, TensorView<'a, T, B, IxD>));
-impl_par_axes_iter_tensor!(IndexedIterAxesMut, (IxD, TensorMut<'a, T, B, IxD>));
+impl_par_axes_iter_tensor!(IterAxesView);
+impl_par_axes_iter_tensor!(IterAxesMut);
+impl_par_axes_iter_tensor!(IndexedIterAxesView);
+impl_par_axes_iter_tensor!(IndexedIterAxesMut);
 
 /* #endregion */
 

--- a/rstsr-core/src/feature_rayon/reduction.rs
+++ b/rstsr-core/src/feature_rayon/reduction.rs
@@ -16,6 +16,8 @@ const PARALLEL_CHUNK_MAX: usize = 1024;
 // Currently, we do not make contiguous parts to be parallel. Only outer
 // iteration is parallelized.
 
+/* #region reduce */
+
 pub fn reduce_all_cpu_rayon<TI, TS, TO, D, I, F, FSum, FOut>(
     a: &[TI],
     la: &Layout<D>,
@@ -65,22 +67,24 @@ where
         } else {
             // parallel inner iteration
             let chunk = PARALLEL_CHUNK_MAX.min(size_contig / nthreads + 1);
-            acc = iter_a
-                .into_par_iter()
-                .fold(&init, |acc_inner, idx_a| {
-                    let res = (0..size_contig)
-                        .into_par_iter()
-                        .step_by(chunk)
-                        .fold(&init, |acc_chunk, idx| {
-                            let chunk = chunk.min(size_contig - idx);
-                            let start = idx_a + idx;
-                            let slc = &a[start..start + chunk];
-                            f_sum(acc_chunk, unrolled_reduce(slc, &init, &f, &f_sum))
-                        })
-                        .reduce(&init, &f_sum);
-                    f_sum(acc_inner, res)
-                })
-                .reduce(&init, &f_sum);
+            acc = pool.install(|| {
+                iter_a
+                    .into_par_iter()
+                    .fold(&init, |acc_inner, idx_a| {
+                        let res = (0..size_contig)
+                            .into_par_iter()
+                            .step_by(chunk)
+                            .fold(&init, |acc_chunk, idx| {
+                                let chunk = chunk.min(size_contig - idx);
+                                let start = idx_a + idx;
+                                let slc = &a[start..start + chunk];
+                                f_sum(acc_chunk, unrolled_reduce(slc, &init, &f, &f_sum))
+                            })
+                            .reduce(&init, &f_sum);
+                        f_sum(acc_inner, res)
+                    })
+                    .reduce(&init, &f_sum)
+            });
         }
         return Ok(f_out(acc));
     } else {
@@ -149,17 +153,20 @@ where
         let out_ptr = AtomicPtr::new(out.as_mut_ptr());
 
         // actual evaluation
-        (iter_out_swapped, iter_rest_swapped).into_par_iter().try_for_each(
-            |(idx_out, idx_rest)| -> Result<()> {
-                let out_ptr = out_ptr.load(Ordering::Relaxed);
-                // let out_ptr = out_ptr.get();
-                let mut layout_inner = layout_axes.clone();
-                unsafe { layout_inner.set_offset(idx_rest) };
-                let acc = reduce_all_cpu_rayon(a, &layout_inner, &init, &f, &f_sum, &f_out, pool)?;
-                unsafe { *out_ptr.add(idx_out) = acc };
-                Ok(())
-            },
-        )?;
+        pool.install(|| {
+            (iter_out_swapped, iter_rest_swapped).into_par_iter().try_for_each(
+                |(idx_out, idx_rest)| -> Result<()> {
+                    let out_ptr = out_ptr.load(Ordering::Relaxed);
+                    // let out_ptr = out_ptr.get();
+                    let mut layout_inner = layout_axes.clone();
+                    unsafe { layout_inner.set_offset(idx_rest) };
+                    let acc =
+                        reduce_all_cpu_rayon(a, &layout_inner, &init, &f, &f_sum, &f_out, pool)?;
+                    unsafe { *out_ptr.add(idx_out) = acc };
+                    Ok(())
+                },
+            )
+        })?;
         return Ok((out, layout_out));
     } else {
         // iterate layout_axes
@@ -239,17 +246,20 @@ where
         let out_ptr = AtomicPtr::new(out.as_mut_ptr());
 
         // actual evaluation
-        (iter_out_swapped, iter_rest_swapped).into_par_iter().try_for_each(
-            |(idx_out, idx_rest)| -> Result<()> {
-                let out_ptr = out_ptr.load(Ordering::Relaxed);
-                // let out_ptr = out_ptr.get();
-                let mut layout_inner = layout_axes.clone();
-                unsafe { layout_inner.set_offset(idx_rest) };
-                let acc = reduce_all_cpu_rayon(a, &layout_inner, &init, &f, &f_sum, &f_out, pool)?;
-                unsafe { *out_ptr.add(idx_out) = acc };
-                Ok(())
-            },
-        )?;
+        pool.install(|| {
+            (iter_out_swapped, iter_rest_swapped).into_par_iter().try_for_each(
+                |(idx_out, idx_rest)| -> Result<()> {
+                    let out_ptr = out_ptr.load(Ordering::Relaxed);
+                    // let out_ptr = out_ptr.get();
+                    let mut layout_inner = layout_axes.clone();
+                    unsafe { layout_inner.set_offset(idx_rest) };
+                    let acc =
+                        reduce_all_cpu_rayon(a, &layout_inner, &init, &f, &f_sum, &f_out, pool)?;
+                    unsafe { *out_ptr.add(idx_out) = acc };
+                    Ok(())
+                },
+            )
+        })?;
         return Ok((out, layout_out));
     } else {
         // iterate layout_axes
@@ -284,3 +294,194 @@ where
         return Ok((out_converted, layout_out));
     }
 }
+
+/* #endregion */
+
+/* #region reduce unraveled axes */
+
+pub fn reduce_all_unraveled_arg_cpu_rayon<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    f_comp: Fcomp,
+    f_eq: Feq,
+    pool: &rayon::ThreadPool,
+) -> Result<D>
+where
+    T: Clone + Send + Sync,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+    Feq: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+{
+    rstsr_assert!(la.size() > 0, InvalidLayout, "empty sequence is not allowed for reduce_arg.")?;
+
+    let nthreads = pool.current_num_threads();
+    let size = la.size();
+    if size < PARALLEL_SWITCH * nthreads {
+        return reduce_all_unraveled_arg_cpu_serial(a, la, f_comp, f_eq);
+    }
+
+    let fold_func = |acc: Option<(D, T)>, (cur_idx, cur_offset): (D, usize)| -> Option<(D, T)> {
+        let cur_val = a[cur_offset].clone();
+
+        let comp = f_comp(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
+        if let Some(comp) = comp {
+            if comp {
+                // cond 1: current value is accepted
+                Some((cur_idx, cur_val))
+            } else {
+                let comp_eq = f_eq(acc.as_ref().map(|(_, val)| val.clone()), cur_val.clone());
+                if comp_eq.is_some_and(|x| x) {
+                    // cond 2: current value is same with previous value, return smaller index
+                    if let Some(acc_idx) = acc.as_ref().map(|(idx, _)| idx.clone()) {
+                        if cur_idx < acc_idx {
+                            Some((cur_idx, cur_val))
+                        } else {
+                            acc
+                        }
+                    } else {
+                        Some((cur_idx, cur_val))
+                    }
+                } else {
+                    // cond 3: current value is not accepted
+                    acc
+                }
+            }
+        } else {
+            // cond 4: current comparasion is not valid
+            acc
+        }
+    };
+    let sum_func = |acc1: Option<(D, T)>, acc2: Option<(D, T)>| match (acc1, acc2) {
+        (Some((idx1, val1)), Some((idx2, _))) => fold_func(
+            Some((idx1, val1)),
+            (idx2.clone(), unsafe { la.index_uncheck(idx2.as_ref()) as usize }),
+        )
+        .map(|(idx, val)| (idx, val)),
+        (Some((idx1, val1)), None) => Some((idx1, val1)),
+        (None, Some((idx2, val2))) => Some((idx2, val2)),
+        (None, None) => None,
+    };
+
+    let iter_a = IndexedIterLayout::new(la, RowMajor)?;
+    let acc =
+        pool.install(|| iter_a.into_par_iter().fold(|| None, fold_func).reduce(|| None, sum_func));
+    if acc.is_none() {
+        rstsr_raise!(InvalidValue, "reduce_arg seems not returning a valid value.")?;
+    }
+    return Ok(acc.unwrap().0);
+}
+
+pub fn reduce_axes_unraveled_arg_cpu_rayon<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    axes: &[isize],
+    f_comp: Fcomp,
+    f_eq: Feq,
+    pool: &rayon::ThreadPool,
+) -> Result<(Vec<IxD>, Layout<IxD>)>
+where
+    T: Clone + Send + Sync,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+    Feq: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+{
+    // determine whether to use parallel iteration
+    let nthreads = pool.current_num_threads();
+    let size = la.size();
+    if size < PARALLEL_SWITCH * nthreads {
+        return reduce_axes_unraveled_arg_cpu_serial(a, la, axes, f_comp, f_eq);
+    }
+
+    // split the layout into axes (to be summed) and the rest
+    let (layout_axes, layout_rest) = la.dim_split_axes(axes)?;
+    let layout_axes = translate_to_col_major_unary(&layout_axes, TensorIterOrder::default())?;
+
+    // generate layout for result (from layout_rest)
+    let layout_out = layout_for_array_copy(&layout_rest, TensorIterOrder::default())?;
+
+    // generate layouts for actual evaluation
+    let layouts_swapped =
+        translate_to_col_major(&[&layout_out, &layout_rest], TensorIterOrder::default())?;
+    let layout_out_swapped = &layouts_swapped[0];
+    let layout_rest_swapped = &layouts_swapped[1];
+
+    // iterate both layout_rest and layout_out
+    let iter_out_swapped = IterLayoutRowMajor::new(layout_out_swapped)?;
+    let iter_rest_swapped = IterLayoutRowMajor::new(layout_rest_swapped)?;
+
+    // prepare output
+    let len_out = layout_out.size();
+    let mut out: Vec<IxD> = unsafe { uninitialized_vec(len_out) };
+    let out_ptr = AtomicPtr::new(out.as_mut_ptr());
+
+    // actual evaluation
+    pool.install(|| {
+        (iter_out_swapped, iter_rest_swapped).into_par_iter().try_for_each(
+            |(idx_out, idx_rest)| -> Result<()> {
+                let out_ptr = out_ptr.load(Ordering::Relaxed);
+                // let out_ptr = out_ptr.get();
+                let mut layout_inner = layout_axes.clone();
+                unsafe { layout_inner.set_offset(idx_rest) };
+                let acc =
+                    reduce_all_unraveled_arg_cpu_rayon(a, &layout_inner, &f_comp, &f_eq, pool)?;
+                unsafe { *out_ptr.add(idx_out) = acc.clone() };
+                Ok(())
+            },
+        )
+    })?;
+    return Ok((out, layout_out));
+}
+
+pub fn reduce_all_arg_cpu_rayon<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    f_comp: Fcomp,
+    f_eq: Feq,
+    order: FlagOrder,
+    pool: &rayon::ThreadPool,
+) -> Result<usize>
+where
+    T: Clone + Send + Sync,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+    Feq: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+{
+    let idx = reduce_all_unraveled_arg_cpu_rayon(a, la, f_comp, f_eq, pool)?;
+    let pseudo_shape = la.shape();
+    let pseudo_layout = match order {
+        RowMajor => pseudo_shape.c(),
+        ColMajor => pseudo_shape.f(),
+    };
+    unsafe { Ok(pseudo_layout.index_uncheck(idx.as_ref()) as usize) }
+}
+
+pub fn reduce_axes_arg_cpu_rayon<T, D, Fcomp, Feq>(
+    a: &[T],
+    la: &Layout<D>,
+    axes: &[isize],
+    f_comp: Fcomp,
+    f_eq: Feq,
+    order: FlagOrder,
+    pool: &rayon::ThreadPool,
+) -> Result<(Vec<usize>, Layout<IxD>)>
+where
+    T: Clone + Send + Sync,
+    D: DimAPI,
+    Fcomp: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+    Feq: Fn(Option<T>, T) -> Option<bool> + Send + Sync,
+{
+    let (idx, layout) = reduce_axes_unraveled_arg_cpu_rayon(a, la, axes, f_comp, f_eq, pool)?;
+    let pseudo_shape = layout.shape();
+    let pseudo_layout = match order {
+        RowMajor => pseudo_shape.c(),
+        ColMajor => pseudo_shape.f(),
+    };
+    let out = pool.install(|| {
+        idx.into_par_iter()
+            .map(|x| unsafe { pseudo_layout.index_uncheck(x.as_ref()) as usize })
+            .collect()
+    });
+    return Ok((out, layout));
+}
+
+/* #endregion */

--- a/rstsr-core/src/feature_rayon/reduction.rs
+++ b/rstsr-core/src/feature_rayon/reduction.rs
@@ -355,8 +355,7 @@ where
         (Some((idx1, val1)), Some((idx2, _))) => fold_func(
             Some((idx1, val1)),
             (idx2.clone(), unsafe { la.index_uncheck(idx2.as_ref()) as usize }),
-        )
-        .map(|(idx, val)| (idx, val)),
+        ),
         (Some((idx1, val1)), None) => Some((idx1, val1)),
         (None, Some((idx2, val2))) => Some((idx2, val2)),
         (None, None) => None,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -128,11 +128,17 @@ pub mod rstsr_funcs {
     };
     // reduction
     pub use crate::tensor::reduction::{
-        l2_norm_all, l2_norm_all_f, l2_norm_axes, l2_norm_axes_f, max_all, max_all_f, max_axes,
-        max_axes_f, mean_all, mean_all_f, mean_axes, mean_axes_f, min_all, min_all_f, min_axes,
-        min_axes_f, prod_all, prod_all_f, prod_axes, prod_axes_f, std_all, std_all_f, std_axes,
-        std_axes_f, sum_all, sum_all_f, sum_axes, sum_axes_f, var_all, var_all_f, var_axes,
-        var_axes_f,
+        argmax, argmax_all, argmax_all_f, argmax_axes, argmax_axes_f, argmax_f, argmin, argmin_all,
+        argmin_all_f, argmin_axes, argmin_axes_f, argmin_f, l2_norm, l2_norm_all, l2_norm_all_f,
+        l2_norm_axes, l2_norm_axes_f, l2_norm_f, max, max_all, max_all_f, max_axes, max_axes_f,
+        max_f, mean, mean_all, mean_all_f, mean_axes, mean_axes_f, mean_f, min, min_all, min_all_f,
+        min_axes, min_axes_f, min_f, prod, prod_all, prod_all_f, prod_axes, prod_axes_f, prod_f,
+        std, std_all, std_all_f, std_axes, std_axes_f, std_f, sum, sum_all, sum_all_f, sum_axes,
+        sum_axes_f, sum_f, unraveled_argmax, unraveled_argmax_all, unraveled_argmax_all_f,
+        unraveled_argmax_axes, unraveled_argmax_axes_f, unraveled_argmax_f, unraveled_argmin,
+        unraveled_argmin_all, unraveled_argmin_all_f, unraveled_argmin_axes,
+        unraveled_argmin_axes_f, unraveled_argmin_f, var, var_all, var_all_f, var_axes, var_axes_f,
+        var_f,
     };
 }
 

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -128,10 +128,11 @@ pub mod rstsr_funcs {
     };
     // reduction
     pub use crate::tensor::reduction::{
-        l2_norm, l2_norm_all, l2_norm_all_f, l2_norm_f, max, max_all, max_all_f, max_f, mean,
-        mean_all, mean_all_f, mean_f, min, min_all, min_all_f, min_f, prod, prod_all, prod_all_f,
-        prod_f, std, std_all, std_all_f, std_f, sum, sum_all, sum_all_f, sum_f, var, var_all,
-        var_all_f, var_f,
+        l2_norm_all, l2_norm_all_f, l2_norm_axes, l2_norm_axes_f, max_all, max_all_f, max_axes,
+        max_axes_f, mean_all, mean_all_f, mean_axes, mean_axes_f, min_all, min_all_f, min_axes,
+        min_axes_f, prod_all, prod_all_f, prod_axes, prod_axes_f, std_all, std_all_f, std_axes,
+        std_axes_f, sum_all, sum_all_f, sum_axes, sum_axes_f, var_all, var_all_f, var_axes,
+        var_axes_f,
     };
 }
 

--- a/rstsr-core/src/storage/reduction.rs
+++ b/rstsr-core/src/storage/reduction.rs
@@ -34,6 +34,8 @@ trait_reduction!(OpMeanAPI, mean_axes, mean_all);
 trait_reduction!(OpVarAPI, var_axes, var_all);
 trait_reduction!(OpStdAPI, std_axes, std_all);
 trait_reduction!(OpL2NormAPI, l2_norm_axes, l2_norm_all);
+trait_reduction!(OpArgMinAPI, argmin_axes, argmin_all);
+trait_reduction!(OpArgMaxAPI, argmax_axes, argmax_all);
 
 macro_rules! trait_reduction_arg {
     ($OpReduceAPI: ident, $func: ident, $func_all: ident) => {
@@ -58,5 +60,5 @@ macro_rules! trait_reduction_arg {
     };
 }
 
-trait_reduction_arg!(OpArgMinAPI, argmin_axes, argmin_all);
-trait_reduction_arg!(OpArgMaxAPI, argmax_axes, argmax_all);
+trait_reduction_arg!(OpUnraveledArgMinAPI, unraveled_argmin_axes, unraveled_argmin_all);
+trait_reduction_arg!(OpUnraveledArgMaxAPI, unraveled_argmax_axes, unraveled_argmax_all);

--- a/rstsr-core/src/storage/reduction.rs
+++ b/rstsr-core/src/storage/reduction.rs
@@ -26,14 +26,14 @@ macro_rules! trait_reduction {
     };
 }
 
-trait_reduction!(OpSumAPI, sum, sum_all);
-trait_reduction!(OpMinAPI, min, min_all);
-trait_reduction!(OpMaxAPI, max, max_all);
-trait_reduction!(OpProdAPI, prod, prod_all);
-trait_reduction!(OpMeanAPI, mean, mean_all);
-trait_reduction!(OpVarAPI, var, var_all);
-trait_reduction!(OpStdAPI, std, std_all);
-trait_reduction!(OpL2NormAPI, l2_norm, l2_norm_all);
+trait_reduction!(OpSumAPI, sum_axes, sum_all);
+trait_reduction!(OpMinAPI, min_axes, min_all);
+trait_reduction!(OpMaxAPI, max_axes, max_all);
+trait_reduction!(OpProdAPI, prod_axes, prod_all);
+trait_reduction!(OpMeanAPI, mean_axes, mean_all);
+trait_reduction!(OpVarAPI, var_axes, var_all);
+trait_reduction!(OpStdAPI, std_axes, std_all);
+trait_reduction!(OpL2NormAPI, l2_norm_axes, l2_norm_all);
 
 macro_rules! trait_reduction_arg {
     ($OpReduceAPI: ident, $func: ident, $func_all: ident) => {
@@ -58,5 +58,5 @@ macro_rules! trait_reduction_arg {
     };
 }
 
-trait_reduction_arg!(OpArgMinAPI, argmin, argmin_all);
-trait_reduction_arg!(OpArgMaxAPI, argmax, argmax_all);
+trait_reduction_arg!(OpArgMinAPI, argmin_axes, argmin_all);
+trait_reduction_arg!(OpArgMaxAPI, argmax_axes, argmax_all);

--- a/rstsr-core/src/tensor/reduction.rs
+++ b/rstsr-core/src/tensor/reduction.rs
@@ -95,14 +95,14 @@ macro_rules! trait_reduction {
     };
 }
 
-trait_reduction!(OpSumAPI, sum, sum_f, sum_all, sum_all_f);
-trait_reduction!(OpMinAPI, min, min_f, min_all, min_all_f);
-trait_reduction!(OpMaxAPI, max, max_f, max_all, max_all_f);
-trait_reduction!(OpProdAPI, prod, prod_f, prod_all, prod_all_f);
-trait_reduction!(OpMeanAPI, mean, mean_f, mean_all, mean_all_f);
-trait_reduction!(OpVarAPI, var, var_f, var_all, var_all_f);
-trait_reduction!(OpStdAPI, std, std_f, std_all, std_all_f);
-trait_reduction!(OpL2NormAPI, l2_norm, l2_norm_f, l2_norm_all, l2_norm_all_f);
+trait_reduction!(OpSumAPI, sum_axes, sum_axes_f, sum_all, sum_all_f);
+trait_reduction!(OpMinAPI, min_axes, min_axes_f, min_all, min_all_f);
+trait_reduction!(OpMaxAPI, max_axes, max_axes_f, max_all, max_all_f);
+trait_reduction!(OpProdAPI, prod_axes, prod_axes_f, prod_all, prod_all_f);
+trait_reduction!(OpMeanAPI, mean_axes, mean_axes_f, mean_all, mean_all_f);
+trait_reduction!(OpVarAPI, var_axes, var_axes_f, var_all, var_all_f);
+trait_reduction!(OpStdAPI, std_axes, std_axes_f, std_all, std_all_f);
+trait_reduction!(OpL2NormAPI, l2_norm_axes, l2_norm_axes_f, l2_norm_all, l2_norm_all_f);
 
 macro_rules! trait_reduction_arg {
     ($OpReduceAPI: ident, $fn: ident, $fn_f: ident, $fn_all: ident, $fn_all_f: ident) => {
@@ -188,8 +188,8 @@ macro_rules! trait_reduction_arg {
     };
 }
 
-trait_reduction_arg!(OpArgMinAPI, argmin, argmin_f, argmin_all, argmin_all_f);
-trait_reduction_arg!(OpArgMaxAPI, argmax, argmax_f, argmax_all, argmax_all_f);
+trait_reduction_arg!(OpArgMinAPI, argmin_axes, argmin_axes_f, argmin_all, argmin_all_f);
+trait_reduction_arg!(OpArgMaxAPI, argmax_axes, argmax_axes_f, argmax_all, argmax_all_f);
 
 #[cfg(test)]
 mod test {
@@ -212,7 +212,7 @@ mod test {
         let s = a.sum_all();
         assert_eq!(s, 446586);
 
-        let s = a.sum(());
+        let s = a.sum_axes(());
         println!("{:?}", s);
         assert_eq!(s.to_scalar(), 446586);
 
@@ -228,7 +228,7 @@ mod test {
         let s = a.sum_all();
         assert_eq!(s, 446586);
 
-        let s = a.sum(());
+        let s = a.sum_axes(());
         println!("{:?}", s);
         assert_eq!(s.to_scalar(), 446586);
     }
@@ -238,7 +238,7 @@ mod test {
         // DeviceCpuSerial
         let a =
             arange((3240, &DeviceCpuSerial)).into_shape([4, 6, 15, 9]).into_transpose([2, 0, 3, 1]);
-        let s = a.sum([0, -2]);
+        let s = a.sum_axes([0, -2]);
         println!("{:?}", s);
         assert_eq!(s[[0, 1]], 27270);
         assert_eq!(s[[1, 2]], 154845);
@@ -246,7 +246,7 @@ mod test {
 
         // DeviceFaer
         let a: Tensor<usize> = arange(3240).into_shape([4, 6, 15, 9]).into_transpose([2, 0, 3, 1]);
-        let s = a.sum([0, -2]);
+        let s = a.sum_axes([0, -2]);
         println!("{:?}", s);
         assert_eq!(s[[0, 1]], 27270);
         assert_eq!(s[[1, 2]], 154845);
@@ -259,9 +259,9 @@ mod test {
         let v = vec![8, 4, 2, 9, 3, 7, 2, 8, 1, 6, 10, 5];
         let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
         println!("{:}", a);
-        let m = a.min(0);
+        let m = a.min_axes(0);
         assert_eq!(m.to_vec(), vec![2, 3, 1]);
-        let m = a.min(1);
+        let m = a.min_axes(1);
         assert_eq!(m.to_vec(), vec![2, 3, 1, 5]);
         let m = a.min_all();
         assert_eq!(m, 1);
@@ -270,9 +270,9 @@ mod test {
         let v = vec![8, 4, 2, 9, 3, 7, 2, 8, 1, 6, 10, 5];
         let a = asarray((&v, [4, 3].c()));
         println!("{:}", a);
-        let m = a.min(0);
+        let m = a.min_axes(0);
         assert_eq!(m.to_vec(), vec![2, 3, 1]);
-        let m = a.min(1);
+        let m = a.min_axes(1);
         assert_eq!(m.to_vec(), vec![2, 3, 1, 5]);
         let m = a.min_all();
         assert_eq!(m, 1);
@@ -285,11 +285,11 @@ mod test {
         let m = a.mean_all();
         assert_eq!(m, 11.5);
 
-        let m = a.mean((0, 2));
+        let m = a.mean_axes((0, 2));
         println!("{:}", m);
         assert_eq!(m.to_vec(), vec![7.5, 11.5, 15.5]);
 
-        let m = a.i((slice!(None, None, -1), .., slice!(None, None, -2))).mean((-1, 1));
+        let m = a.i((slice!(None, None, -1), .., slice!(None, None, -2))).mean_axes((-1, 1));
         println!("{:}", m);
         assert_eq!(m.to_vec(), vec![18.0, 6.0]);
 
@@ -298,11 +298,11 @@ mod test {
         let m = a.mean_all();
         assert_eq!(m, 11.5);
 
-        let m = a.mean((0, 2));
+        let m = a.mean_axes((0, 2));
         println!("{:}", m);
         assert_eq!(m.to_vec(), vec![7.5, 11.5, 15.5]);
 
-        let m = a.i((slice!(None, None, -1), .., slice!(None, None, -2))).mean((-1, 1));
+        let m = a.i((slice!(None, None, -1), .., slice!(None, None, -2))).mean_axes((-1, 1));
         println!("{:}", m);
         assert_eq!(m.to_vec(), vec![18.0, 6.0]);
     }
@@ -317,11 +317,11 @@ mod test {
         println!("{:}", m);
         assert!((m - 8.409722222222221).abs() < 1e-10);
 
-        let m = a.var(0);
+        let m = a.var_axes(0);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![7.1875, 8.1875, 5.6875])));
 
-        let m = a.var(1);
+        let m = a.var_axes(1);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![6.22222222, 6.22222222, 9.55555556, 4.66666667])));
 
@@ -333,11 +333,11 @@ mod test {
         println!("{:}", m);
         assert!((m - 8.409722222222221).abs() < 1e-10);
 
-        let m = a.var(0);
+        let m = a.var_axes(0);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![7.1875, 8.1875, 5.6875])));
 
-        let m = a.var(1);
+        let m = a.var_axes(1);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![6.22222222, 6.22222222, 9.55555556, 4.66666667])));
     }
@@ -352,11 +352,11 @@ mod test {
         println!("{:}", m);
         assert!((m - 2.899952106884219).abs() < 1e-10);
 
-        let m = a.std(0);
+        let m = a.std_axes(0);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![2.68095132, 2.86138079, 2.384848])));
 
-        let m = a.std(1);
+        let m = a.std_axes(1);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![2.49443826, 2.49443826, 3.09120617, 2.1602469])));
 
@@ -381,11 +381,11 @@ mod test {
         println!("{:}", m);
         assert!((m - 2.899952106884219).abs() < 1e-10);
 
-        let m = a.std(0);
+        let m = a.std_axes(0);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![2.68095132, 2.86138079, 2.384848])));
 
-        let m = a.std(1);
+        let m = a.std_axes(1);
         println!("{:}", m);
         assert!(allclose_f64(&m, &asarray(vec![2.49443826, 2.49443826, 3.09120617, 2.1602469])));
 
@@ -449,10 +449,10 @@ mod test {
         println!("{:?}", c_std);
         assert!((c_std - 148.88523481701804) < 1e-6);
 
-        let c_std_1 = c.std((0, 1));
+        let c_std_1 = c.std_axes((0, 1));
         println!("{}", c_std_1);
 
-        let c_std_2 = c.std((1, 2));
+        let c_std_2 = c.std_axes((1, 2));
         println!("{}", c_std_2);
     }
 
@@ -471,12 +471,12 @@ mod test {
         println!("{:?}", m);
         assert_eq!(m, vec![1, 2]);
 
-        let m = a.argmin(-1);
+        let m = a.argmin_axes(-1);
         println!("{:?}", m);
         let m_vec = m.raw();
         assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1], vec![2]]);
 
-        let m = a.argmin(0);
+        let m = a.argmin_axes(0);
         println!("{:?}", m);
         let m_vec = m.raw();
         assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1]]);

--- a/rstsr-core/src/tensor/reduction.rs
+++ b/rstsr-core/src/tensor/reduction.rs
@@ -103,6 +103,8 @@ trait_reduction!(OpMeanAPI, mean_axes, mean_axes_f, mean_all, mean_all_f);
 trait_reduction!(OpVarAPI, var_axes, var_axes_f, var_all, var_all_f);
 trait_reduction!(OpStdAPI, std_axes, std_axes_f, std_all, std_all_f);
 trait_reduction!(OpL2NormAPI, l2_norm_axes, l2_norm_axes_f, l2_norm_all, l2_norm_all_f);
+trait_reduction!(OpArgMinAPI, argmin_axes, argmin_axes_f, argmin_all, argmin_all_f);
+trait_reduction!(OpArgMaxAPI, argmax_axes, argmax_axes_f, argmax_all, argmax_all_f);
 
 macro_rules! trait_reduction_arg {
     ($OpReduceAPI: ident, $fn: ident, $fn_f: ident, $fn_all: ident, $fn_all_f: ident) => {
@@ -188,8 +190,20 @@ macro_rules! trait_reduction_arg {
     };
 }
 
-trait_reduction_arg!(OpArgMinAPI, argmin_axes, argmin_axes_f, argmin_all, argmin_all_f);
-trait_reduction_arg!(OpArgMaxAPI, argmax_axes, argmax_axes_f, argmax_all, argmax_all_f);
+trait_reduction_arg!(
+    OpUnraveledArgMinAPI,
+    unraveled_argmin_axes,
+    unraveled_argmin_axes_f,
+    unraveled_argmin_all,
+    unraveled_argmin_all_f
+);
+trait_reduction_arg!(
+    OpUnraveledArgMaxAPI,
+    unraveled_argmax_axes,
+    unraveled_argmax_axes_f,
+    unraveled_argmax_all,
+    unraveled_argmax_all_f
+);
 
 #[cfg(test)]
 mod test {
@@ -457,6 +471,32 @@ mod test {
     }
 
     #[test]
+    fn test_unraveled_argmin() {
+        // DeviceCpuSerial
+        let v = vec![8, 4, 2, 9, 7, 1, 2, 1, 8, 6, 10, 5];
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        println!("{:}", a);
+        // [[ 8 4 2]
+        //  [ 9 7 1]
+        //  [ 2 1 8]
+        //  [ 6 10 5]]
+
+        let m = a.unraveled_argmin_all();
+        println!("{:?}", m);
+        assert_eq!(m, vec![1, 2]);
+
+        let m = a.unraveled_argmin_axes(-1);
+        println!("{:?}", m);
+        let m_vec = m.raw();
+        assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1], vec![2]]);
+
+        let m = a.unraveled_argmin_axes(0);
+        println!("{:?}", m);
+        let m_vec = m.raw();
+        assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1]]);
+    }
+
+    #[test]
     fn test_argmin() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 7, 1, 2, 1, 8, 6, 10, 5];
@@ -469,16 +509,16 @@ mod test {
 
         let m = a.argmin_all();
         println!("{:?}", m);
-        assert_eq!(m, vec![1, 2]);
+        assert_eq!(m, 5);
 
         let m = a.argmin_axes(-1);
         println!("{:?}", m);
         let m_vec = m.raw();
-        assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1], vec![2]]);
+        assert_eq!(m_vec, &vec![2, 2, 1, 2]);
 
         let m = a.argmin_axes(0);
         println!("{:?}", m);
         let m_vec = m.raw();
-        assert_eq!(m_vec, &vec![vec![2], vec![2], vec![1]]);
+        assert_eq!(m_vec, &vec![2, 2, 1]);
     }
 }

--- a/rstsr-core/tests/tensor_sum.rs
+++ b/rstsr-core/tests/tensor_sum.rs
@@ -17,7 +17,7 @@ mod test {
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
             let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial));
-            b_full.sum(0)
+            b_full.sum_axes(0)
         };
         println!("{:} usec", time.elapsed().as_micros());
         let t_rstsr = t_rstsr.reshape(-1).to_vec();
@@ -29,7 +29,7 @@ mod test {
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
             let b_full = rt::asarray((vec_b, [4, n, n]));
-            b_full.sum(0)
+            b_full.sum_axes(0)
         };
         println!("{:} usec", time.elapsed().as_micros());
         let t_rayon = t_rayon.reshape(-1).to_vec();
@@ -73,7 +73,7 @@ mod test {
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
             let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial));
-            b_full.sum([-1, -2])
+            b_full.sum_axes([-1, -2])
         };
         println!("{:} usec", time.elapsed().as_micros());
         let t_rstsr = t_rstsr.reshape(-1).to_vec();
@@ -85,7 +85,7 @@ mod test {
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
             let b_full = rt::asarray((vec_b, [4, n, n]));
-            b_full.sum([-1, -2])
+            b_full.sum_axes([-1, -2])
         };
         println!("{:} usec", time.elapsed().as_micros());
         let t_rayon = t_rayon.reshape(-1).to_vec();

--- a/rstsr-openblas/readme.md
+++ b/rstsr-openblas/readme.md
@@ -6,7 +6,7 @@ This crate enables OpenBLAS device.
 
 ```rust
 use rstsr_core::prelude::*;
-use rstsr_openblas::device::DeviceOpenBLAS;
+use rstsr_openblas::DeviceOpenBLAS;
 
 // specify the number of threads of 16
 let device = DeviceOpenBLAS::new(16);

--- a/rstsr-openblas/tests/test_argmin.rs
+++ b/rstsr-openblas/tests/test_argmin.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+mod test {
+    use rstsr_core::prelude_dev::*;
+    use rstsr_openblas::DeviceOpenBLAS as DeviceBLAS;
+    use rstsr_test_manifest::get_vec;
+
+    #[test]
+    pub fn test_argmin() {
+        let device = DeviceBLAS::default();
+        let la = [1024, 4096].c();
+        let lb = [128, 129, 130].c();
+        let a = Tensor::new(Storage::new(get_vec::<f64>('a').into(), device.clone()), la);
+        let b = Tensor::new(Storage::new(get_vec::<f64>('b').into(), device.clone()), lb);
+        let argmin_a = a.argmin_all();
+        assert_eq!(argmin_a, 3772851);
+        let unraveled_argmin_b = b.unraveled_argmin_all();
+        assert_eq!(unraveled_argmin_b, [2, 7, 2]);
+        let argmax_a = a.argmax_all();
+        assert_eq!(argmax_a, 3706286);
+        let unraveled_argmax_b = b.unraveled_argmax_all();
+        assert_eq!(unraveled_argmax_b, [46, 63, 15]);
+    }
+}

--- a/rstsr-openblas/tests/test_workable.rs
+++ b/rstsr-openblas/tests/test_workable.rs
@@ -26,10 +26,10 @@ mod test {
         println!("{:?}", c_std);
         assert!((c_std - 148.88523481701804) < 1e-6);
 
-        let c_std_1 = c.std((0, 1));
+        let c_std_1 = c.std_axes((0, 1));
         println!("{}", c_std_1);
 
-        let c_std_2 = c.std((1, 2));
+        let c_std_2 = c.std_axes((1, 2));
         println!("{}", c_std_2);
     }
 }


### PR DESCRIPTION
This PR is assisted by copilot summary.

This pull request includes several changes to the `rstsr-core` library, specifically focusing on renaming methods for consistency and adding new reduction functions. The most important changes are grouped by their themes: renaming methods, updating benchmarks, and adding new reduction functions.

### Renaming Methods for Consistency:
* Renamed various reduction methods in `rstsr-core/src/device_cpu_serial/operators/reduction.rs` to use the `_axes` suffix, such as `sum_axes`, `min_axes`, `max_axes`, `prod_axes`, `mean_axes`, `var_axes`, `std_axes`, `l2_norm_axes`, `argmin_axes`, and `argmax_axes`. [[1]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L24-R24) [[2]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L60-R60) [[3]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L101-R101) [[4]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L138-R138) [[5]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L173-R173) [[6]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L217-R217) [[7]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L269-R269) [[8]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L314-R314) [[9]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L337-R344) [[10]](diffhunk://#diff-1781087119394734d30ca4b94cccf2af49720a41e63064b64e820bda6c9658a8L386-R492)

### Adding New Reduction Functions:
* Added new reduction functions in `rstsr-core/src/device_cpu_serial/reduction.rs` for handling unraveled arguments, such as `reduce_all_unraveled_arg_cpu_serial`, `reduce_axes_unraveled_arg_cpu_serial`, `reduce_all_arg_cpu_serial`, and `reduce_axes_arg_cpu_serial`.

### Documentation Update:
* Updated the documentation link in `rstsr-core/src/dev_utilities/mod.rs` to use the correct Markdown link format.

These changes improve the consistency and functionality of the reduction operations within the `rstsr-core` library.