### PR TITLE
Allow linalg function accept any dimension instead of only 2-D

### DIFF
--- a/rstsr-openblas/src/impl_linalg_traits/cholesky.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/cholesky.rs
@@ -3,53 +3,62 @@ use rstsr_blas_traits::prelude::*;
 use rstsr_core::prelude_dev::*;
 use rstsr_linalg_traits::prelude_dev::*;
 
-impl<R, T> LinalgCholeskyAPI<DeviceBLAS> for (&TensorAny<R, T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<R, T, D> LinalgCholeskyAPI<DeviceBLAS> for (&TensorAny<R, T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
     R: DataCloneAPI<Data = Vec<T>>,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, Ix2> + POTRFDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn cholesky_f(args: Self) -> Result<Self::Out> {
         let (a, uplo) = args;
-        Ok(blas_cholesky_f(a.view().into(), uplo)?.into_owned())
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a = a.view().into_dim::<Ix2>();
+        let result = blas_cholesky_f(a.view().into(), uplo)?.into_owned();
+        Ok(result.into_dim::<IxD>().into_dim::<D>())
     }
 }
 
-impl<T> LinalgCholeskyAPI<DeviceBLAS> for (TensorView<'_, T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<T, D> LinalgCholeskyAPI<DeviceBLAS> for (TensorView<'_, T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, Ix2> + POTRFDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn cholesky_f(args: Self) -> Result<Self::Out> {
         let (a, uplo) = args;
-        Ok(blas_cholesky_f(a.into(), uplo)?.into_owned())
+        LinalgCholeskyAPI::<DeviceBLAS>::cholesky_f((&a, uplo))
     }
 }
 
-impl<'a, T> LinalgCholeskyAPI<DeviceBLAS> for (TensorMut<'a, T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<'a, T, D> LinalgCholeskyAPI<DeviceBLAS> for (TensorMut<'a, T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, Ix2> + POTRFDriverAPI<T>,
 {
-    type Out = TensorMutable<'a, T, DeviceBLAS, Ix2>;
+    type Out = TensorMutable<'a, T, DeviceBLAS, D>;
     fn cholesky_f(args: Self) -> Result<Self::Out> {
         let (a, uplo) = args;
-        blas_cholesky_f(a.into(), uplo)
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a = a.into_dim::<Ix2>();
+        let result = blas_cholesky_f(a.into(), uplo)?;
+        Ok(result.into_dim::<IxD>().into_dim::<D>())
     }
 }
 
-impl<T> LinalgCholeskyAPI<DeviceBLAS> for (Tensor<T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<T, D> LinalgCholeskyAPI<DeviceBLAS> for (Tensor<T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, Ix2> + POTRFDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn cholesky_f(args: Self) -> Result<Self::Out> {
         let (mut a, uplo) = args;
-        let a_mut = a.view_mut().into();
-        blas_cholesky_f(a_mut, uplo)?;
+        LinalgCholeskyAPI::<DeviceBLAS>::cholesky_f((a.view_mut(), uplo))?;
         Ok(a)
     }
 }
@@ -67,7 +76,7 @@ mod test {
         let a_cholesky = cholesky((a, Lower));
         println!("{:?}", a_cholesky);
         let vec_a = [1, 1, 2, 1, 3, 1, 2, 1, 8].iter().map(|&x| x as f64).collect::<Vec<_>>();
-        let a = asarray((vec_a, [3, 3].c(), &device)).into_dim::<Ix2>();
+        let a = asarray((vec_a, vec![3, 3].c(), &device));
         let a_cholesky = cholesky((a, Upper));
         println!("{:?}", a_cholesky);
     }

--- a/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
@@ -3,10 +3,11 @@ use rstsr_blas_traits::prelude::*;
 use rstsr_core::prelude_dev::*;
 use rstsr_linalg_traits::prelude_dev::*;
 
-impl<Ra, Rb, T> LinalgSolveTriangularAPI<DeviceBLAS>
-    for (&TensorAny<Ra, T, DeviceBLAS, Ix2>, &TensorAny<Rb, T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<Ra, Rb, T, D> LinalgSolveTriangularAPI<DeviceBLAS>
+    for (&TensorAny<Ra, T, DeviceBLAS, D>, &TensorAny<Rb, T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     Ra: DataCloneAPI<Data = Vec<T>>,
     Rb: DataCloneAPI<Data = Vec<T>>,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
@@ -16,17 +17,23 @@ where
         + BlasThreadAPI
         + TRSMDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn solve_triangular_f(args: Self) -> Result<Self::Out> {
         let (a, b, uplo) = args;
-        Ok(blas_solve_triangular_f(a.view().into(), b.view().into(), uplo)?.into_owned())
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = b.view().into_dim::<Ix2>();
+        let result = blas_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
+        return Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>());
     }
 }
 
-impl<T> LinalgSolveTriangularAPI<DeviceBLAS>
-    for (TensorView<'_, T, DeviceBLAS, Ix2>, TensorView<'_, T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<T, D> LinalgSolveTriangularAPI<DeviceBLAS>
+    for (TensorView<'_, T, DeviceBLAS, D>, TensorView<'_, T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -34,18 +41,19 @@ where
         + BlasThreadAPI
         + TRSMDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn solve_triangular_f(args: Self) -> Result<Self::Out> {
         let (a, b, uplo) = args;
-        solve_triangular_f((&a, &b, uplo))
+        LinalgSolveTriangularAPI::<DeviceBLAS>::solve_triangular_f((&a, &b, uplo))
     }
 }
 
-impl<R, T> LinalgSolveTriangularAPI<DeviceBLAS>
-    for (&TensorAny<R, T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<R, T, D> LinalgSolveTriangularAPI<DeviceBLAS>
+    for (&TensorAny<R, T, DeviceBLAS, D>, Tensor<T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
     R: DataCloneAPI<Data = Vec<T>>,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -53,18 +61,23 @@ where
         + BlasThreadAPI
         + TRSMDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn solve_triangular_f(args: Self) -> Result<Self::Out> {
         let (a, mut b, uplo) = args;
-        blas_solve_triangular_f(a.view().into(), b.view_mut().into(), uplo)?;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = b.view_mut().into_dim::<Ix2>();
+        blas_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
         Ok(b)
     }
 }
 
-impl<T> LinalgSolveTriangularAPI<DeviceBLAS>
-    for (TensorView<'_, T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<T, D> LinalgSolveTriangularAPI<DeviceBLAS>
+    for (TensorView<'_, T, DeviceBLAS, D>, Tensor<T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -72,17 +85,18 @@ where
         + BlasThreadAPI
         + TRSMDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn solve_triangular_f(args: Self) -> Result<Self::Out> {
         let (a, b, uplo) = args;
-        solve_triangular_f((&a, b, uplo))
+        LinalgSolveTriangularAPI::<DeviceBLAS>::solve_triangular_f((&a, b, uplo))
     }
 }
 
-impl<T> LinalgSolveTriangularAPI<DeviceBLAS>
-    for (Tensor<T, DeviceBLAS, Ix2>, Tensor<T, DeviceBLAS, Ix2>, FlagUpLo)
+impl<T, D> LinalgSolveTriangularAPI<DeviceBLAS>
+    for (Tensor<T, DeviceBLAS, D>, Tensor<T, DeviceBLAS, D>, FlagUpLo)
 where
     T: BlasFloat + Send + Sync,
+    D: DimAPI,
     DeviceBLAS: DeviceAPI<T, Raw = Vec<T>>
         + DeviceAPI<blasint, Raw = Vec<blasint>>
         + DeviceComplexFloatAPI<T, Ix2>
@@ -90,10 +104,14 @@ where
         + BlasThreadAPI
         + TRSMDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, Ix2>;
+    type Out = Tensor<T, DeviceBLAS, D>;
     fn solve_triangular_f(args: Self) -> Result<Self::Out> {
         let (mut a, mut b, uplo) = args;
-        blas_solve_triangular_f(a.view_mut().into(), b.view_mut().into(), uplo)?;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let b_view = b.view_mut().into_dim::<Ix2>();
+        blas_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
         Ok(b)
     }
 }


### PR DESCRIPTION
This change will allow linalg (openblas specifically) to accept any dimension as valid input.
However, currently we do not allow broadcasting in linalg functions, so only 2-D or 2-D (dyn) are allowed. Dimensions are checked in runtime instead of compile time.
This change should be more convenient when the user is using RSTSR in dyn dimension in most time.