### PR TITLE
fix rayon pool memory blow up

### DIFF
--- a/rstsr-core/src/device_faer/matmul.rs
+++ b/rstsr-core/src/device_faer/matmul.rs
@@ -43,7 +43,7 @@ where
         && unsafe {
             let a_ptr = a.as_ptr().add(la.offset()) as *const TC;
             let b_ptr = b.as_ptr().add(lb.offset()) as *const TC;
-            let equal_ptr = a_ptr == b_ptr;
+            let equal_ptr = core::ptr::eq(a_ptr, b_ptr);
             let equal_shape = la.shape() == lb.reverse_axes().shape();
             let equal_stride = la.stride() == lb.reverse_axes().stride();
             equal_ptr && equal_shape && equal_stride

--- a/rstsr-core/src/feature_rayon/assignment.rs
+++ b/rstsr-core/src/feature_rayon/assignment.rs
@@ -125,7 +125,7 @@ where
     // determine whether to use parallel iteration
     let nthreads = pool.current_num_threads();
     let size = lc.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return fill_cpu_serial(c, lc, fill);
     }
 

--- a/rstsr-core/src/feature_rayon/reduction.rs
+++ b/rstsr-core/src/feature_rayon/reduction.rs
@@ -40,7 +40,7 @@ where
     // determine whether to use parallel iteration
     let nthreads = pool.current_num_threads();
     let size = la.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return reduce_all_cpu_serial(a, la, init, f, f_sum, f_out);
     }
 
@@ -123,7 +123,7 @@ where
     // determine whether to use parallel iteration
     let nthreads = pool.current_num_threads();
     let size = la.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return reduce_axes_cpu_serial(a, la, axes, init, f, f_sum, f_out);
     }
 
@@ -216,7 +216,7 @@ where
     // determine whether to use parallel iteration
     let nthreads = pool.current_num_threads();
     let size = la.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return reduce_axes_difftype_cpu_serial(a, la, axes, init, f, f_sum, f_out);
     }
 
@@ -316,7 +316,7 @@ where
 
     let nthreads = pool.current_num_threads();
     let size = la.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return reduce_all_unraveled_arg_cpu_serial(a, la, f_comp, f_eq);
     }
 
@@ -387,7 +387,7 @@ where
     // determine whether to use parallel iteration
     let nthreads = pool.current_num_threads();
     let size = la.size();
-    if size < PARALLEL_SWITCH * nthreads {
+    if size < PARALLEL_SWITCH * nthreads || nthreads == 1 {
         return reduce_axes_unraveled_arg_cpu_serial(a, la, axes, f_comp, f_eq);
     }
 

--- a/rstsr-openblas/src/impl_linalg_traits/solve_general.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_general.rs
@@ -133,6 +133,6 @@ mod test {
 
         let x = solve_general((&a, b));
         println!("{:?}", x);
-        assert!(x.as_ptr() == ptr_b);
+        assert_eq!(x.as_ptr(), ptr_b);
     }
 }

--- a/rstsr-openblas/src/impl_linalg_traits/solve_symmetric.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_symmetric.rs
@@ -138,6 +138,6 @@ mod test {
 
         let x = solve_symmetric((&a, b, false, Upper));
         println!("{:?}", x);
-        assert!(x.as_ptr() == ptr_b);
+        assert_eq!(x.as_ptr(), ptr_b);
     }
 }

--- a/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
+++ b/rstsr-openblas/src/impl_linalg_traits/solve_triangular.rs
@@ -133,6 +133,6 @@ mod test {
 
         let x = solve_triangular((&a, b, Upper));
         println!("{:?}", x);
-        assert!(x.as_ptr() == ptr_b);
+        assert_eq!(x.as_ptr(), ptr_b);
     }
 }

--- a/rstsr-openblas/src/matmul.rs
+++ b/rstsr-openblas/src/matmul.rs
@@ -39,7 +39,7 @@ where
         && unsafe {
             let a_ptr = a.as_ptr().add(la.offset()) as *const TC;
             let b_ptr = b.as_ptr().add(lb.offset()) as *const TC;
-            let equal_ptr = a_ptr == b_ptr;
+            let equal_ptr = core::ptr::eq(a_ptr, b_ptr);
             let equal_shape = la.shape() == lb.reverse_axes().shape();
             let equal_stride = la.stride() == lb.reverse_axes().stride();
             equal_ptr && equal_shape && equal_stride


### PR DESCRIPTION
c.f. https://github.com/RESTGroup/rstsr/issues/12

This fixes memory blowup when using reduce functions.
However more check need to be performed, since other `pool.install` code may cause memory blow up.

As a programming practice, it is better not using `pool.install` inside rayon spawned parallel task. Parallel and serial tasks must use different codes. When rayon parallel not detected, use `pool.install`, while when rayon parallel detected, use serial code.