### PR TITLE
Column major support

### DIFF
--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -13,6 +13,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: unittest
         run: cargo test -p rstsr-core --lib
+
+  unittests-col-major:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: unittest
+        run: cargo test -p rstsr-core --lib --no-default-features --features="std faer rayon col_major faer_as_default"
   
   integration-tests:
     runs-on: ubuntu-latest

--- a/rstsr-blas-traits/src/blas3/gemm.rs
+++ b/rstsr-blas-traits/src/blas3/gemm.rs
@@ -53,15 +53,14 @@ where
         let Self { a, b, c, alpha, beta, transa, transb, order } = self;
 
         // determine preferred layout
-        let order_a = (a.c_prefer(), a.f_prefer());
-        let order_b = (b.c_prefer(), b.f_prefer());
         let order_c = c.as_ref().map(|c| (c.c_prefer(), c.f_prefer()));
         let order = order.map(|order| match order {
             ColMajor => (true, false),
             RowMajor => (false, true),
         });
 
-        let order = get_order_row_preferred(&[order, order_c], &[order_a, order_b]);
+        let default_order = a.device().default_order();
+        let order = get_output_order(&[order, order_c], &[], default_order);
         if order == ColMajor {
             // f-prefer: C = op(A) op(B)
             let (transa, a_cow) = flip_trans(order, transa, a, false)?;

--- a/rstsr-blas-traits/src/blas3/syhemm.rs
+++ b/rstsr-blas-traits/src/blas3/syhemm.rs
@@ -54,15 +54,14 @@ where
         let Self { a, b, c, alpha, beta, side, uplo, order } = self;
 
         // determine preferred layout
-        let order_a = (a.c_prefer(), a.f_prefer());
-        let order_b = (b.c_prefer(), b.f_prefer());
         let order_c = c.as_ref().map(|c| (c.c_prefer(), c.f_prefer()));
         let order = order.map(|order| match order {
             ColMajor => (true, false),
             RowMajor => (false, true),
         });
 
-        let order = get_order_row_preferred(&[order, order_c], &[order_a, order_b]);
+        let default_order = a.device().default_order();
+        let order = get_output_order(&[order, order_c], &[], default_order);
         if order == ColMajor {
             let (uplo, a_cow) = match (HERMI, a.f_prefer()) {
                 (false, false) => (uplo.flip()?, a.to_contig_f(ColMajor)?),

--- a/rstsr-blas-traits/src/blas3/trsm.rs
+++ b/rstsr-blas-traits/src/blas3/trsm.rs
@@ -52,14 +52,14 @@ where
         let Self { a, b, alpha, side, uplo, transa, diag, order } = self;
 
         // determine preferred layout
-        let order_a = (a.c_prefer(), a.f_prefer());
         let order_b = (b.c_prefer(), b.f_prefer());
         let order = order.map(|order| match order {
             ColMajor => (true, false),
             RowMajor => (false, true),
         });
 
-        let order = get_order_row_preferred(&[order, Some(order_b)], &[order_a]);
+        let default_order = b.device().default_order();
+        let order = get_output_order(&[order, Some(order_b)], &[], default_order);
         if order == ColMajor {
             let (transa_new, a_cow) = flip_trans(ColMajor, transa, a, false)?;
             let uplo = if transa_new != transa { uplo.flip()? } else { uplo };

--- a/rstsr-blas-traits/src/cblas_flags.rs
+++ b/rstsr-blas-traits/src/cblas_flags.rs
@@ -95,8 +95,8 @@ impl From<FlagSide> for CblasSide {
 impl From<FlagOrder> for CblasLayout {
     fn from(order: FlagOrder) -> Self {
         match order {
-            RowMajor => CblasOrder::RowMajor,
-            ColMajor => CblasOrder::ColMajor,
+            FlagOrder::RowMajor => CblasOrder::RowMajor,
+            FlagOrder::ColMajor => CblasOrder::ColMajor,
         }
     }
 }

--- a/rstsr-blas-traits/src/cblas_flags.rs
+++ b/rstsr-blas-traits/src/cblas_flags.rs
@@ -49,7 +49,7 @@ pub type CBLAS_SIDE = u32;
 
 /* #region flag into */
 
-use rstsr_core::flags::{FlagDiag, FlagSide, FlagTrans, FlagUpLo, TensorOrder};
+use rstsr_core::flags::{FlagDiag, FlagOrder, FlagSide, FlagTrans, FlagUpLo};
 
 impl From<FlagTrans> for CblasTranspose {
     fn from(flag: FlagTrans) -> Self {
@@ -92,11 +92,11 @@ impl From<FlagSide> for CblasSide {
     }
 }
 
-impl From<TensorOrder> for CblasLayout {
-    fn from(order: TensorOrder) -> Self {
+impl From<FlagOrder> for CblasLayout {
+    fn from(order: FlagOrder) -> Self {
         match order {
-            TensorOrder::C => CblasOrder::RowMajor,
-            TensorOrder::F => CblasOrder::ColMajor,
+            RowMajor => CblasOrder::RowMajor,
+            ColMajor => CblasOrder::ColMajor,
         }
     }
 }

--- a/rstsr-blas-traits/src/util/util_layout.rs
+++ b/rstsr-blas-traits/src/util/util_layout.rs
@@ -1,25 +1,25 @@
-use rstsr_core::flags::TensorOrder;
+use rstsr_core::flags::FlagOrder;
 
 pub fn get_order_row_preferred(
     by_first: &[Option<(bool, bool)>],
     by_all: &[(bool, bool)],
-) -> TensorOrder {
+) -> FlagOrder {
     // inputs are in the form of (c_prefer, f_prefer)
     for x in by_first {
         if let &Some((c_prefer, f_prefer)) = x {
             if c_prefer {
-                return TensorOrder::C;
+                return FlagOrder::C;
             } else if f_prefer {
-                return TensorOrder::F;
+                return FlagOrder::F;
             }
         }
     }
 
     if by_all.iter().any(|&(c_prefer, _)| c_prefer) {
-        TensorOrder::C
+        FlagOrder::C
     } else if by_all.iter().any(|&(_, f_prefer)| f_prefer) {
-        TensorOrder::F
+        FlagOrder::F
     } else {
-        TensorOrder::default()
+        FlagOrder::default()
     }
 }

--- a/rstsr-blas-traits/src/util/util_layout.rs
+++ b/rstsr-blas-traits/src/util/util_layout.rs
@@ -1,25 +1,24 @@
-use rstsr_core::flags::FlagOrder;
+use rstsr_core::flags::{ColMajor, FlagOrder, RowMajor};
 
-pub fn get_order_row_preferred(
+pub fn get_output_order(
     by_first: &[Option<(bool, bool)>],
     by_all: &[(bool, bool)],
+    default_order: FlagOrder,
 ) -> FlagOrder {
     // inputs are in the form of (c_prefer, f_prefer)
     for x in by_first {
-        if let &Some((c_prefer, f_prefer)) = x {
-            if c_prefer {
-                return FlagOrder::C;
-            } else if f_prefer {
-                return FlagOrder::F;
-            }
+        match x {
+            Some((true, false)) => return RowMajor,
+            Some((false, true)) => return ColMajor,
+            _ => continue,
         }
     }
 
     if by_all.iter().any(|&(c_prefer, _)| c_prefer) {
-        FlagOrder::C
+        RowMajor
     } else if by_all.iter().any(|&(_, f_prefer)| f_prefer) {
-        FlagOrder::F
+        ColMajor
     } else {
-        FlagOrder::default()
+        default_order
     }
 }

--- a/rstsr-blas-traits/src/util/util_tensor.rs
+++ b/rstsr-blas-traits/src/util/util_tensor.rs
@@ -62,7 +62,7 @@ where
 /* #region flip */
 
 pub fn flip_trans<T, B>(
-    order: TensorOrder,
+    order: FlagOrder,
     trans: FlagTrans,
     view: TensorView<'_, T, B, Ix2>,
     hermi: bool,
@@ -76,7 +76,7 @@ where
         + OpAssignAPI<T, Ix2>,
 {
     // row-major
-    if (order == TensorOrder::C && view.c_prefer()) || (order == TensorOrder::F && view.f_prefer())
+    if (order == FlagOrder::C && view.c_prefer()) || (order == FlagOrder::F && view.f_prefer())
     {
         // tensor is already in the preferred order
         Ok((trans, view.into_cow()))

--- a/rstsr-blas-traits/src/util/util_tensor.rs
+++ b/rstsr-blas-traits/src/util/util_tensor.rs
@@ -18,7 +18,7 @@ where
     let order = match (a.f_prefer(), a.c_prefer()) {
         (true, false) => ColMajor,
         (false, true) => RowMajor,
-        _ => FlagOrder::default(),
+        _ => a.device().default_order(),
     };
     let a = if a.is_ref() {
         TensorMutable::Owned(TensorView::from(a).into_contig_f(order)?)
@@ -76,8 +76,7 @@ where
         + OpAssignAPI<T, Ix2>,
 {
     // row-major
-    if (order == FlagOrder::C && view.c_prefer()) || (order == FlagOrder::F && view.f_prefer())
-    {
+    if (order == FlagOrder::C && view.c_prefer()) || (order == FlagOrder::F && view.f_prefer()) {
         // tensor is already in the preferred order
         Ok((trans, view.into_cow()))
     } else {

--- a/rstsr-core/Cargo.toml
+++ b/rstsr-core/Cargo.toml
@@ -30,12 +30,18 @@ criterion = { workspace = true }
 cpu-time = { workspace = true }
 
 [features]
-default = ["faer", "faer_as_default"]
+default = ["row_major", "faer", "faer_as_default"]
 std = []
-f_prefer = []  # NOTE: THIS FEATURE IS NOT STABLE
 rayon = ["dep:rayon"]
 faer = ["rayon", "dep:faer", "dep:faer-ext", "dep:faer-entity"]
 faer_as_default = []
+
+# Row-major or Col-major will be contractidary features.
+# Only one is accepted, otherwise this will panic in runtime.
+# - Row-major convention: similar to NumPy (with same behavior of versatile broadcasting)
+# - Col-major convention: similar to Julia (limited broadcasting)
+row_major = []
+col_major = []
 
 # Dispatch dimensinoality in layout iterators
 # This option is recommended for efficiency for large tensor, especially with non-contiguous strides.

--- a/rstsr-core/benches/tensor_add.rs
+++ b/rstsr-core/benches/tensor_add.rs
@@ -11,8 +11,8 @@ fn rstsr_serial_4096(criterion: &mut Criterion) {
 
     let vec_a: Vec<f64> = (0..2 * n * 2 * n).map(|_| rng.gen()).collect::<_>();
     let vec_b: Vec<f64> = (0..2 * n * 2 * n).map(|_| rng.gen()).collect::<_>();
-    let a_full = rt::asarray((vec_a, [2 * n, 2 * n], &DeviceCpuSerial));
-    let b_full = rt::asarray((vec_b, [2 * n, 2 * n], &DeviceCpuSerial));
+    let a_full = rt::asarray((vec_a, [2 * n, 2 * n], &DeviceCpuSerial::default()));
+    let b_full = rt::asarray((vec_b, [2 * n, 2 * n], &DeviceCpuSerial::default()));
 
     criterion.bench_function("rstsr serial add 8192 contiguous", |bencher| {
         bencher.iter(|| {

--- a/rstsr-core/benches/tensor_sum.rs
+++ b/rstsr-core/benches/tensor_sum.rs
@@ -10,7 +10,7 @@ fn rstsr_serial_4096(criterion: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
 
     let vec_a: Vec<f64> = (0..n * n).map(|_| rng.gen()).collect::<_>();
-    let a = rt::asarray((vec_a, [n, n], &DeviceCpuSerial));
+    let a = rt::asarray((vec_a, [n, n], &DeviceCpuSerial::default()));
 
     criterion.bench_function("rstsr serial simple sum 4096", |bencher| {
         bencher.iter(|| {
@@ -20,7 +20,7 @@ fn rstsr_serial_4096(criterion: &mut Criterion) {
     });
 
     let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
-    let b_full = rt::asarray((vec_b, [2 * n, 2 * n], &DeviceCpuSerial));
+    let b_full = rt::asarray((vec_b, [2 * n, 2 * n], &DeviceCpuSerial::default()));
 
     // contiguous slice
     let b = b_full.slice([0..n, 0..n]);

--- a/rstsr-core/src/device_cpu_serial/creation.rs
+++ b/rstsr-core/src/device_cpu_serial/creation.rs
@@ -208,7 +208,7 @@ mod test {
         use super::*;
         use num::Complex;
 
-        let device = DeviceCpuSerial;
+        let device = DeviceCpuSerial::default();
         let storage: Storage<_, f64, _> = device.zeros_impl(10).unwrap();
         println!("{:?}", storage);
         let storage: Storage<_, f64, _> = device.ones_impl(10).unwrap();

--- a/rstsr-core/src/device_cpu_serial/device.rs
+++ b/rstsr-core/src/device_cpu_serial/device.rs
@@ -1,18 +1,22 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
 
-#[derive(Clone, Debug)]
-pub struct DeviceCpuSerial;
-
-impl Default for DeviceCpuSerial {
-    fn default() -> Self {
-        DeviceCpuSerial
-    }
+#[derive(Clone, Debug, Default)]
+pub struct DeviceCpuSerial {
+    default_order: FlagOrder,
 }
 
 impl DeviceBaseAPI for DeviceCpuSerial {
-    fn same_device(&self, _other: &Self) -> bool {
-        true
+    fn same_device(&self, other: &Self) -> bool {
+        self.default_order == other.default_order
+    }
+
+    fn default_order(&self) -> FlagOrder {
+        self.default_order
+    }
+
+    fn set_default_order(&mut self, order: FlagOrder) {
+        self.default_order = order;
     }
 }
 
@@ -80,6 +84,7 @@ impl<T> DeviceStorageAPI<T> for DeviceCpuSerial {
 }
 
 impl<T> DeviceAPI<T> for DeviceCpuSerial {}
+
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceCpuSerial
 where
     T: ComplexFloat,
@@ -100,21 +105,21 @@ mod tests {
 
     #[test]
     fn test_cpu_device_same_device() {
-        let device1 = DeviceCpuSerial;
-        let device2 = DeviceCpuSerial;
+        let device1 = DeviceCpuSerial::default();
+        let device2 = DeviceCpuSerial::default();
         assert!(device1.same_device(&device2));
     }
 
     #[test]
     fn test_cpu_storage_to_vec() {
-        let storage = Storage::new(DataOwned::from(vec![1, 2, 3]), DeviceCpuSerial);
+        let storage = Storage::new(DataOwned::from(vec![1, 2, 3]), DeviceCpuSerial::default());
         let vec = storage.to_cpu_vec().unwrap();
         assert_eq!(vec, vec![1, 2, 3]);
     }
 
     #[test]
     fn test_cpu_storage_into_vec() {
-        let storage = Storage::new(DataOwned::from(vec![1, 2, 3]), DeviceCpuSerial);
+        let storage = Storage::new(DataOwned::from(vec![1, 2, 3]), DeviceCpuSerial::default());
         let vec = storage.into_cpu_vec().unwrap();
         assert_eq!(vec, vec![1, 2, 3]);
     }

--- a/rstsr-core/src/device_cpu_serial/matmul.rs
+++ b/rstsr-core/src/device_cpu_serial/matmul.rs
@@ -34,6 +34,7 @@ where
         alpha: TC,
         beta: TC,
     ) -> Result<()> {
+        let default_order = self.default_order();
         match (la.ndim(), lb.ndim(), lc.ndim()) {
             (1, 1, 0) => {
                 // rule 1: vector inner dot
@@ -66,6 +67,9 @@ where
             (1, 2.., _) => {
                 // rule 3: | `        K` | `..., K, N` | `   ..., N` |
                 rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
+                if default_order == ColMajor && lb.ndim() > 2 {
+                    rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")?;
+                }
                 let la = &la.clone().into_dim::<Ix1>().unwrap();
                 let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
                 let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
@@ -84,6 +88,9 @@ where
             (2.., 1, _) => {
                 // rule 4: | `..., M, K` | `        K` | `   ..., M` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
+                if default_order == ColMajor && la.ndim() > 2 {
+                    rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")?;
+                }
                 let lb = &lb.clone().into_dim::<Ix1>().unwrap();
                 let (la_rest, la_matmul) = la.dim_split_at(-2)?;
                 let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
@@ -102,6 +109,9 @@ where
             (2, 3.., _) => {
                 // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
                 rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")?;
+                }
                 let la = &la.clone().into_dim::<Ix2>().unwrap();
                 let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
                 let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
@@ -120,6 +130,9 @@ where
             (3.., 2, _) => {
                 // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")?;
+                }
                 let lb = &lb.clone().into_dim::<Ix2>().unwrap();
                 let (la_rest, la_matmul) = la.dim_split_at(-2)?;
                 let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
@@ -139,6 +152,9 @@ where
                 // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
                 rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")?;
+                }
                 let (la_rest, la_matmul) = la.dim_split_at(-2)?;
                 let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
                 let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;

--- a/rstsr-core/src/device_cpu_serial/operators/op_tri.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/op_tri.rs
@@ -542,7 +542,16 @@ where
         lb: &Layout<IxD>,
         uplo: FlagUpLo,
     ) -> Result<()> {
-        pack_tri_cpu_serial(a, la, b, lb, uplo)
+        let default_order = self.default_order();
+        match default_order {
+            RowMajor => pack_tri_cpu_serial(a, la, b, lb, uplo),
+            ColMajor => {
+                let la = la.reverse_axes();
+                let lb = lb.reverse_axes();
+                let uplo = uplo.flip()?;
+                pack_tri_cpu_serial(a, &la, b, &lb, uplo)
+            },
+        }
     }
 }
 
@@ -559,7 +568,16 @@ where
         uplo: FlagUpLo,
         symm: FlagSymm,
     ) -> Result<()> {
-        unpack_tri_cpu_serial(a, la, b, lb, uplo, symm)
+        let default_order = self.default_order();
+        match default_order {
+            RowMajor => unpack_tri_cpu_serial(a, la, b, lb, uplo, symm),
+            ColMajor => {
+                let la = la.reverse_axes();
+                let lb = lb.reverse_axes();
+                let uplo = uplo.flip()?;
+                unpack_tri_cpu_serial(a, &la, b, &lb, uplo, symm)
+            },
+        }
     }
 }
 

--- a/rstsr-core/src/device_faer/conversion.rs
+++ b/rstsr-core/src/device_faer/conversion.rs
@@ -207,7 +207,7 @@ mod test {
 
     #[test]
     fn test_device_conversion() {
-        let device_serial = DeviceCpuSerial {};
+        let device_serial = DeviceCpuSerial::default();
         let device_faer = DeviceFaer::new(0);
         let a = linspace((1.0, 5.0, 5, &device_faer));
         let b = a.to_device(&device_serial);

--- a/rstsr-core/src/device_faer/creation.rs
+++ b/rstsr-core/src/device_faer/creation.rs
@@ -7,7 +7,7 @@ where
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.empty_impl(len)?;
+        let storage = DeviceCpuSerial::default().empty_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -16,7 +16,7 @@ where
     where
         T: Clone,
     {
-        let storage = DeviceCpuSerial.full_impl(len, fill)?;
+        let storage = DeviceCpuSerial::default().full_impl(len, fill)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -40,19 +40,19 @@ where
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     fn zeros_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.zeros_impl(len)?;
+        let storage = DeviceCpuSerial::default().zeros_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
 
     fn ones_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.ones_impl(len)?;
+        let storage = DeviceCpuSerial::default().ones_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
 
     fn arange_int_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.arange_int_impl(len)?;
+        let storage = DeviceCpuSerial::default().arange_int_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -69,7 +69,7 @@ where
         end: T,
         step: T,
     ) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.arange_impl(start, end, step)?;
+        let storage = DeviceCpuSerial::default().arange_impl(start, end, step)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -87,7 +87,7 @@ where
         n: usize,
         endpoint: bool,
     ) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.linspace_impl(start, end, n, endpoint)?;
+        let storage = DeviceCpuSerial::default().linspace_impl(start, end, n, endpoint)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -102,14 +102,14 @@ where
     where
         D: DimAPI,
     {
-        DeviceCpuSerial.tril_impl(raw, layout, k)
+        DeviceCpuSerial::default().tril_impl(raw, layout, k)
     }
 
     fn triu_impl<D>(&self, raw: &mut Self::Raw, layout: &Layout<D>, k: isize) -> Result<()>
     where
         D: DimAPI,
     {
-        DeviceCpuSerial.triu_impl(raw, layout, k)
+        DeviceCpuSerial::default().triu_impl(raw, layout, k)
     }
 }
 

--- a/rstsr-core/src/device_faer/device.rs
+++ b/rstsr-core/src/device_faer/device.rs
@@ -44,7 +44,17 @@ impl Default for DeviceFaer {
 
 impl DeviceBaseAPI for DeviceFaer {
     fn same_device(&self, other: &Self) -> bool {
-        self.get_num_threads() == other.get_num_threads()
+        let same_num_threads = self.get_num_threads() == other.get_num_threads();
+        let same_default_order = self.default_order() == other.default_order();
+        same_num_threads && same_default_order
+    }
+
+    fn default_order(&self) -> FlagOrder {
+        self.base.default_order()
+    }
+
+    fn set_default_order(&mut self, order: FlagOrder) {
+        self.base.set_default_order(order);
     }
 }
 
@@ -112,6 +122,7 @@ impl<T> DeviceStorageAPI<T> for DeviceFaer {
 }
 
 impl<T> DeviceAPI<T> for DeviceFaer {}
+
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceFaer
 where
     T: ComplexFloat + Send + Sync,

--- a/rstsr-core/src/device_faer/matmul.rs
+++ b/rstsr-core/src/device_faer/matmul.rs
@@ -103,6 +103,7 @@ where
         alpha: TC,
         beta: TC,
     ) -> Result<()> {
+        let default_order = self.default_order();
         let pool = self.get_current_pool();
         let nthreads = match pool {
             Some(pool) => pool.current_num_threads(),
@@ -144,10 +145,16 @@ where
             (1, 2.., _) => {
                 // rule 3: | `        K` | `..., K, N` | `   ..., N` |
                 rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
+                if default_order == ColMajor && lb.ndim() > 2 {
+                    rstsr_raise!(
+                        InvalidLayout,
+                        "Broadcasting matmul is not supported in col-major."
+                    )?;
+                }
                 let (la_r, la_m) = la.dim_split_at(-1)?;
                 let (lb_r, lb_m) = lb.dim_split_at(-2)?;
                 let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-                la_rest = broadcast_layout_to_first(&lc_r, &la_r)?.1;
+                la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
                 lb_rest = lb_r;
                 lc_rest = lc_r;
                 la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
@@ -157,11 +164,17 @@ where
             (2.., 1, _) => {
                 // rule 4: | `..., M, K` | `        K` | `   ..., M` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
+                if default_order == ColMajor && la.ndim() > 2 {
+                    rstsr_raise!(
+                        InvalidLayout,
+                        "Broadcasting matmul is not supported in col-major."
+                    )?;
+                }
                 let (la_r, la_m) = la.dim_split_at(-2)?;
                 let (lb_r, lb_m) = lb.dim_split_at(-1)?;
                 let (lc_r, lc_m) = lc.dim_split_at(-1)?;
                 la_rest = la_r;
-                lb_rest = broadcast_layout_to_first(&lc_r, &lb_r)?.1;
+                lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
                 lc_rest = lc_r;
                 la_matmul = la_m.into_dim::<Ix2>()?;
                 lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
@@ -170,10 +183,16 @@ where
             (2, 3.., _) => {
                 // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
                 rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(
+                        InvalidLayout,
+                        "Broadcasting matmul is not supported in col-major."
+                    )?;
+                }
                 let (la_r, la_m) = la.dim_split_at(-2)?;
                 let (lb_r, lb_m) = lb.dim_split_at(-2)?;
                 let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-                la_rest = broadcast_layout_to_first(&lc_r, &la_r)?.1;
+                la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
                 lb_rest = lb_r;
                 lc_rest = lc_r;
                 la_matmul = la_m.into_dim::<Ix2>()?;
@@ -183,11 +202,17 @@ where
             (3.., 2, _) => {
                 // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(
+                        InvalidLayout,
+                        "Broadcasting matmul is not supported in col-major."
+                    )?;
+                }
                 let (la_r, la_m) = la.dim_split_at(-2)?;
                 let (lb_r, lb_m) = lb.dim_split_at(-2)?;
                 let (lc_r, lc_m) = lc.dim_split_at(-2)?;
                 la_rest = la_r;
-                lb_rest = broadcast_layout_to_first(&lc_r, &lb_r)?.1;
+                lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
                 lc_rest = lc_r;
                 la_matmul = la_m.into_dim::<Ix2>()?;
                 lb_matmul = lb_m.into_dim::<Ix2>()?;
@@ -197,6 +222,12 @@ where
                 // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
                 rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
                 rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+                if default_order == ColMajor {
+                    rstsr_raise!(
+                        InvalidLayout,
+                        "Broadcasting matmul is not supported in col-major."
+                    )?;
+                }
                 let (la_r, la_m) = la.dim_split_at(-2)?;
                 let (lb_r, lb_m) = lb.dim_split_at(-2)?;
                 let (lc_r, lc_m) = lc.dim_split_at(-2)?;

--- a/rstsr-core/src/device_faer/matmul.rs
+++ b/rstsr-core/src/device_faer/matmul.rs
@@ -289,20 +289,23 @@ mod test {
         let b = linspace((0.0, 14.0, 15, &device));
         println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 2.0, 3, &device));
-        let b = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
-        println!("{:}", &a % &b);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = linspace((0.0, 2.0, 3, &device));
+            let b = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
-        let b = linspace((0.0, 4.0, 5, &device));
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
+            let b = linspace((0.0, 4.0, 5, &device));
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 14.0, 15, &device)).into_shape_assume_contig([5, 3]);
-        let b = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 14.0, 15, &device)).into_shape_assume_contig([5, 3]);
+            let b = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
-        let b = linspace((0.0, 14.0, 15, &device)).into_shape_assume_contig([5, 3]);
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 29.0, 30, &device)).into_shape_assume_contig([2, 3, 5]);
+            let b = linspace((0.0, 14.0, 15, &device)).into_shape_assume_contig([5, 3]);
+            println!("{:}", &a % &b);
+        }
     }
 }

--- a/rstsr-core/src/feature_rayon/auto_impl/assignment.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/assignment.rs
@@ -14,7 +14,8 @@ where
         la: &Layout<DA>,
     ) -> Result<()> {
         let pool = self.get_current_pool();
-        assign_arbitary_cpu_rayon(c, lc, a, la, pool)
+        let default_order = self.default_order();
+        assign_arbitary_cpu_rayon(c, lc, a, la, default_order, pool)
     }
 }
 

--- a/rstsr-core/src/feature_rayon/auto_impl/op_tri.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/op_tri.rs
@@ -15,7 +15,16 @@ where
         uplo: FlagUpLo,
     ) -> Result<()> {
         let pool = self.get_current_pool();
-        pack_tri_cpu_rayon(a, la, b, lb, uplo, pool)
+        let default_order = self.default_order();
+        match default_order {
+            RowMajor => pack_tri_cpu_rayon(a, la, b, lb, uplo, pool),
+            ColMajor => {
+                let la = la.reverse_axes();
+                let lb = lb.reverse_axes();
+                let uplo = uplo.flip()?;
+                pack_tri_cpu_rayon(a, &la, b, &lb, uplo, pool)
+            },
+        }
     }
 }
 
@@ -33,6 +42,15 @@ where
         symm: FlagSymm,
     ) -> Result<()> {
         let pool = self.get_current_pool();
-        unpack_tri_cpu_rayon(a, la, b, lb, uplo, symm, pool)
+        let default_order = self.default_order();
+        match default_order {
+            RowMajor => unpack_tri_cpu_rayon(a, la, b, lb, uplo, symm, pool),
+            ColMajor => {
+                let la = la.reverse_axes();
+                let lb = lb.reverse_axes();
+                let uplo = uplo.flip()?;
+                unpack_tri_cpu_rayon(a, &la, b, &lb, uplo, symm, pool)
+            },
+        }
     }
 }

--- a/rstsr-core/src/feature_rayon/device.rs
+++ b/rstsr-core/src/feature_rayon/device.rs
@@ -41,12 +41,13 @@ pub trait DeviceRayonAPI {
 pub struct DeviceCpuRayon {
     num_threads: usize,
     pool: Arc<ThreadPool>,
+    default_order: FlagOrder,
 }
 
 impl DeviceCpuRayon {
     pub fn new(num_threads: usize) -> Self {
         let pool = Arc::new(Self::generate_pool(num_threads).unwrap());
-        DeviceCpuRayon { num_threads, pool }
+        DeviceCpuRayon { num_threads, pool, default_order: FlagOrder::default() }
     }
 
     fn generate_pool(n: usize) -> Result<ThreadPool> {
@@ -62,7 +63,15 @@ impl Default for DeviceCpuRayon {
 
 impl DeviceBaseAPI for DeviceCpuRayon {
     fn same_device(&self, other: &Self) -> bool {
-        self.num_threads == other.num_threads
+        self.default_order == other.default_order
+    }
+
+    fn default_order(&self) -> FlagOrder {
+        self.default_order
+    }
+
+    fn set_default_order(&mut self, order: FlagOrder) {
+        self.default_order = order;
     }
 }
 

--- a/rstsr-core/src/flags.rs
+++ b/rstsr-core/src/flags.rs
@@ -67,13 +67,17 @@ pub enum FlagOrder {
 #[allow(clippy::derivable_impls)]
 impl Default for FlagOrder {
     fn default() -> Self {
-        #[cfg(not(feature = "f_prefer"))]
-        {
-            FlagOrder::C
+        if cfg!(feature = "row_major") && cfg!(feature = "col_major") {
+            panic!(concat!(
+                "`row_major` and `col_major` are not compatible with each other. ",
+                "Please choose one of them in cargo features.",
+            ));
         }
-        #[cfg(feature = "f_prefer")]
-        {
-            FlagOrder::F
+
+        if cfg!(feature = "col_major") {
+            return FlagOrder::F;
+        } else {
+            return FlagOrder::C;
         }
     }
 }

--- a/rstsr-core/src/flags.rs
+++ b/rstsr-core/src/flags.rs
@@ -64,6 +64,12 @@ pub enum FlagOrder {
     F = 102,
 }
 
+#[allow(non_upper_case_globals)]
+impl FlagOrder {
+    pub const RowMajor: Self = FlagOrder::C;
+    pub const ColMajor: Self = FlagOrder::F;
+}
+
 #[allow(clippy::derivable_impls)]
 impl Default for FlagOrder {
     fn default() -> Self {

--- a/rstsr-core/src/layout/iterator.rs
+++ b/rstsr-core/src/layout/iterator.rs
@@ -634,12 +634,12 @@ where
                 let iter = IterLayoutColMajor::new(layout)?;
                 return Ok(Self::ColMajor(iter));
             },
-            A => match TensorOrder::default() {
-                TensorOrder::C => {
+            A => match FlagOrder::default() {
+                RowMajor => {
                     let iter = IterLayoutRowMajor::new(layout)?;
                     return Ok(Self::RowMajor(iter));
                 },
-                TensorOrder::F => {
+                ColMajor => {
                     let iter = IterLayoutColMajor::new(layout)?;
                     return Ok(Self::ColMajor(iter));
                 },

--- a/rstsr-core/src/layout/layoutbase.rs
+++ b/rstsr-core/src/layout/layoutbase.rs
@@ -605,15 +605,6 @@ pub trait DimLayoutContigAPI: DimBaseAPI + DimShapeAPI + DimStrideAPI {
         unsafe { Layout::new_unchecked(shape, stride, offset.unwrap_or(0)) }
     }
 
-    /// Generate new layout by providing shape and offset; Whether c-contiguous
-    /// or f-contiguous depends on cargo feature `f_prefer`.
-    fn new_contig(&self, offset: Option<usize>) -> Layout<Self> {
-        match TensorOrder::default() {
-            TensorOrder::C => self.new_c_contig(offset),
-            TensorOrder::F => self.new_f_contig(offset),
-        }
-    }
-
     /// Simplified function to generate c-contiguous layout. See also
     /// [DimLayoutContigAPI::new_c_contig].
     fn c(&self) -> Layout<Self> {

--- a/rstsr-core/src/layout/matmul.rs
+++ b/rstsr-core/src/layout/matmul.rs
@@ -593,7 +593,7 @@ mod test_fixed {
             let la = [4, 1, 2, 5, 6].f().swapaxes(0, 2).unwrap();
             let lb = [4, 3, 1, 6, 7].f().swapaxes(0, 2).unwrap();
             let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [1, 2, 6, 24, 120], 0).unwrap());
+            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [420, 140, 35, 7, 1], 0).unwrap());
 
             let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
             let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();

--- a/rstsr-core/src/layout/matmul.rs
+++ b/rstsr-core/src/layout/matmul.rs
@@ -6,6 +6,8 @@ Layout manuplication for matmul and other linalg operations
 
 We refer [Python array API](https://data-apis.org/array-api/2023.12/specification/generated/array_api.matmul.html) for more information.
 
+Please note that the following rule only applies to row-major.
+
 | Id | A | B | C |
 |----|---|---|---|
 | 1. | `        N` | `        N` | `         ` |
@@ -15,6 +17,8 @@ We refer [Python array API](https://data-apis.org/array-api/2023.12/specificatio
 | 5. | `     M, K` | `..., K, N` | `..., M, N` |
 | 6. | `..., M, K` | `     K, N` | `..., M, N` |
 | 7. | `..., M, K` | `..., K, N` | `..., M, N` |
+
+For col-major, only rule 1, 2, (part of) 3, (part of) 4 are valid.
 
 */
 
@@ -107,17 +111,9 @@ impl LayoutMatMulAPI<Ix2, Ix2> for LayoutMatMulConfig<Ix2, Ix2> {
         let lc = match order {
             Order::C => sc.c(),
             Order::F => sc.f(),
-            Order::A | Order::K => {
-                if la.c_prefer() && lb.c_prefer() {
-                    sc.c()
-                } else if la.f_prefer() && lb.f_prefer() {
-                    sc.f()
-                } else {
-                    match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
-                    }
-                }
+            Order::A | Order::K => match TensorOrder::default() {
+                TensorOrder::C => sc.c(),
+                TensorOrder::F => sc.f(),
             },
             _ => rstsr_invalid!(order)?,
         };
@@ -135,6 +131,7 @@ impl LayoutMatMulAPI<Ix2, Ix2> for LayoutMatMulConfig<Ix2, Ix2> {
     }
 }
 
+#[cfg(not(feature = "col_major"))]
 impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
     type DC = IxD;
     fn layout_matmul(la: &Layout<IxD>, lb: &Layout<IxD>, order: Order) -> Result<Self> {
@@ -165,17 +162,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A | Order::K => {
-                        if la.c_prefer() && lb.c_prefer() {
-                            sc.c()
-                        } else if la.f_prefer() && lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A | Order::K => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     _ => rstsr_invalid!(order)?,
                 };
@@ -202,17 +191,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => {
-                        if lb.c_prefer() {
-                            sc.c()
-                        } else if lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     Order::K => {
                         let lb_ord = lb.dim_select(-2, 0)?;
@@ -246,17 +227,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => {
-                        if lb.c_prefer() {
-                            sc.c()
-                        } else if lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     Order::K => {
                         let la_ord = la.dim_select(-1, 0)?;
@@ -290,17 +263,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => {
-                        if lb.c_prefer() {
-                            sc.c()
-                        } else if lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     Order::K => {
                         let (_, permute) = greedy_layout(lb, true);
@@ -333,17 +298,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => {
-                        if lb.c_prefer() {
-                            sc.c()
-                        } else if lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     Order::K => {
                         let (_, permute) = greedy_layout(la, true);
@@ -377,31 +334,17 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => {
-                        if lb.c_prefer() {
-                            sc.c()
-                        } else if lb.f_prefer() {
-                            sc.f()
-                        } else {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
-                            }
-                        }
+                    Order::A => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
                     },
                     Order::K => {
                         let (_, a_permute) = greedy_layout(la, true);
                         let (_, b_permute) = greedy_layout(lb, true);
                         if a_permute != b_permute {
-                            if lb.c_prefer() {
-                                sc.c()
-                            } else if lb.f_prefer() {
-                                sc.f()
-                            } else {
-                                match TensorOrder::default() {
-                                    TensorOrder::C => sc.c(),
-                                    TensorOrder::F => sc.f(),
-                                }
+                            match TensorOrder::default() {
+                                TensorOrder::C => sc.c(),
+                                TensorOrder::F => sc.f(),
                             }
                         } else {
                             let sc_perm = sc.f().transpose(&a_permute)?.shape().clone();
@@ -422,6 +365,98 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                     lb_matmul: lb_matmul.to_dim()?,
                     lc_matmul: lc_matmul.to_dim()?,
                 })
+            },
+            (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
+        }
+    }
+}
+
+#[cfg(feature = "col_major")]
+impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
+    type DC = IxD;
+    fn layout_matmul(la: &Layout<IxD>, lb: &Layout<IxD>, order: Order) -> Result<Self> {
+        let na = la.ndim();
+        let nb = lb.ndim();
+        match (na, nb) {
+            (1, 1) => {
+                // rule 1: vector inner dot
+                rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
+                let lc = unsafe { Layout::new_unchecked(vec![], vec![], 0) };
+                Ok(LayoutMatMulConfig {
+                    matmul_type: MatMulType::InnerDot,
+                    lc: lc.clone(),
+                    la_rest: None,
+                    lb_rest: None,
+                    lc_rest: None,
+                    la_matmul: la.to_dim()?,
+                    lb_matmul: lb.to_dim()?,
+                    lc_matmul: lc.to_dim()?,
+                })
+            },
+            (2, 2) => {
+                // rule 2: matrix multiplication
+                // check and generate shape
+                rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+                let sc = vec![la.shape()[0], lb.shape()[1]];
+                // layout order determination
+                let lc = match order {
+                    Order::C => sc.c(),
+                    Order::F => sc.f(),
+                    Order::A | Order::K => match TensorOrder::default() {
+                        TensorOrder::C => sc.c(),
+                        TensorOrder::F => sc.f(),
+                    },
+                    _ => rstsr_invalid!(order)?,
+                };
+                // return layout configuration
+                Ok(LayoutMatMulConfig {
+                    matmul_type: MatMulType::GEMM22,
+                    lc: lc.clone(),
+                    la_rest: None,
+                    lb_rest: None,
+                    lc_rest: None,
+                    la_matmul: la.to_dim()?,
+                    lb_matmul: lb.to_dim()?,
+                    lc_matmul: lc.to_dim()?,
+                })
+            },
+            (1, 2) => {
+                // rule 3: | `        K` | `     K, N` | `        N` |
+                // check and generate shape
+                rstsr_assert_eq!(la.shape()[0], lb.shape()[0], InvalidLayout)?;
+                let sc = vec![lb.shape()[1]];
+                let lc = sc.f();
+                Ok(LayoutMatMulConfig {
+                    matmul_type: MatMulType::GEVM,
+                    lc: lc.to_dim()?,
+                    la_rest: None,
+                    lb_rest: None,
+                    lc_rest: None,
+                    la_matmul: la.to_dim()?,
+                    lb_matmul: lb.to_dim()?,
+                    lc_matmul: lc.to_dim()?,
+                })
+            },
+            (2, 1) => {
+                // rule 4: | `     M, K` | `        K` | `        M` |
+                // check and generate shape
+                rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+                let sc = vec![la.shape()[0]];
+                let lc = sc.f();
+                // return layout configuration
+                Ok(LayoutMatMulConfig {
+                    matmul_type: MatMulType::GEMV,
+                    lc: lc.to_dim()?,
+                    la_rest: None,
+                    lb_rest: None,
+                    lc_rest: None,
+                    la_matmul: la.to_dim()?,
+                    lb_matmul: lb.to_dim()?,
+                    lc_matmul: lc.to_dim()?,
+                })
+            },
+            (1, 3..) | (3.., 1) | (2, 3..) | (3.., 2) | (3.., 3..) => {
+                rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")
             },
             (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
         }
@@ -521,46 +556,49 @@ impl_fixed!(IxD, Ix9, IxD);
 
 #[cfg(test)]
 mod test_fixed {
-    use super::*;
 
     #[test]
     fn test_layout_matmul() {
-        let la = [4].c();
-        let lb = [4].c();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::C).unwrap();
-        assert_eq!(config.matmul_type, MatMulType::InnerDot);
-        assert_eq!(config.lc.shape(), &[]);
-        assert_eq!(config.la_matmul.shape(), &[4]);
-        assert_eq!(config.lb_matmul.shape(), &[4]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            use super::*;
+            let la = [4].c();
+            let lb = [4].c();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::C).unwrap();
+            assert_eq!(config.matmul_type, MatMulType::InnerDot);
+            assert_eq!(config.lc.shape(), &[]);
+            assert_eq!(config.la_matmul.shape(), &[4]);
+            assert_eq!(config.lb_matmul.shape(), &[4]);
 
-        let la = [5].c();
-        let lb = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([4, 3, 6], [3, 1, 12], 0).unwrap());
+            let la = [5].c();
+            let lb = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([4, 3, 6], [3, 1, 12], 0).unwrap());
 
-        let la = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
-        let lb = [6].c();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([4, 3, 5], [3, 1, 12], 0).unwrap());
+            let la = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
+            let lb = [6].c();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([4, 3, 5], [3, 1, 12], 0).unwrap());
 
-        let la = [7, 6].c();
-        let lb = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([2, 3, 4, 7, 5], [1, 2, 6, 120, 24], 0).unwrap());
+            let la = [7, 6].c();
+            let lb = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([2, 3, 4, 7, 5], [1, 2, 6, 120, 24], 0).unwrap());
 
-        let la = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
-        let lb = [5, 7].c();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([2, 3, 4, 6, 7], [1, 2, 6, 168, 24], 0).unwrap());
+            let la = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
+            let lb = [5, 7].c();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([2, 3, 4, 6, 7], [1, 2, 6, 168, 24], 0).unwrap());
 
-        let la = [4, 1, 2, 5, 6].f().swapaxes(0, 2).unwrap();
-        let lb = [4, 3, 1, 6, 7].f().swapaxes(0, 2).unwrap();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [420, 140, 35, 7, 1], 0).unwrap());
+            let la = [4, 1, 2, 5, 6].f().swapaxes(0, 2).unwrap();
+            let lb = [4, 3, 1, 6, 7].f().swapaxes(0, 2).unwrap();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [1, 2, 6, 24, 120], 0).unwrap());
 
-        let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
-        let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();
-        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-        assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [12, 4, 1, 24, 120], 0).unwrap());
+            let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
+            let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();
+            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
+            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [12, 4, 1, 24, 120], 0).unwrap());
+        }
     }
 }

--- a/rstsr-core/src/layout/matmul.rs
+++ b/rstsr-core/src/layout/matmul.rs
@@ -24,9 +24,6 @@ For col-major, only rule 1, 2, (part of) 3, (part of) 4 are valid.
 
 use crate::prelude_dev::*;
 
-// type alias for this file
-type Order = TensorIterOrder;
-
 /// Rules of matmul.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MatMulType {
@@ -65,25 +62,14 @@ where
     type DC: DimAPI;
     /// Layout configuration for matmul.
     ///
-    /// For order,
-    /// - `C`: return c-contig layout
-    /// - `F`: return f-contig layout
-    /// - `A`: c/f-contig if input is contiguous, otherwise return layout based
-    ///   on default tensor order (`FlagOrder::default()`)
-    /// - `K`:
-    ///   - rule 1 (vector): no effect (order is not of that important);
-    ///   - rule 7 (tensor-gemm): if input layouts returns the same
-    ///     `permute_index` in [`greedy_layout`], then use this order; otherwise
-    ///     use auto order;
-    ///   - rules 2, 3, 4 (gemv/gevm/2d-gemm): the same to `A`;
-    ///   - rules 5, 6 (tensor-gemm): order of the layout with larger dimension.
-    fn layout_matmul(la: &Layout<DA>, lb: &Layout<DB>, order: Order) -> Result<Self>;
+    /// For order, currently we only accept deterministic order.
+    fn layout_matmul(la: &Layout<DA>, lb: &Layout<DB>, order: FlagOrder) -> Result<Self>;
 }
 
 // rule 1
 impl LayoutMatMulAPI<Ix1, Ix1> for LayoutMatMulConfig<Ix1, Ix1> {
     type DC = Ix0;
-    fn layout_matmul(la: &Layout<Ix1>, lb: &Layout<Ix1>, _: Order) -> Result<Self> {
+    fn layout_matmul(la: &Layout<Ix1>, lb: &Layout<Ix1>, _: FlagOrder) -> Result<Self> {
         // check shape
         rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
         let lc = unsafe { Layout::new_unchecked([], [], 0) };
@@ -103,19 +89,14 @@ impl LayoutMatMulAPI<Ix1, Ix1> for LayoutMatMulConfig<Ix1, Ix1> {
 // rule 2
 impl LayoutMatMulAPI<Ix2, Ix2> for LayoutMatMulConfig<Ix2, Ix2> {
     type DC = Ix2;
-    fn layout_matmul(la: &Layout<Ix2>, lb: &Layout<Ix2>, order: Order) -> Result<Self> {
+    fn layout_matmul(la: &Layout<Ix2>, lb: &Layout<Ix2>, order: FlagOrder) -> Result<Self> {
         // check and generate shape
         rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
         let sc = [la.shape()[0], lb.shape()[1]];
         // layout order determination
         let lc = match order {
-            Order::C => sc.c(),
-            Order::F => sc.f(),
-            Order::A | Order::K => match FlagOrder::default() {
-                RowMajor => sc.c(),
-                ColMajor => sc.f(),
-            },
-            _ => rstsr_invalid!(order)?,
+            RowMajor => sc.c(),
+            ColMajor => sc.f(),
         };
         // return layout configuration
         Ok(LayoutMatMulConfig {
@@ -131,334 +112,251 @@ impl LayoutMatMulAPI<Ix2, Ix2> for LayoutMatMulConfig<Ix2, Ix2> {
     }
 }
 
-#[cfg(not(feature = "col_major"))]
-impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
-    type DC = IxD;
-    fn layout_matmul(la: &Layout<IxD>, lb: &Layout<IxD>, order: Order) -> Result<Self> {
-        let na = la.ndim();
-        let nb = lb.ndim();
-        match (na, nb) {
-            (1, 1) => {
-                // rule 1: vector inner dot
-                rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
-                let lc = unsafe { Layout::new_unchecked(vec![], vec![], 0) };
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::InnerDot,
-                    lc: lc.clone(),
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (2, 2) => {
-                // rule 2: matrix multiplication
-                // check and generate shape
-                rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
-                let sc = vec![la.shape()[0], lb.shape()[1]];
-                // layout order determination
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A | Order::K => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMM22,
-                    lc: lc.clone(),
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (1, 2..) => {
-                // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-                // check and generate shape
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                rstsr_assert_eq!(la.shape()[0], lb_matmul.shape()[0], InvalidLayout)?;
-                // layout order determination
-                let mut sc = lb_rest.shape().clone();
-                sc.push(lb_matmul.shape()[1]);
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    Order::K => {
-                        let lb_ord = lb.dim_select(-2, 0)?;
-                        let (_, permute) = greedy_layout(&lb_ord, true);
-                        let sc_perm = sc.f().transpose(&permute)?.shape().clone();
-                        sc_perm.f().transpose(&reversed_permute(&permute))?
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEVM,
-                    lc: lc.to_dim()?,
-                    la_rest: None,
-                    lb_rest: Some(lb_rest),
-                    lc_rest: Some(lc_rest),
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb_matmul.to_dim()?,
-                    lc_matmul: lc_matmul.to_dim()?,
-                })
-            },
-            (2.., 1) => {
-                // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-                // check and generate shape
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                rstsr_assert_eq!(lb.shape()[0], la_matmul.shape()[1], InvalidLayout)?;
-                // layout order determination
-                let mut sc = la_rest.shape().clone();
-                sc.push(la_matmul.shape()[0]);
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    Order::K => {
-                        let la_ord = la.dim_select(-1, 0)?;
-                        let (_, permute) = greedy_layout(&la_ord, true);
-                        let sc_perm = sc.f().transpose(&permute)?.shape().clone();
-                        sc_perm.f().transpose(&reversed_permute(&permute))?
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMV,
-                    lc: lc.to_dim()?,
-                    la_rest: Some(la_rest),
-                    lb_rest: None,
-                    lc_rest: Some(lc_rest),
-                    la_matmul: la_matmul.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc_matmul.to_dim()?,
-                })
-            },
-            (2, 3..) => {
-                // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-                // check and generate shape
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                rstsr_assert_eq!(la.shape()[1], lb_matmul.shape()[0], InvalidLayout)?;
-                // layout order determination
-                let mut sc = lb_rest.shape().clone();
-                sc.append(&mut vec![la.shape()[0], lb_matmul.shape()[1]]);
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    Order::K => {
-                        let (_, permute) = greedy_layout(lb, true);
-                        let sc_perm = sc.f().transpose(&permute)?.shape().clone();
-                        sc_perm.f().transpose(&reversed_permute(&permute))?
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMM2X,
-                    lc: lc.to_dim()?,
-                    la_rest: None,
-                    lb_rest: Some(lb_rest),
-                    lc_rest: Some(lc_rest),
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb_matmul.to_dim()?,
-                    lc_matmul: lc_matmul.to_dim()?,
-                })
-            },
-            (3.., 2) => {
-                // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-                // check and generate shape
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                rstsr_assert_eq!(la_matmul.shape()[1], lb.shape()[0], InvalidLayout)?;
-                // layout order determination
-                let mut sc = la_rest.shape().clone();
-                sc.append(&mut vec![la_matmul.shape()[0], lb.shape()[1]]);
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    Order::K => {
-                        let (_, permute) = greedy_layout(la, true);
-                        let sc_perm = sc.f().transpose(&permute)?.shape().clone();
-                        sc_perm.f().transpose(&reversed_permute(&permute))?
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMMX2,
-                    lc: lc.to_dim()?,
-                    la_rest: Some(la_rest),
-                    lb_rest: None,
-                    lc_rest: Some(lc_rest),
-                    la_matmul: la_matmul.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc_matmul.to_dim()?,
-                })
-            },
-            (3.., 3..) => {
-                // check and generate shape
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                rstsr_assert_eq!(la_matmul.shape()[1], lb_matmul.shape()[0], InvalidLayout)?;
-                let (la_rest_b, lb_rest_b) = broadcast_layout(&la_rest, &lb_rest)?;
-                // layout order determination
-                let mut sc = la_rest_b.shape().clone();
-                sc.append(&mut vec![la_matmul.shape()[0], lb_matmul.shape()[1]]);
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    Order::K => {
-                        let (_, a_permute) = greedy_layout(la, true);
-                        let (_, b_permute) = greedy_layout(lb, true);
-                        if a_permute != b_permute {
-                            match FlagOrder::default() {
-                                RowMajor => sc.c(),
-                                ColMajor => sc.f(),
-                            }
-                        } else {
-                            let sc_perm = sc.f().transpose(&a_permute)?.shape().clone();
-                            sc_perm.f().transpose(&reversed_permute(&a_permute))?
-                        }
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMMXX,
-                    lc: lc.to_dim()?,
-                    la_rest: Some(la_rest_b),
-                    lb_rest: Some(lb_rest_b),
-                    lc_rest: Some(lc_rest),
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb_matmul.to_dim()?,
-                    lc_matmul: lc_matmul.to_dim()?,
-                })
-            },
-            (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
-        }
+fn layout_matmul_dyn_row_major(
+    la: &Layout<IxD>,
+    lb: &Layout<IxD>,
+) -> Result<LayoutMatMulConfig<IxD, IxD>> {
+    let na = la.ndim();
+    let nb = lb.ndim();
+    match (na, nb) {
+        (1, 1) => {
+            // rule 1: vector inner dot
+            rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
+            let lc = unsafe { Layout::new_unchecked(vec![], vec![], 0) };
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::InnerDot,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (2, 2) => {
+            // rule 2: matrix multiplication
+            // check and generate shape
+            rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+            let sc = vec![la.shape()[0], lb.shape()[1]];
+            // layout order determination
+            let lc = sc.c();
+            // return layout configuration
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMM22,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (1, 2..) => {
+            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
+            // check and generate shape
+            let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
+            rstsr_assert_eq!(la.shape()[0], lb_matmul.shape()[0], InvalidLayout)?;
+            // layout order determination
+            let mut sc = lb_rest.shape().clone();
+            sc.push(lb_matmul.shape()[1]);
+            let lc = sc.c();
+            // return layout configuration
+            let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEVM,
+                lc: lc.to_dim()?,
+                la_rest: None,
+                lb_rest: Some(lb_rest),
+                lc_rest: Some(lc_rest),
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb_matmul.to_dim()?,
+                lc_matmul: lc_matmul.to_dim()?,
+            })
+        },
+        (2.., 1) => {
+            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
+            // check and generate shape
+            let (la_rest, la_matmul) = la.dim_split_at(-2)?;
+            rstsr_assert_eq!(lb.shape()[0], la_matmul.shape()[1], InvalidLayout)?;
+            // layout order determination
+            let mut sc = la_rest.shape().clone();
+            sc.push(la_matmul.shape()[0]);
+            let lc = sc.c();
+            // return layout configuration
+            let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMV,
+                lc: lc.to_dim()?,
+                la_rest: Some(la_rest),
+                lb_rest: None,
+                lc_rest: Some(lc_rest),
+                la_matmul: la_matmul.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc_matmul.to_dim()?,
+            })
+        },
+        (2, 3..) => {
+            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
+            // check and generate shape
+            let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
+            rstsr_assert_eq!(la.shape()[1], lb_matmul.shape()[0], InvalidLayout)?;
+            // layout order determination
+            let mut sc = lb_rest.shape().clone();
+            sc.append(&mut vec![la.shape()[0], lb_matmul.shape()[1]]);
+            let lc = sc.c();
+            // return layout configuration
+            let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMM2X,
+                lc: lc.to_dim()?,
+                la_rest: None,
+                lb_rest: Some(lb_rest),
+                lc_rest: Some(lc_rest),
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb_matmul.to_dim()?,
+                lc_matmul: lc_matmul.to_dim()?,
+            })
+        },
+        (3.., 2) => {
+            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
+            // check and generate shape
+            let (la_rest, la_matmul) = la.dim_split_at(-2)?;
+            rstsr_assert_eq!(la_matmul.shape()[1], lb.shape()[0], InvalidLayout)?;
+            // layout order determination
+            let mut sc = la_rest.shape().clone();
+            sc.append(&mut vec![la_matmul.shape()[0], lb.shape()[1]]);
+            let lc = sc.c();
+            // return layout configuration
+            let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMMX2,
+                lc: lc.to_dim()?,
+                la_rest: Some(la_rest),
+                lb_rest: None,
+                lc_rest: Some(lc_rest),
+                la_matmul: la_matmul.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc_matmul.to_dim()?,
+            })
+        },
+        (3.., 3..) => {
+            // check and generate shape
+            let (la_rest, la_matmul) = la.dim_split_at(-2)?;
+            let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
+            rstsr_assert_eq!(la_matmul.shape()[1], lb_matmul.shape()[0], InvalidLayout)?;
+            let (la_rest_b, lb_rest_b) = broadcast_layout(&la_rest, &lb_rest)?;
+            // layout order determination
+            let mut sc = la_rest_b.shape().clone();
+            sc.append(&mut vec![la_matmul.shape()[0], lb_matmul.shape()[1]]);
+            let lc = sc.c();
+            // return layout configuration
+            let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMMXX,
+                lc: lc.to_dim()?,
+                la_rest: Some(la_rest_b),
+                lb_rest: Some(lb_rest_b),
+                lc_rest: Some(lc_rest),
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb_matmul.to_dim()?,
+                lc_matmul: lc_matmul.to_dim()?,
+            })
+        },
+        (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
     }
 }
 
-#[cfg(feature = "col_major")]
+fn layout_matmul_dyn_col_major(
+    la: &Layout<IxD>,
+    lb: &Layout<IxD>,
+) -> Result<LayoutMatMulConfig<IxD, IxD>> {
+    let na = la.ndim();
+    let nb = lb.ndim();
+    match (na, nb) {
+        (1, 1) => {
+            // rule 1: vector inner dot
+            rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
+            let lc = unsafe { Layout::new_unchecked(vec![], vec![], 0) };
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::InnerDot,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (2, 2) => {
+            // rule 2: matrix multiplication
+            // check and generate shape
+            rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+            let sc = vec![la.shape()[0], lb.shape()[1]];
+            // layout order determination
+            let lc = sc.f();
+            // return layout configuration
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMM22,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (1, 2) => {
+            // rule 3: | `        K` | `     K, N` | `        N` |
+            // check and generate shape
+            rstsr_assert_eq!(la.shape()[0], lb.shape()[0], InvalidLayout)?;
+            let sc = vec![lb.shape()[1]];
+            let lc = sc.f();
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEVM,
+                lc: lc.to_dim()?,
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (2, 1) => {
+            // rule 4: | `     M, K` | `        K` | `        M` |
+            // check and generate shape
+            rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+            let sc = vec![la.shape()[0]];
+            let lc = sc.f();
+            // return layout configuration
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMV,
+                lc: lc.to_dim()?,
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.to_dim()?,
+                lb_matmul: lb.to_dim()?,
+                lc_matmul: lc.to_dim()?,
+            })
+        },
+        (1, 3..) | (3.., 1) | (2, 3..) | (3.., 2) | (3.., 3..) => {
+            rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")
+        },
+        (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
+    }
+}
+
 impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
     type DC = IxD;
-    fn layout_matmul(la: &Layout<IxD>, lb: &Layout<IxD>, order: Order) -> Result<Self> {
-        let na = la.ndim();
-        let nb = lb.ndim();
-        match (na, nb) {
-            (1, 1) => {
-                // rule 1: vector inner dot
-                rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
-                let lc = unsafe { Layout::new_unchecked(vec![], vec![], 0) };
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::InnerDot,
-                    lc: lc.clone(),
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (2, 2) => {
-                // rule 2: matrix multiplication
-                // check and generate shape
-                rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
-                let sc = vec![la.shape()[0], lb.shape()[1]];
-                // layout order determination
-                let lc = match order {
-                    Order::C => sc.c(),
-                    Order::F => sc.f(),
-                    Order::A | Order::K => match FlagOrder::default() {
-                        RowMajor => sc.c(),
-                        ColMajor => sc.f(),
-                    },
-                    _ => rstsr_invalid!(order)?,
-                };
-                // return layout configuration
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMM22,
-                    lc: lc.clone(),
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (1, 2) => {
-                // rule 3: | `        K` | `     K, N` | `        N` |
-                // check and generate shape
-                rstsr_assert_eq!(la.shape()[0], lb.shape()[0], InvalidLayout)?;
-                let sc = vec![lb.shape()[1]];
-                let lc = sc.f();
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEVM,
-                    lc: lc.to_dim()?,
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (2, 1) => {
-                // rule 4: | `     M, K` | `        K` | `        M` |
-                // check and generate shape
-                rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
-                let sc = vec![la.shape()[0]];
-                let lc = sc.f();
-                // return layout configuration
-                Ok(LayoutMatMulConfig {
-                    matmul_type: MatMulType::GEMV,
-                    lc: lc.to_dim()?,
-                    la_rest: None,
-                    lb_rest: None,
-                    lc_rest: None,
-                    la_matmul: la.to_dim()?,
-                    lb_matmul: lb.to_dim()?,
-                    lc_matmul: lc.to_dim()?,
-                })
-            },
-            (1, 3..) | (3.., 1) | (2, 3..) | (3.., 2) | (3.., 3..) => {
-                rstsr_raise!(InvalidLayout, "Broadcasting matmul is not supported in col-major.")
-            },
-            (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
+    fn layout_matmul(la: &Layout<IxD>, lb: &Layout<IxD>, order: FlagOrder) -> Result<Self> {
+        match order {
+            RowMajor => layout_matmul_dyn_row_major(la, lb),
+            ColMajor => layout_matmul_dyn_col_major(la, lb),
         }
     }
 }
@@ -467,7 +365,7 @@ macro_rules! impl_fixed {
     ($DA:ident, $DB:ident, $DC:ident) => {
         impl LayoutMatMulAPI<$DA, $DB> for LayoutMatMulConfig<$DA, $DB> {
             type DC = $DC;
-            fn layout_matmul(la: &Layout<$DA>, lb: &Layout<$DB>, order: Order) -> Result<Self> {
+            fn layout_matmul(la: &Layout<$DA>, lb: &Layout<$DB>, order: FlagOrder) -> Result<Self> {
                 let la = la.to_dim::<IxD>()?;
                 let lb = lb.to_dim::<IxD>()?;
                 let cfg = LayoutMatMulConfig::layout_matmul(&la, &lb, order)?;
@@ -559,46 +457,53 @@ mod test_fixed {
 
     #[test]
     fn test_layout_matmul() {
-        #[cfg(not(feature = "col_major"))]
-        {
-            use super::*;
-            let la = [4].c();
-            let lb = [4].c();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::C).unwrap();
-            assert_eq!(config.matmul_type, MatMulType::InnerDot);
-            assert_eq!(config.lc.shape(), &[]);
-            assert_eq!(config.la_matmul.shape(), &[4]);
-            assert_eq!(config.lb_matmul.shape(), &[4]);
+        use super::*;
+        let la = [4].c();
+        let lb = [4].c();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.matmul_type, MatMulType::InnerDot);
+        assert_eq!(config.lc.shape(), &[]);
+        assert_eq!(config.la_matmul.shape(), &[4]);
+        assert_eq!(config.lb_matmul.shape(), &[4]);
 
-            let la = [5].c();
-            let lb = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([4, 3, 6], [3, 1, 12], 0).unwrap());
+        let la = [5].c();
+        let lb = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [4, 3, 6].c());
 
-            let la = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
-            let lb = [6].c();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([4, 3, 5], [3, 1, 12], 0).unwrap());
+        let la = [3, 4, 5, 6].f().swapaxes(0, 1).unwrap();
+        let lb = [6].c();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [4, 3, 5].c());
 
-            let la = [7, 6].c();
-            let lb = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([2, 3, 4, 7, 5], [1, 2, 6, 120, 24], 0).unwrap());
+        let la = [7, 6].c();
+        let lb = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [2, 3, 4, 7, 5].c());
 
-            let la = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
-            let lb = [5, 7].c();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([2, 3, 4, 6, 7], [1, 2, 6, 168, 24], 0).unwrap());
+        let la = [2, 3, 4, 5, 6].f().swapaxes(-1, -2).unwrap();
+        let lb = [5, 7].c();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [2, 3, 4, 6, 7].c());
 
-            let la = [4, 1, 2, 5, 6].f().swapaxes(0, 2).unwrap();
-            let lb = [4, 3, 1, 6, 7].f().swapaxes(0, 2).unwrap();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [420, 140, 35, 7, 1], 0).unwrap());
+        let la = [4, 1, 2, 5, 6].f().swapaxes(0, 2).unwrap();
+        let lb = [4, 3, 1, 6, 7].f().swapaxes(0, 2).unwrap();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [2, 3, 4, 5, 7].c());
 
-            let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
-            let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();
-            let config = LayoutMatMulConfig::layout_matmul(&la, &lb, Order::K).unwrap();
-            assert_eq!(config.lc, Layout::new([2, 3, 4, 5, 7], [12, 4, 1, 24, 120], 0).unwrap());
-        }
+        let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
+        let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, RowMajor).unwrap();
+        assert_eq!(config.lc, [2, 3, 4, 5, 7].c());
+
+        let la = [4, 3, 2, 5, 6].f().swapaxes(0, 2).unwrap();
+        let lb = [4, 3, 2, 6, 7].f().swapaxes(0, 2).unwrap();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, ColMajor);
+        assert!(config.is_err());
+
+        let la = [5, 6].c();
+        let lb = [6, 7].c();
+        let config = LayoutMatMulConfig::layout_matmul(&la, &lb, ColMajor).unwrap();
+        assert_eq!(config.lc, [5, 7].f());
     }
 }

--- a/rstsr-core/src/layout/matmul.rs
+++ b/rstsr-core/src/layout/matmul.rs
@@ -246,7 +246,7 @@ fn layout_matmul_dyn_row_major(
             let (la_rest, la_matmul) = la.dim_split_at(-2)?;
             let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
             rstsr_assert_eq!(la_matmul.shape()[1], lb_matmul.shape()[0], InvalidLayout)?;
-            let (la_rest_b, lb_rest_b) = broadcast_layout(&la_rest, &lb_rest)?;
+            let (la_rest_b, lb_rest_b) = broadcast_layout(&la_rest, &lb_rest, RowMajor)?;
             // layout order determination
             let mut sc = la_rest_b.shape().clone();
             sc.append(&mut vec![la_matmul.shape()[0], lb_matmul.shape()[1]]);

--- a/rstsr-core/src/layout/matmul.rs
+++ b/rstsr-core/src/layout/matmul.rs
@@ -69,7 +69,7 @@ where
     /// - `C`: return c-contig layout
     /// - `F`: return f-contig layout
     /// - `A`: c/f-contig if input is contiguous, otherwise return layout based
-    ///   on default tensor order (`TensorOrder::default()`)
+    ///   on default tensor order (`FlagOrder::default()`)
     /// - `K`:
     ///   - rule 1 (vector): no effect (order is not of that important);
     ///   - rule 7 (tensor-gemm): if input layouts returns the same
@@ -111,9 +111,9 @@ impl LayoutMatMulAPI<Ix2, Ix2> for LayoutMatMulConfig<Ix2, Ix2> {
         let lc = match order {
             Order::C => sc.c(),
             Order::F => sc.f(),
-            Order::A | Order::K => match TensorOrder::default() {
-                TensorOrder::C => sc.c(),
-                TensorOrder::F => sc.f(),
+            Order::A | Order::K => match FlagOrder::default() {
+                RowMajor => sc.c(),
+                ColMajor => sc.f(),
             },
             _ => rstsr_invalid!(order)?,
         };
@@ -162,9 +162,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A | Order::K => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A | Order::K => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     _ => rstsr_invalid!(order)?,
                 };
@@ -191,9 +191,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     Order::K => {
                         let lb_ord = lb.dim_select(-2, 0)?;
@@ -227,9 +227,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     Order::K => {
                         let la_ord = la.dim_select(-1, 0)?;
@@ -263,9 +263,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     Order::K => {
                         let (_, permute) = greedy_layout(lb, true);
@@ -298,9 +298,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     Order::K => {
                         let (_, permute) = greedy_layout(la, true);
@@ -334,17 +334,17 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     Order::K => {
                         let (_, a_permute) = greedy_layout(la, true);
                         let (_, b_permute) = greedy_layout(lb, true);
                         if a_permute != b_permute {
-                            match TensorOrder::default() {
-                                TensorOrder::C => sc.c(),
-                                TensorOrder::F => sc.f(),
+                            match FlagOrder::default() {
+                                RowMajor => sc.c(),
+                                ColMajor => sc.f(),
                             }
                         } else {
                             let sc_perm = sc.f().transpose(&a_permute)?.shape().clone();
@@ -402,9 +402,9 @@ impl LayoutMatMulAPI<IxD, IxD> for LayoutMatMulConfig<IxD, IxD> {
                 let lc = match order {
                     Order::C => sc.c(),
                     Order::F => sc.f(),
-                    Order::A | Order::K => match TensorOrder::default() {
-                        TensorOrder::C => sc.c(),
-                        TensorOrder::F => sc.f(),
+                    Order::A | Order::K => match FlagOrder::default() {
+                        RowMajor => sc.c(),
+                        ColMajor => sc.f(),
                     },
                     _ => rstsr_invalid!(order)?,
                 };

--- a/rstsr-core/src/layout/rearrangement.rs
+++ b/rstsr-core/src/layout/rearrangement.rs
@@ -136,8 +136,8 @@ where
                 layout.shape().f()
             } else {
                 match TensorOrder::default() {
-                    TensorOrder::C => layout.shape().c(),
-                    TensorOrder::F => layout.shape().f(),
+                    RowMajor => layout.shape().c(),
+                    ColMajor => layout.shape().f(),
                 }
             }
         },
@@ -204,9 +204,9 @@ where
                 match (c_prefer, f_prefer) {
                     (true, false) => fn_c(layout),
                     (false, true) => fn_f(layout),
-                    (_, _) => match TensorOrder::default() {
-                        TensorOrder::C => fn_c(layout),
-                        TensorOrder::F => fn_f(layout),
+                    (_, _) => match FlagOrder::default() {
+                        RowMajor => fn_c(layout),
+                        ColMajor => fn_f(layout),
                     },
                 }
             }
@@ -230,7 +230,7 @@ where
 /// - K: greedy layout for the one which have the largest non-broadcast-size,
 ///   otherwise left-most layout (usually for mutable-assign/inplace-op)
 /// - G: invalid option here
-/// - B:sequential memory; valid option if `size = bound_max - bound_min`,
+/// - B: sequential memory; valid option if `size = bound_max - bound_min`,
 ///   otherwise raise err
 ///
 /// This operation will not flip any strides.
@@ -265,16 +265,16 @@ where
             let c_contig = layouts.iter().all(|&l| l.c_contig());
             let f_contig = layouts.iter().all(|&l| l.f_contig());
             if c_contig || f_contig {
-                fn_single(layouts, TensorIterOrder::B)
+                fn_single(layouts, Order::B)
             } else {
                 let c_prefer = layouts.iter().all(|&l| l.c_contig());
                 let f_prefer = layouts.iter().all(|&l| l.f_contig());
                 match (c_prefer, f_prefer) {
-                    (true, false) => fn_single(layouts, TensorIterOrder::C),
-                    (false, true) => fn_single(layouts, TensorIterOrder::F),
-                    (_, _) => match TensorOrder::default() {
-                        TensorOrder::C => fn_single(layouts, TensorIterOrder::C),
-                        TensorOrder::F => fn_single(layouts, TensorIterOrder::F),
+                    (true, false) => fn_single(layouts, Order::C),
+                    (false, true) => fn_single(layouts, Order::F),
+                    (_, _) => match FlagOrder::default() {
+                        RowMajor => fn_single(layouts, Order::C),
+                        ColMajor => fn_single(layouts, Order::F),
                     },
                 }
             }

--- a/rstsr-core/src/layout/reshape.rs
+++ b/rstsr-core/src/layout/reshape.rs
@@ -213,79 +213,179 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_playground() {
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a1 = linspace((1.0, 24.0, 24));
+            let a2 = a1.to_shape([2, 3, 4]);
+            println!("{:?}", a2);
+            println!("{:?}", core::ptr::eq(a1.as_ptr(), a2.as_ptr()));
+
+            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4]).unwrap();
+            println!("{:?}", v);
+
+            let b1 = linspace((1.0, 24.0, 24)).into_layout(vec![2, 3, 4].f());
+            let b2 = b1.to_shape([24]);
+            println!("{:?}", b2);
+            println!("{:?}", core::ptr::eq(b1.as_ptr(), b2.as_ptr()));
+
+            let v = layout_reshapeable(b1.layout(), &vec![24]).unwrap();
+            println!("{:?}", v);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let a1 = linspace((1.0, 24.0, 24));
+            let a2 = a1.to_shape([2, 3, 4]);
+            println!("{:?}", a2);
+            println!("{:?}", core::ptr::eq(a1.as_ptr(), a2.as_ptr()));
+            println!("a2[:, :, 0] =\n{:}", a2.i((.., .., 0)));
+            println!("a2[:, :, 1] =\n{:}", a2.i((.., .., 1)));
+            println!("a2[:, :, 2] =\n{:}", a2.i((.., .., 2)));
+            println!("a2[:, :, 3] =\n{:}", a2.i((.., .., 3)));
+
+            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4]).unwrap();
+            println!("{:?}", v);
+
+            let b1 = linspace((1.0, 24.0, 24)).into_layout(vec![2, 3, 4].f());
+            let b2 = b1.to_shape([24]);
+            println!("{:?}", b2);
+            println!("{:?}", core::ptr::eq(b1.as_ptr(), b2.as_ptr()));
+
+            let v = layout_reshapeable(b1.layout(), &vec![24]).unwrap();
+            println!("{:?}", v);
+        }
+    }
+
+    #[test]
     fn test_contig() {
-        let layout_in = vec![2, 3, 4].c();
-        let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4]).unwrap();
-        assert_eq!(layout_out.unwrap(), vec![2, 3, 4].c());
+        #[cfg(not(feature = "col_major"))]
+        {
+            let layout_in = vec![2, 3, 4].c();
+            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![2, 3, 4].c());
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4]).unwrap();
-        assert_eq!(layout_out.unwrap(), vec![3, 2, 4].c());
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![3, 2, 4].c());
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![1, 4, 1, 6]).unwrap();
-        assert_eq!(layout_out.unwrap(), vec![1, 4, 1, 6].c());
+            let layout_out = layout_reshapeable(&layout_in, &vec![1, 4, 1, 6]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![1, 4, 1, 6].c());
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let layout_in = vec![2, 3, 4].f();
+            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![2, 3, 4].f());
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![3, 2, 4].f());
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![1, 4, 1, 6]).unwrap();
+            assert_eq!(layout_out.unwrap(), vec![1, 4, 1, 6].f());
+        }
     }
 
     #[test]
     fn test_partial_contig() {
-        // np.zeros(12, 15, 18); a[3:, :, ::3]
-        // this case is actually contiguous, but with stride 3
-        let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 3], 810).unwrap();
+        #[cfg(not(feature = "col_major"))]
+        {
+            // np.zeros(12, 15, 18); a[3:, :, ::3]
+            // this case is actually contiguous, but with stride 3
+            let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 3], 810).unwrap();
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 9, 3]);
-        assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 9, 3]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![10, 27, 3]);
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![243, 9, 3]);
-        assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![10, 27, 3]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![243, 9, 3]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-        // insert some new axes
-        let layout_out = layout_reshapeable(&layout_in, &vec![1, 10, 1, 27, 3]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![1, 10, 1, 27, 3]);
-        // strides follows c-contiguous, but zero is also valid for broadcast
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![2430, 243, 243, 9, 3]);
+            // insert some new axes
+            let layout_out = layout_reshapeable(&layout_in, &vec![1, 10, 1, 27, 3]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![1, 10, 1, 27, 3]);
+            // strides follows c-contiguous, but zero is also valid for broadcast
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![2430, 243, 243, 9, 3]);
 
-        // np.zeros(12, 15, 18); a[3:, :, 3:15:2]
-        // this case is not contiguous in last two dimensions
-        let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 2], 813).unwrap();
+            // np.zeros(12, 15, 18); a[3:, :, 3:15:2]
+            // this case is not contiguous in last two dimensions
+            let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 2], 813).unwrap();
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 6, 2]);
-        assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 6, 2]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
-        assert!(layout_out.is_none());
+            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            assert!(layout_out.is_none());
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let layout_in = Layout::new(vec![6, 15, 9], vec![3, 18, 270], 810).unwrap();
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 9, 15]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 2, 9, 15]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 18, 162]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 27, 10]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 27, 10]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 243]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+
+            // insert some new axes
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 27, 1, 10, 1]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 27, 1, 10, 1]);
+            // strides follows f-contiguous, but zero is also valid for broadcast
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 243, 243, 2430]);
+
+            // np.zeros(12, 15, 18); a[3:, :, 3:15:2]
+            // this case is not contiguous in last two dimensions
+            let layout_in = Layout::new(vec![6, 15, 9], vec![2, 18, 270], 813).unwrap();
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 9, 15]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 2, 9, 15]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![2, 6, 18, 162]);
+            assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
+
+            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            assert!(layout_out.is_none());
+        }
     }
 
     #[test]
     fn test_minus_stride() {
-        // np.zeros(12, 15, 18); a[3:, ::-1, ::-3]
-        // this case should be seen contiguous in last two dimensions
-        let layout_in = Layout::new(vec![9, 15, 6], vec![270, -18, -3], 1079).unwrap();
+        #[cfg(not(feature = "col_major"))]
+        {
+            // np.zeros(12, 15, 18); a[3:, ::-1, ::-3]
+            // this case should be seen contiguous in last two dimensions
+            let layout_in = Layout::new(vec![9, 15, 6], vec![270, -18, -3], 1079).unwrap();
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
-        assert!(layout_out.is_none());
+            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            assert!(layout_out.is_none());
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![3, 3, 10, 9]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 3, 10, 9]);
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, -27, -3]);
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 3, 10, 9]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 3, 10, 9]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, -27, -3]);
+        }
     }
 
     #[test]
     fn test_broadcast_reshape() {
-        // a = np.zeros(12, 15, 18);
-        // b = np.broadcast_to(a[:, None], (12, 16, 15, 18))
-        let layout_in =
-            unsafe { Layout::new_unchecked(vec![12, 16, 15, 18], vec![270, 0, 18, 1], 0) };
+        #[cfg(not(feature = "col_major"))]
+        {
+            // a = np.zeros(12, 15, 18);
+            // b = np.broadcast_to(a[:, None], (12, 16, 15, 18))
+            let layout_in =
+                unsafe { Layout::new_unchecked(vec![12, 16, 15, 18], vec![270, 0, 18, 1], 0) };
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![4, 3, 4, 4, 9, 1, 30]).unwrap();
-        assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![4, 3, 4, 4, 9, 1, 30]);
-        assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, 0, 0, 30, 30, 1]);
+            let layout_out = layout_reshapeable(&layout_in, &vec![4, 3, 4, 4, 9, 1, 30]).unwrap();
+            assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![4, 3, 4, 4, 9, 1, 30]);
+            assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, 0, 0, 30, 30, 1]);
 
-        let layout_out = layout_reshapeable(&layout_in, &vec![16, 12, 15, 18]).unwrap();
-        assert!(layout_out.is_none());
+            let layout_out = layout_reshapeable(&layout_in, &vec![16, 12, 15, 18]).unwrap();
+            assert!(layout_out.is_none());
+        }
     }
 }

--- a/rstsr-core/src/layout/reshape.rs
+++ b/rstsr-core/src/layout/reshape.rs
@@ -52,7 +52,13 @@ pub(crate) fn reshape_substitute_negatives(
 ///
 /// For more complex reshaping, return `None`, and other functions should handle
 /// this kind of situation.
-fn quick_check(shape_out: &Vec<usize>, layout_in: &Layout<IxD>) -> Result<Option<Layout<IxD>>> {
+///
+/// For order option, row-major and col-major behaves differently.
+fn quick_check(
+    shape_out: &Vec<usize>,
+    layout_in: &Layout<IxD>,
+    order: FlagOrder,
+) -> Result<Option<Layout<IxD>>> {
     // check if size is the same
     let size_in = layout_in.size();
     let size_out = shape_out.iter().product();
@@ -77,7 +83,7 @@ fn quick_check(shape_out: &Vec<usize>, layout_in: &Layout<IxD>) -> Result<Option
     }
 
     // check if contiguous
-    match FlagOrder::default() {
+    match order {
         RowMajor => {
             if layout_in.c_contig() {
                 return Ok(Some(shape_out.new_c_contig(Some(layout_in.offset()))));
@@ -157,7 +163,11 @@ fn pop_shape_out(
 }
 
 /// Internal function for reshaping a tensor in any cases.
-fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<Layout<IxD>> {
+fn complicated_reshape(
+    shape_out: &[usize],
+    layout_in: &Layout<IxD>,
+    order: FlagOrder,
+) -> Option<Layout<IxD>> {
     let shape_out_ref = shape_out; // the original shape_out not modified
     let mut shape_out = shape_out.to_vec(); // the shape_out to be destroyed in iteration
     let mut stride_out = Vec::new();
@@ -166,7 +176,7 @@ fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<L
     let offset = layout_in.offset();
 
     // f-prefer handled by reversing everything
-    if FlagOrder::default() == FlagOrder::F {
+    if order == FlagOrder::F {
         shape_in.reverse();
         stride_in.reverse();
         shape_out.reverse();
@@ -182,7 +192,7 @@ fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<L
     rstsr_assert_eq!(stride_out.len(), shape_out_ref.len(), RuntimeError).unwrap();
     // note that stride_out is in reverse order in c-prefer
     // as contrary, shape_out is in reverse order in f-prefer
-    match FlagOrder::default() {
+    match order {
         RowMajor => stride_out.reverse(),
         ColMajor => shape_out.reverse(),
     };
@@ -198,14 +208,17 @@ fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<L
 /// - If shape not match, this function will raise error.
 /// - If shape match but data need to be copied, return `Ok(None)`.
 /// - If everything is fine, return `Ok(Some(layout_out))`.
+///
+/// For order, row-major and col-major behaves differently.
 pub fn layout_reshapeable(
     layout_in: &Layout<IxD>,
     shape_out: &Vec<usize>,
+    order: FlagOrder,
 ) -> Result<Option<Layout<IxD>>> {
-    if let Some(layout_out) = quick_check(shape_out, layout_in)? {
+    if let Some(layout_out) = quick_check(shape_out, layout_in, order)? {
         return Ok(Some(layout_out));
     }
-    return Ok(complicated_reshape(shape_out, layout_in));
+    return Ok(complicated_reshape(shape_out, layout_in, order));
 }
 
 #[cfg(test)]
@@ -218,10 +231,11 @@ mod test {
         {
             let a1 = linspace((1.0, 24.0, 24));
             let a2 = a1.to_shape([2, 3, 4]);
+            let default_order = a1.device().default_order();
             println!("{:?}", a2);
             println!("{:?}", core::ptr::eq(a1.as_ptr(), a2.as_ptr()));
 
-            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4]).unwrap();
+            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4], default_order).unwrap();
             println!("{:?}", v);
 
             let b1 = linspace((1.0, 24.0, 24)).into_layout(vec![2, 3, 4].f());
@@ -229,13 +243,14 @@ mod test {
             println!("{:?}", b2);
             println!("{:?}", core::ptr::eq(b1.as_ptr(), b2.as_ptr()));
 
-            let v = layout_reshapeable(b1.layout(), &vec![24]).unwrap();
+            let v = layout_reshapeable(b1.layout(), &vec![24], default_order).unwrap();
             println!("{:?}", v);
         }
         #[cfg(feature = "col_major")]
         {
             let a1 = linspace((1.0, 24.0, 24));
             let a2 = a1.to_shape([2, 3, 4]);
+            let default_order = a1.device().default_order();
             println!("{:?}", a2);
             println!("{:?}", core::ptr::eq(a1.as_ptr(), a2.as_ptr()));
             println!("a2[:, :, 0] =\n{:}", a2.i((.., .., 0)));
@@ -243,7 +258,7 @@ mod test {
             println!("a2[:, :, 2] =\n{:}", a2.i((.., .., 2)));
             println!("a2[:, :, 3] =\n{:}", a2.i((.., .., 3)));
 
-            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4]).unwrap();
+            let v = layout_reshapeable(a1.layout(), &vec![2, 3, 4], default_order).unwrap();
             println!("{:?}", v);
 
             let b1 = linspace((1.0, 24.0, 24)).into_layout(vec![2, 3, 4].f());
@@ -251,7 +266,7 @@ mod test {
             println!("{:?}", b2);
             println!("{:?}", core::ptr::eq(b1.as_ptr(), b2.as_ptr()));
 
-            let v = layout_reshapeable(b1.layout(), &vec![24]).unwrap();
+            let v = layout_reshapeable(b1.layout(), &vec![24], default_order).unwrap();
             println!("{:?}", v);
         }
     }
@@ -261,25 +276,29 @@ mod test {
         #[cfg(not(feature = "col_major"))]
         {
             let layout_in = vec![2, 3, 4].c();
-            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4]).unwrap();
+            let default_order = RowMajor;
+            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![2, 3, 4].c());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4]).unwrap();
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![3, 2, 4].c());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![1, 4, 1, 6]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![1, 4, 1, 6], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![1, 4, 1, 6].c());
         }
         #[cfg(feature = "col_major")]
         {
             let layout_in = vec![2, 3, 4].f();
-            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4]).unwrap();
+            let default_order = ColMajor;
+            let layout_out = layout_reshapeable(&layout_in, &vec![2, 3, 4], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![2, 3, 4].f());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4]).unwrap();
+            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 4], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![3, 2, 4].f());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![1, 4, 1, 6]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![1, 4, 1, 6], default_order).unwrap();
             assert_eq!(layout_out.unwrap(), vec![1, 4, 1, 6].f());
         }
     }
@@ -291,19 +310,23 @@ mod test {
             // np.zeros(12, 15, 18); a[3:, :, ::3]
             // this case is actually contiguous, but with stride 3
             let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 3], 810).unwrap();
+            let default_order = RowMajor;
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![15, 9, 2, 3], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 9, 3]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![10, 27, 3], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![10, 27, 3]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![243, 9, 3]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
             // insert some new axes
-            let layout_out = layout_reshapeable(&layout_in, &vec![1, 10, 1, 27, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![1, 10, 1, 27, 3], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![1, 10, 1, 27, 3]);
             // strides follows c-contiguous, but zero is also valid for broadcast
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![2430, 243, 243, 9, 3]);
@@ -312,30 +335,36 @@ mod test {
             // this case is not contiguous in last two dimensions
             let layout_in = Layout::new(vec![9, 15, 6], vec![270, 18, 2], 813).unwrap();
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![15, 9, 2, 3], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![15, 9, 2, 3]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![162, 18, 6, 2]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![10, 27, 3], default_order).unwrap();
             assert!(layout_out.is_none());
         }
         #[cfg(feature = "col_major")]
         {
             let layout_in = Layout::new(vec![6, 15, 9], vec![3, 18, 270], 810).unwrap();
+            let default_order = ColMajor;
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 9, 15]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![3, 2, 9, 15], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 2, 9, 15]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 18, 162]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 27, 10]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![3, 27, 10], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 27, 10]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 243]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
             // insert some new axes
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 27, 1, 10, 1]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![3, 27, 1, 10, 1], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 27, 1, 10, 1]);
             // strides follows f-contiguous, but zero is also valid for broadcast
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![3, 9, 243, 243, 2430]);
@@ -344,12 +373,14 @@ mod test {
             // this case is not contiguous in last two dimensions
             let layout_in = Layout::new(vec![6, 15, 9], vec![2, 18, 270], 813).unwrap();
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 2, 9, 15]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![3, 2, 9, 15], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 2, 9, 15]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![2, 6, 18, 162]);
             assert_eq!(layout_out.as_ref().unwrap().offset(), layout_in.offset());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![10, 27, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![10, 27, 3], default_order).unwrap();
             assert!(layout_out.is_none());
         }
     }
@@ -361,11 +392,14 @@ mod test {
             // np.zeros(12, 15, 18); a[3:, ::-1, ::-3]
             // this case should be seen contiguous in last two dimensions
             let layout_in = Layout::new(vec![9, 15, 6], vec![270, -18, -3], 1079).unwrap();
+            let default_order = RowMajor;
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![15, 9, 2, 3]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![15, 9, 2, 3], default_order).unwrap();
             assert!(layout_out.is_none());
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![3, 3, 10, 9]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![3, 3, 10, 9], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![3, 3, 10, 9]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, -27, -3]);
         }
@@ -379,12 +413,15 @@ mod test {
             // b = np.broadcast_to(a[:, None], (12, 16, 15, 18))
             let layout_in =
                 unsafe { Layout::new_unchecked(vec![12, 16, 15, 18], vec![270, 0, 18, 1], 0) };
+            let default_order = RowMajor;
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![4, 3, 4, 4, 9, 1, 30]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![4, 3, 4, 4, 9, 1, 30], default_order).unwrap();
             assert_eq!(layout_out.as_ref().unwrap().shape(), &vec![4, 3, 4, 4, 9, 1, 30]);
             assert_eq!(layout_out.as_ref().unwrap().stride(), &vec![810, 270, 0, 0, 30, 30, 1]);
 
-            let layout_out = layout_reshapeable(&layout_in, &vec![16, 12, 15, 18]).unwrap();
+            let layout_out =
+                layout_reshapeable(&layout_in, &vec![16, 12, 15, 18], default_order).unwrap();
             assert!(layout_out.is_none());
         }
     }

--- a/rstsr-core/src/layout/reshape.rs
+++ b/rstsr-core/src/layout/reshape.rs
@@ -77,13 +77,13 @@ fn quick_check(shape_out: &Vec<usize>, layout_in: &Layout<IxD>) -> Result<Option
     }
 
     // check if contiguous
-    match TensorOrder::default() {
-        TensorOrder::C => {
+    match FlagOrder::default() {
+        RowMajor => {
             if layout_in.c_contig() {
                 return Ok(Some(shape_out.new_c_contig(Some(layout_in.offset()))));
             }
         },
-        TensorOrder::F => {
+        ColMajor => {
             if layout_in.f_contig() {
                 return Ok(Some(shape_out.new_f_contig(Some(layout_in.offset()))));
             }
@@ -166,7 +166,7 @@ fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<L
     let offset = layout_in.offset();
 
     // f-prefer handled by reversing everything
-    if TensorOrder::default() == TensorOrder::F {
+    if FlagOrder::default() == FlagOrder::F {
         shape_in.reverse();
         stride_in.reverse();
         shape_out.reverse();
@@ -182,9 +182,9 @@ fn complicated_reshape(shape_out: &[usize], layout_in: &Layout<IxD>) -> Option<L
     rstsr_assert_eq!(stride_out.len(), shape_out_ref.len(), RuntimeError).unwrap();
     // note that stride_out is in reverse order in c-prefer
     // as contrary, shape_out is in reverse order in f-prefer
-    match TensorOrder::default() {
-        TensorOrder::C => stride_out.reverse(),
-        TensorOrder::F => shape_out.reverse(),
+    match FlagOrder::default() {
+        RowMajor => stride_out.reverse(),
+        ColMajor => shape_out.reverse(),
     };
 
     let layout_out =

--- a/rstsr-core/src/layout/shape.rs
+++ b/rstsr-core/src/layout/shape.rs
@@ -94,9 +94,9 @@ impl<const N: usize> DimShapeAPI for Ix<N> {
     }
 
     fn stride_contig(&self) -> [isize; N] {
-        match TensorOrder::default() {
-            TensorOrder::C => Self::stride_c_contig(self),
-            TensorOrder::F => Self::stride_f_contig(self),
+        match FlagOrder::default() {
+            RowMajor => Self::stride_c_contig(self),
+            ColMajor => Self::stride_f_contig(self),
         }
     }
 
@@ -204,9 +204,9 @@ impl DimShapeAPI for IxD {
     }
 
     fn stride_contig(&self) -> Vec<isize> {
-        match TensorOrder::default() {
-            TensorOrder::C => Self::stride_c_contig(self),
-            TensorOrder::F => Self::stride_f_contig(self),
+        match FlagOrder::default() {
+            RowMajor => Self::stride_c_contig(self),
+            ColMajor => Self::stride_f_contig(self),
         }
     }
 

--- a/rstsr-core/src/storage/device.rs
+++ b/rstsr-core/src/storage/device.rs
@@ -1,10 +1,12 @@
 use crate::prelude_dev::*;
 
-pub trait DeviceBaseAPI: Default + Clone {
+pub trait DeviceBaseAPI {
     fn same_device(&self, other: &Self) -> bool;
+    fn default_order(&self) -> FlagOrder;
+    fn set_default_order(&mut self, order: FlagOrder);
 }
 
-pub trait DeviceRawAPI<T>: DeviceBaseAPI {
+pub trait DeviceRawAPI<T>: DeviceBaseAPI + Clone {
     type Raw;
 }
 
@@ -150,4 +152,7 @@ where
     }
 }
 
-pub trait DeviceAPI<T>: DeviceBaseAPI + DeviceRawAPI<T> + DeviceStorageAPI<T> {}
+pub trait DeviceAPI<T>:
+    DeviceBaseAPI + DeviceRawAPI<T> + DeviceStorageAPI<T> + Clone + Default
+{
+}

--- a/rstsr-core/src/tensor/asarray.rs
+++ b/rstsr-core/src/tensor/asarray.rs
@@ -590,7 +590,7 @@ mod tests {
     fn test_asarray_scalar() {
         let tensor = asarray_f(1).unwrap();
         println!("{:?}", tensor);
-        let tensor = asarray_f((Complex64::new(0., 1.), &DeviceCpuSerial)).unwrap();
+        let tensor = asarray_f((Complex64::new(0., 1.), &DeviceCpuSerial::default())).unwrap();
         println!("{:?}", tensor);
     }
 }

--- a/rstsr-core/src/tensor/assignment.rs
+++ b/rstsr-core/src/tensor/assignment.rs
@@ -46,7 +46,8 @@ where
         )?;
         let la = a.layout().to_dim::<IxD>()?;
         let lb = b.layout().to_dim::<IxD>()?;
-        let (la_b, lb_b) = broadcast_layout_to_first(&la, &lb)?;
+        let default_order = a.device().default_order();
+        let (la_b, lb_b) = broadcast_layout_to_first(&la, &lb, default_order)?;
         let la_b = la_b.into_dim::<DA>()?;
         let lb_b = lb_b.into_dim::<DA>()?;
         // assign

--- a/rstsr-core/src/tensor/creation.rs
+++ b/rstsr-core/src/tensor/creation.rs
@@ -368,7 +368,7 @@ where
     return EyeAPI::eye_f(param);
 }
 
-impl<T, B> EyeAPI<(T, B)> for (usize, usize, isize, TensorOrder, &B)
+impl<T, B> EyeAPI<(T, B)> for (usize, usize, isize, FlagOrder, &B)
 where
     T: Num,
     B: DeviceAPI<T> + DeviceCreationNumAPI<T> + OpAssignAPI<T, Ix1>,
@@ -378,8 +378,8 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         let (n_rows, n_cols, k, order, device) = self;
         let layout = match order {
-            TensorOrder::C => [n_rows, n_cols].c(),
-            TensorOrder::F => [n_cols, n_rows].f(),
+            RowMajor => [n_rows, n_cols].c(),
+            ColMajor => [n_cols, n_rows].f(),
         };
         let mut storage = device.zeros_impl(layout.size())?;
         let layout_diag = layout.diagonal(Some(k), Some(0), Some(1))?;
@@ -398,7 +398,7 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k, device) -> (n_rows, n_cols, k, C, device)
         let (n_rows, n_cols, k, device) = self;
-        eye_f((n_rows, n_cols, k, TensorOrder::default(), device))
+        eye_f((n_rows, n_cols, k, FlagOrder::default(), device))
     }
 }
 
@@ -412,11 +412,11 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k, device) -> (n_rows, n_cols, k, C, device)
         let (n_rows, device) = self;
-        eye_f((n_rows, n_rows, 0, TensorOrder::default(), device))
+        eye_f((n_rows, n_rows, 0, FlagOrder::default(), device))
     }
 }
 
-impl<T> EyeAPI<T> for (usize, usize, isize, TensorOrder)
+impl<T> EyeAPI<T> for (usize, usize, isize, FlagOrder)
 where
     T: Num + Clone + Send + Sync,
 {
@@ -437,7 +437,7 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k) -> (n_rows, n_cols, k, C)
         let (n_rows, n_cols, k) = self;
-        eye_f((n_rows, n_cols, k, TensorOrder::default(), &DeviceCpu::default()))
+        eye_f((n_rows, n_cols, k, FlagOrder::default(), &DeviceCpu::default()))
     }
 }
 
@@ -449,7 +449,7 @@ where
 
     fn eye_f(self) -> Result<Self::Out> {
         // n_rows -> (n_rows, n_rows, 0, C)
-        eye_f((self, self, 0, TensorOrder::default(), &DeviceCpu::default()))
+        eye_f((self, self, 0, FlagOrder::default(), &DeviceCpu::default()))
     }
 }
 

--- a/rstsr-core/src/tensor/creation.rs
+++ b/rstsr-core/src/tensor/creation.rs
@@ -193,9 +193,8 @@ where
     return EmptyAPI::empty_f(param);
 }
 
-impl<T, D, B, L> EmptyAPI<(T, D)> for (L, &B)
+impl<T, D, B> EmptyAPI<(T, D)> for (Layout<D>, &B)
 where
-    L: Into<Layout<D>>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
 {
@@ -203,16 +202,33 @@ where
 
     unsafe fn empty_f(self) -> Result<Self::Out> {
         let (layout, device) = self;
-        let layout = layout.into();
         let (_, idx_max) = layout.bounds_index()?;
         let storage = B::empty_impl(device, idx_max)?;
         unsafe { Ok(Tensor::new_unchecked(storage, layout.into_dim()?)) }
     }
 }
 
-impl<T, D, L> EmptyAPI<(T, D)> for L
+impl<T, D, B> EmptyAPI<(T, D)> for (D, &B)
 where
-    L: Into<Layout<D>>,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
+{
+    type Out = Tensor<T, B, IxD>;
+
+    unsafe fn empty_f(self) -> Result<Self::Out> {
+        let (shape, device) = self;
+        let default_order = device.default_order();
+        let layout = match default_order {
+            RowMajor => shape.c(),
+            ColMajor => shape.f(),
+        };
+        empty_f((layout, device))
+    }
+}
+
+#[duplicate_item(L; [D]; [Layout<D>])]
+impl<T, D> EmptyAPI<(T, D)> for L
+where
     D: DimAPI,
 {
     type Out = Tensor<T, DeviceCpu, IxD>;
@@ -398,7 +414,8 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k, device) -> (n_rows, n_cols, k, C, device)
         let (n_rows, n_cols, k, device) = self;
-        eye_f((n_rows, n_cols, k, FlagOrder::default(), device))
+        let default_order = device.default_order();
+        eye_f((n_rows, n_cols, k, default_order, device))
     }
 }
 
@@ -412,7 +429,8 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k, device) -> (n_rows, n_cols, k, C, device)
         let (n_rows, device) = self;
-        eye_f((n_rows, n_rows, 0, FlagOrder::default(), device))
+        let default_order = device.default_order();
+        eye_f((n_rows, n_rows, 0, default_order, device))
     }
 }
 
@@ -437,7 +455,9 @@ where
     fn eye_f(self) -> Result<Self::Out> {
         // (n_rows, n_cols, k) -> (n_rows, n_cols, k, C)
         let (n_rows, n_cols, k) = self;
-        eye_f((n_rows, n_cols, k, FlagOrder::default(), &DeviceCpu::default()))
+        let device = DeviceCpu::default();
+        let default_order = device.default_order();
+        eye_f((n_rows, n_cols, k, default_order, &device))
     }
 }
 
@@ -449,7 +469,9 @@ where
 
     fn eye_f(self) -> Result<Self::Out> {
         // n_rows -> (n_rows, n_rows, 0, C)
-        eye_f((self, self, 0, FlagOrder::default(), &DeviceCpu::default()))
+        let device = DeviceCpu::default();
+        let default_order = device.default_order();
+        eye_f((self, self, 0, default_order, &device))
     }
 }
 
@@ -489,35 +511,52 @@ where
     return FullAPI::full_f(param);
 }
 
-impl<T, D, B, L> FullAPI<(T, D)> for (L, T, &B)
+impl<T, D, B> FullAPI<(T, D)> for (Layout<D>, T, &B)
 where
     T: Clone,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, B, IxD>;
 
     fn full_f(self) -> Result<Self::Out> {
         let (layout, fill, device) = self;
-        let layout = layout.into();
         let idx_max = layout.size();
         let storage = device.full_impl(idx_max, fill)?;
         unsafe { Ok(Tensor::new_unchecked(storage, layout.into_dim()?)) }
     }
 }
 
-impl<T, D, L> FullAPI<(T, D)> for (L, T)
+impl<T, D, B> FullAPI<(T, D)> for (D, T, &B)
+where
+    T: Clone,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceCreationAnyAPI<T>,
+{
+    type Out = Tensor<T, B, IxD>;
+
+    fn full_f(self) -> Result<Self::Out> {
+        let (shape, fill, device) = self;
+        let default_order = device.default_order();
+        let layout = match default_order {
+            RowMajor => shape.c(),
+            ColMajor => shape.f(),
+        };
+        full_f((layout, fill, device))
+    }
+}
+
+#[duplicate_item(L; [D]; [Layout<D>])]
+impl<T, D> FullAPI<(T, D)> for (L, T)
 where
     D: DimAPI,
     T: Clone,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, DeviceCpu, IxD>;
 
     fn full_f(self) -> Result<Self::Out> {
-        let (layout, fill) = self;
-        full_f((layout, fill, &DeviceCpu::default()))
+        let (shape, fill) = self;
+        full_f((shape, fill, &DeviceCpu::default()))
     }
 }
 
@@ -770,29 +809,46 @@ where
     return OnesAPI::ones_f(param);
 }
 
-impl<T, D, B, L> OnesAPI<(T, D)> for (L, &B)
+impl<T, D, B> OnesAPI<(T, D)> for (Layout<D>, &B)
 where
     T: Num,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationNumAPI<T>,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, B, IxD>;
 
     fn ones_f(self) -> Result<Self::Out> {
         let (layout, device) = self;
-        let layout = layout.into();
         let (_, idx_max) = layout.bounds_index()?;
         let storage = device.ones_impl(idx_max)?;
         unsafe { Ok(Tensor::new_unchecked(storage, layout.into_dim()?)) }
     }
 }
 
-impl<T, D, L> OnesAPI<(T, D)> for L
+impl<T, D, B> OnesAPI<(T, D)> for (D, &B)
+where
+    T: Num,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceCreationNumAPI<T>,
+{
+    type Out = Tensor<T, B, IxD>;
+
+    fn ones_f(self) -> Result<Self::Out> {
+        let (shape, device) = self;
+        let default_order = device.default_order();
+        let layout = match default_order {
+            RowMajor => shape.c(),
+            ColMajor => shape.f(),
+        };
+        ones_f((layout, device))
+    }
+}
+
+#[duplicate_item(L; [D]; [Layout<D>])]
+impl<T, D> OnesAPI<(T, D)> for L
 where
     T: Num + Clone,
     D: DimAPI,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, DeviceCpu, IxD>;
 
@@ -960,29 +1016,46 @@ where
     return ZerosAPI::zeros_f(param);
 }
 
-impl<T, D, B, L> ZerosAPI<(T, D)> for (L, &B)
+impl<T, D, B> ZerosAPI<(T, D)> for (Layout<D>, &B)
 where
     T: Num,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationNumAPI<T>,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, B, IxD>;
 
     fn zeros_f(self) -> Result<Self::Out> {
         let (layout, device) = self;
-        let layout: Layout<D> = layout.into();
         let (_, idx_max) = layout.bounds_index()?;
         let storage = B::zeros_impl(device, idx_max)?;
         unsafe { Ok(Tensor::new_unchecked(storage, layout.into_dim()?)) }
     }
 }
 
-impl<T, D, L> ZerosAPI<(T, D)> for L
+impl<T, D, B> ZerosAPI<(T, D)> for (D, &B)
+where
+    T: Num,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceCreationNumAPI<T>,
+{
+    type Out = Tensor<T, B, IxD>;
+
+    fn zeros_f(self) -> Result<Self::Out> {
+        let (shape, device) = self;
+        let default_order = device.default_order();
+        let layout = match default_order {
+            RowMajor => shape.c(),
+            ColMajor => shape.f(),
+        };
+        zeros_f((layout, device))
+    }
+}
+
+#[duplicate_item(L; [D]; [Layout<D>])]
+impl<T, D> ZerosAPI<(T, D)> for L
 where
     T: Num + Clone,
     D: DimAPI,
-    L: Into<Layout<D>>,
 {
     type Out = Tensor<T, DeviceCpu, IxD>;
 
@@ -1164,7 +1237,8 @@ where
 
     fn tril_f(self) -> Result<Self::Out> {
         let (x, k) = self;
-        let mut x = x.into_contig_f(FlagOrder::default())?;
+        let default_order = x.device().default_order();
+        let mut x = x.into_contig_f(default_order)?;
         let device = x.device().clone();
         let layout = x.layout().clone();
         device.tril_impl(x.raw_mut(), &layout, k)?;
@@ -1348,7 +1422,8 @@ where
 
     fn triu_f(self) -> Result<Self::Out> {
         let (x, k) = self;
-        let mut x = x.into_contig_f(FlagOrder::default())?;
+        let default_order = x.device().default_order();
+        let mut x = x.into_contig_f(default_order)?;
         let device = x.device().clone();
         let layout = x.layout().clone();
         device.triu_impl(x.raw_mut(), &layout, k)?;

--- a/rstsr-core/src/tensor/creation.rs
+++ b/rstsr-core/src/tensor/creation.rs
@@ -1496,7 +1496,7 @@ mod test {
         println!("{a:6.3?}");
         let a = arange((15.0, &DeviceCpu::default()));
         println!("{a:6.3?}");
-        let a: Tensor<f64, _> = unsafe { empty(([15, 18].f(), &DeviceCpuSerial)) };
+        let a: Tensor<f64, _> = unsafe { empty(([15, 18].f(), &DeviceCpuSerial::default())) };
         println!("{a:6.3?}");
         let a = unsafe { a.empty_like() };
         println!("{a:6.3?}");
@@ -1520,7 +1520,7 @@ mod test {
         println!("{a:6.3?}");
         let a: Tensor<f64> = zeros([2, 2]);
         println!("{a:6.3?}");
-        let a: Tensor<f64, _> = zeros(([2, 2], &DeviceCpuSerial));
+        let a: Tensor<f64, _> = zeros(([2, 2], &DeviceCpuSerial::default()));
         println!("{a:6.3?}");
         let a = a.zeros_like();
         println!("{a:6.3?}");

--- a/rstsr-core/src/tensor/iterator_axes.rs
+++ b/rstsr-core/src/tensor/iterator_axes.rs
@@ -499,9 +499,9 @@ where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
     {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.indexed_axes_iter_with_order_f(axes, order)
     }
@@ -681,9 +681,9 @@ where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
     {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.indexed_axes_iter_mut_with_order_f(axes, order)
     }

--- a/rstsr-core/src/tensor/iterator_axes.rs
+++ b/rstsr-core/src/tensor/iterator_axes.rs
@@ -726,7 +726,20 @@ mod tests_serial {
                 view[[1, 2]]
             })
             .collect::<Vec<_>>();
-        assert_eq!(res, vec![22, 27, 32, 37, 82, 87, 92, 97]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            // import numpy as np
+            // a = np.arange(120).reshape(2, 3, 4, 5)
+            // a[:, 1, :, 2].reshape(-1)
+            assert_eq!(res, vec![22, 27, 32, 37, 82, 87, 92, 97]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // a = range(0, 119) |> collect;
+            // a = reshape(a, (2, 3, 4, 5));
+            // reshape(a[:, 2, :, 3], 8)'
+            assert_eq!(res, vec![50, 51, 56, 57, 62, 63, 68, 69]);
+        }
     }
 
     #[test]
@@ -742,7 +755,20 @@ mod tests_serial {
             })
             .collect::<Vec<_>>();
         println!("{:?}", res);
-        assert_eq!(res, vec![23, 28, 33, 38, 83, 88, 93, 98]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            // import numpy as np
+            // a = np.arange(120).reshape(2, 3, 4, 5)
+            // a[:, 1, :, 2].reshape(-1) + 1
+            assert_eq!(res, vec![23, 28, 33, 38, 83, 88, 93, 98]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // a = range(0, 119) |> collect;
+            // a = reshape(a, (2, 3, 4, 5));
+            // reshape(a[:, 2, :, 3]', 8)' .+ 1
+            assert_eq!(res, vec![51, 57, 63, 69, 52, 58, 64, 70]);
+        }
     }
 
     #[test]
@@ -757,16 +783,38 @@ mod tests_serial {
                 (index, view[[1, 2]])
             })
             .collect::<Vec<_>>();
-        assert_eq!(res, vec![
-            (vec![0, 0], 22),
-            (vec![0, 1], 27),
-            (vec![0, 2], 32),
-            (vec![0, 3], 37),
-            (vec![1, 0], 82),
-            (vec![1, 1], 87),
-            (vec![1, 2], 92),
-            (vec![1, 3], 97)
-        ]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            // import numpy as np
+            // a = np.arange(120).reshape(2, 3, 4, 5)
+            // a[:, 1, :, 2].reshape(-1)
+            assert_eq!(res, vec![
+                (vec![0, 0], 22),
+                (vec![0, 1], 27),
+                (vec![0, 2], 32),
+                (vec![0, 3], 37),
+                (vec![1, 0], 82),
+                (vec![1, 1], 87),
+                (vec![1, 2], 92),
+                (vec![1, 3], 97)
+            ]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // a = range(0, 119) |> collect;
+            // a = reshape(a, (2, 3, 4, 5));
+            // reshape(a[:, 2, :, 3], 8)'
+            assert_eq!(res, vec![
+                (vec![0, 0], 50),
+                (vec![1, 0], 51),
+                (vec![0, 1], 56),
+                (vec![1, 1], 57),
+                (vec![0, 2], 62),
+                (vec![1, 2], 63),
+                (vec![0, 3], 68),
+                (vec![1, 3], 69)
+            ]);
+        }
     }
 }
 
@@ -790,8 +838,24 @@ mod tests_parallel {
             })
             .collect::<Vec<_>>();
         println!("{:?}", res);
-        assert_eq!(res[..17], vec![
-            259, 275, 291, 307, 323, 339, 355, 371, 387, 403, 419, 435, 451, 467, 483, 499, 4355
-        ]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            // a = np.arange(65536).reshape(16, 16, 16, 16)
+            // a[:, 1, :, 2].reshape(-1)[:17] + 1
+            assert_eq!(res[..17], vec![
+                259, 275, 291, 307, 323, 339, 355, 371, 387, 403, 419, 435, 451, 467, 483, 499,
+                4355
+            ]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // a = range(0, 65535) |> collect;
+            // a = reshape(a, (16, 16, 16, 16))
+            // (reshape(a[:, 2, :, 3], 16 * 16) .+ 1)[1:17]
+            assert_eq!(res[..17], vec![
+                8209, 8210, 8211, 8212, 8213, 8214, 8215, 8216, 8217, 8218, 8219, 8220, 8221, 8222,
+                8223, 8224, 8465
+            ]);
+        }
     }
 }

--- a/rstsr-core/src/tensor/iterator_axes.rs
+++ b/rstsr-core/src/tensor/iterator_axes.rs
@@ -499,7 +499,8 @@ where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
     {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };
@@ -681,7 +682,8 @@ where
         I: TryInto<AxesIndex<isize>>,
         Error: From<I::Error>,
     {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };

--- a/rstsr-core/src/tensor/iterator_elem.rs
+++ b/rstsr-core/src/tensor/iterator_elem.rs
@@ -73,7 +73,8 @@ where
     }
 
     pub fn iter_f(&self) -> Result<IterVecView<'a, T, D>> {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };
@@ -166,7 +167,8 @@ where
     }
 
     pub fn iter_mut_f(&'a mut self) -> Result<IterVecMut<'a, T, D>> {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };
@@ -269,7 +271,8 @@ where
     }
 
     pub fn indexed_iter_f(&self) -> Result<IndexedIterVecView<'a, T, D>> {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };
@@ -381,7 +384,8 @@ where
     }
 
     pub fn indexed_iter_mut_f(&'a mut self) -> Result<IndexedIterVecMut<'a, T, D>> {
-        let order = match FlagOrder::default() {
+        let default_order = self.device().default_order();
+        let order = match default_order {
             RowMajor => TensorIterOrder::C,
             ColMajor => TensorIterOrder::F,
         };

--- a/rstsr-core/src/tensor/iterator_elem.rs
+++ b/rstsr-core/src/tensor/iterator_elem.rs
@@ -73,9 +73,9 @@ where
     }
 
     pub fn iter_f(&self) -> Result<IterVecView<'a, T, D>> {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.iter_with_order_f(order)
     }
@@ -166,9 +166,9 @@ where
     }
 
     pub fn iter_mut_f(&'a mut self) -> Result<IterVecMut<'a, T, D>> {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.iter_mut_with_order_f(order)
     }
@@ -269,9 +269,9 @@ where
     }
 
     pub fn indexed_iter_f(&self) -> Result<IndexedIterVecView<'a, T, D>> {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.indexed_iter_with_order_f(order)
     }
@@ -381,9 +381,9 @@ where
     }
 
     pub fn indexed_iter_mut_f(&'a mut self) -> Result<IndexedIterVecMut<'a, T, D>> {
-        let order = match TensorOrder::default() {
-            TensorOrder::C => TensorIterOrder::C,
-            TensorOrder::F => TensorIterOrder::F,
+        let order = match FlagOrder::default() {
+            RowMajor => TensorIterOrder::C,
+            ColMajor => TensorIterOrder::F,
         };
         self.indexed_iter_mut_with_order_f(order)
     }

--- a/rstsr-core/src/tensor/manuplication.rs
+++ b/rstsr-core/src/tensor/manuplication.rs
@@ -1826,8 +1826,11 @@ mod tests {
         let a = linspace((0.0, 15.0, 16));
         let a = a.into_shape_assume_contig_f([4, 1, 4]).unwrap();
         let a = a.to_broadcast_f([6, 4, 3, 4]).unwrap();
-        assert_eq!(a.layout(), unsafe { &Layout::new_unchecked([6, 4, 3, 4], [0, 4, 0, 1], 0) });
         println!("{:?}", a);
+        #[cfg(not(feature = "col_major"))]
+        assert_eq!(a.layout(), unsafe { &Layout::new_unchecked([6, 4, 3, 4], [0, 4, 0, 1], 0) });
+        #[cfg(feature = "col_major")]
+        assert_eq!(a.layout(), unsafe { &Layout::new_unchecked([6, 4, 3, 4], [0, 1, 0, 4], 0) });
     }
 
     #[test]

--- a/rstsr-core/src/tensor/manuplication.rs
+++ b/rstsr-core/src/tensor/manuplication.rs
@@ -1090,7 +1090,10 @@ where
 {
     // own shape, this is cheap operation
     let shape_new = reshape_substitute_negatives(shape.try_into()?.as_ref(), tensor.size())?;
-    if let Some(layout_new) = layout_reshapeable(&tensor.layout().to_dim()?, &shape_new)? {
+    let default_order = tensor.device().default_order();
+    if let Some(layout_new) =
+        layout_reshapeable(&tensor.layout().to_dim()?, &shape_new, default_order)?
+    {
         // shape does not need to be changed
         let (storage, _) = tensor.into_raw_parts();
         let layout = layout_new.into_dim::<IxD>()?;
@@ -1099,7 +1102,6 @@ where
         // clone underlying data by assign_arbitary
         let (storage, layout) = tensor.into_raw_parts();
         let device = storage.device();
-        let default_order = device.default_order();
         let layout_new = match default_order {
             RowMajor => shape_new.new_c_contig(None),
             ColMajor => shape_new.new_f_contig(None),

--- a/rstsr-core/src/tensor/map_elementwise.rs
+++ b/rstsr-core/src/tensor/map_elementwise.rs
@@ -145,9 +145,9 @@ where
         let lc = if lc_from_a == lc_from_b {
             lc_from_a
         } else {
-            match TensorOrder::default() {
-                TensorOrder::C => la_b.shape().c(),
-                TensorOrder::F => la_b.shape().f(),
+            match FlagOrder::default() {
+                RowMajor => la_b.shape().c(),
+                ColMajor => la_b.shape().f(),
             }
         };
         let device = self.device();
@@ -371,9 +371,9 @@ where
         let lc = if lc_from_a == lc_from_b {
             lc_from_a
         } else {
-            match TensorOrder::default() {
-                TensorOrder::C => la_b.shape().c(),
-                TensorOrder::F => la_b.shape().f(),
+            match FlagOrder::default() {
+                RowMajor => la_b.shape().c(),
+                ColMajor => la_b.shape().f(),
             }
         };
         let device = self.device();

--- a/rstsr-core/src/tensor/map_elementwise.rs
+++ b/rstsr-core/src/tensor/map_elementwise.rs
@@ -494,8 +494,12 @@ mod tests_fnmut {
         let a = linspace((1., 6., 6, &device)).into_shape_assume_contig([2, 3]);
         let b = linspace((1., 3., 3, &device));
         let c = a.mapvb_fnmut(&b, f);
-        assert!(allclose_f64(&c, &vec![5., 10., 15., 11., 16., 21.].into()));
         assert_eq!(i, 6);
+        println!("{:?}", c);
+        #[cfg(not(feature = "col_major"))]
+        assert!(allclose_f64(&c, &vec![5., 10., 15., 11., 16., 21.].into()));
+        #[cfg(feature = "col_major")]
+        assert!(allclose_f64(&c, &vec![5., 11., 10., 16., 15., 21.].into()));
     }
 }
 

--- a/rstsr-core/src/tensor/map_elementwise.rs
+++ b/rstsr-core/src/tensor/map_elementwise.rs
@@ -470,7 +470,7 @@ mod tests_fnmut {
 
     #[test]
     fn test_mapv() {
-        let device = DeviceCpuSerial;
+        let device = DeviceCpuSerial::default();
         let mut i = 0;
         let f = |x| {
             i += 1;
@@ -485,7 +485,7 @@ mod tests_fnmut {
 
     #[test]
     fn test_mapv_binary() {
-        let device = DeviceCpuSerial;
+        let device = DeviceCpuSerial::default();
         let mut i = 0;
         let f = |x, y| {
             i += 1;

--- a/rstsr-core/src/tensor/map_elementwise.rs
+++ b/rstsr-core/src/tensor/map_elementwise.rs
@@ -145,7 +145,7 @@ where
         let lc = if lc_from_a == lc_from_b {
             lc_from_a
         } else {
-            match FlagOrder::default() {
+            match self.device().default_order() {
                 RowMajor => la_b.shape().c(),
                 ColMajor => la_b.shape().f(),
             }
@@ -371,7 +371,7 @@ where
         let lc = if lc_from_a == lc_from_b {
             lc_from_a
         } else {
-            match FlagOrder::default() {
+            match self.device().default_order() {
                 RowMajor => la_b.shape().c(),
                 ColMajor => la_b.shape().f(),
             }

--- a/rstsr-core/src/tensor/operators/matmul.rs
+++ b/rstsr-core/src/tensor/operators/matmul.rs
@@ -464,34 +464,54 @@ mod test {
         let b = linspace((0.0, 14.0, 15));
         println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 2.0, 3));
-        let b = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
-        println!("{:}", &a % &b);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = linspace((0.0, 2.0, 3));
+            let b = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
-        let b = linspace((0.0, 4.0, 5));
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
+            let b = linspace((0.0, 4.0, 5));
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 14.0, 15)).into_shape_assume_contig([5, 3]);
-        let b = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 14.0, 15)).into_shape_assume_contig([5, 3]);
+            let b = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
+            println!("{:}", &a % &b);
 
-        let a = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
-        let b = linspace((0.0, 14.0, 15)).into_shape_assume_contig([5, 3]);
-        println!("{:}", &a % &b);
+            let a = linspace((0.0, 29.0, 30)).into_shape_assume_contig([2, 3, 5]);
+            let b = linspace((0.0, 14.0, 15)).into_shape_assume_contig([5, 3]);
+            println!("{:}", &a % &b);
+        }
     }
 
     #[test]
     fn test_matmul_from() {
-        let a = linspace((0.0, 14.0, 15)).into_shape([3, 5]);
-        let b = linspace((0.0, 19.0, 20)).into_shape([5, 4]);
-        let mut c = linspace((0.0, 11.0, 12)).into_shape([3, 4]);
-        c.matmul_from(&a, &b, 2.0, 1.5);
-        println!("{c}");
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = linspace((0.0, 14.0, 15)).into_shape([3, 5]);
+            let b = linspace((0.0, 19.0, 20)).into_shape([5, 4]);
+            let mut c = linspace((0.0, 11.0, 12)).into_shape([3, 4]);
+            c.matmul_from(&a, &b, 2.0, 1.5);
+            println!("{c}");
 
-        let c_ref_vec =
-            vec![240., 261.5, 283., 304.5, 646., 717.5, 789., 860.5, 1052., 1173.5, 1295., 1416.5];
-        let c_ref = asarray(c_ref_vec);
-        assert!(allclose_f64(&c, &c_ref));
+            let c_ref = vec![
+                240., 261.5, 283., 304.5, 646., 717.5, 789., 860.5, 1052., 1173.5, 1295., 1416.5,
+            ];
+            assert!(allclose_f64(&c.raw().into(), &c_ref.into()));
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let a = linspace((0.0, 14.0, 15)).into_shape([3, 5]);
+            let b = linspace((0.0, 19.0, 20)).into_shape([5, 4]);
+            let mut c = linspace((0.0, 11.0, 12)).into_shape([3, 4]);
+            c.matmul_from(&a, &b, 2.0, 1.5);
+            println!("{c}");
+
+            let c_ref = vec![
+                180.0, 201.5, 223.0, 484.5, 556.0, 627.5, 789.0, 910.5, 1032.0, 1093.5, 1265.0,
+                1436.5,
+            ];
+            assert!(allclose_f64(&c.raw().into(), &c_ref.into()));
+        }
     }
 }

--- a/rstsr-core/src/tensor/operators/matmul.rs
+++ b/rstsr-core/src/tensor/operators/matmul.rs
@@ -61,8 +61,8 @@ where
     B: DeviceMatMulAPI<TA, TB, TC, DA, DB, DC>,
 {
     rstsr_assert!(b.device().same_device(b.device()), DeviceMismatch)?;
-    let order = TensorIterOrder::default();
-    let cfg = LayoutMatMulConfig::<DA, DB>::layout_matmul(a.layout(), b.layout(), order)?;
+    let default_order = a.device().default_order();
+    let cfg = LayoutMatMulConfig::<DA, DB>::layout_matmul(a.layout(), b.layout(), default_order)?;
     let lc = cfg.lc;
     let mut c: Tensor<TC, B, _> = unsafe { empty((lc, a.device())) }.into_dim_f()?;
     op_mutc_refa_refb_matmul(&mut c, a, b, alpha, TC::zero())?;

--- a/rstsr-core/src/tensor/operators/matmul.rs
+++ b/rstsr-core/src/tensor/operators/matmul.rs
@@ -61,10 +61,7 @@ where
     B: DeviceMatMulAPI<TA, TB, TC, DA, DB, DC>,
 {
     rstsr_assert!(b.device().same_device(b.device()), DeviceMismatch)?;
-    let order = match TensorOrder::default() {
-        TensorOrder::F => TensorIterOrder::F,
-        TensorOrder::C => TensorIterOrder::C,
-    };
+    let order = TensorIterOrder::default();
     let cfg = LayoutMatMulConfig::<DA, DB>::layout_matmul(a.layout(), b.layout(), order)?;
     let lc = cfg.lc;
     let mut c: Tensor<TC, B, _> = unsafe { empty((lc, a.device())) }.into_dim_f()?;

--- a/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
@@ -166,9 +166,9 @@ macro_rules! impl_binary_arithmetic_ref {
                 let lc = if lc_from_a == lc_from_b {
                     lc_from_a
                 } else {
-                    match TensorOrder::default() {
-                        TensorOrder::C => la_b.shape().c(),
-                        TensorOrder::F => la_b.shape().f(),
+                    match FlagOrder::default() {
+                        RowMajor => la_b.shape().c(),
+                        ColMajor => la_b.shape().f(),
                     }
                 };
                 // generate empty c

--- a/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
@@ -159,7 +159,8 @@ macro_rules! impl_binary_arithmetic_ref {
                 rstsr_assert!(a.device().same_device(b.device()), DeviceMismatch)?;
                 let la = a.layout();
                 let lb = b.layout();
-                let (la_b, lb_b) = broadcast_layout(la, lb)?;
+                let default_order = a.device().default_order();
+                let (la_b, lb_b) = broadcast_layout(la, lb, default_order)?;
                 // generate output layout
                 let lc_from_a = layout_for_array_copy(&la_b, TensorIterOrder::default())?;
                 let lc_from_b = layout_for_array_copy(&lb_b, TensorIterOrder::default())?;
@@ -305,7 +306,8 @@ macro_rules! impl_binary_lr_consume {
                 let device = a.device().clone();
                 let la = a.layout();
                 let lb = b.layout();
-                let broadcast_result = broadcast_layout_to_first(la, lb);
+                let default_order = a.device().default_order();
+                let broadcast_result = broadcast_layout_to_first(la, lb, default_order);
                 if a.layout().is_broadcasted() || broadcast_result.is_err() {
                     // not broadcastable for output a
                     $TensorOpAPI::$op_f(&a, b)
@@ -355,7 +357,8 @@ macro_rules! impl_binary_lr_consume {
                 let device = b.device().clone();
                 let la = a.layout();
                 let lb = b.layout();
-                let broadcast_result = broadcast_layout_to_first(lb, la);
+                let default_order = b.device().default_order();
+                let broadcast_result = broadcast_layout_to_first(lb, la, default_order);
                 if b.layout().is_broadcasted() || broadcast_result.is_err() {
                     // not broadcastable for output a
                     $TensorOpAPI::$op_f(a, &b)
@@ -451,14 +454,15 @@ macro_rules! impl_binary_lr_consume {
                 rstsr_assert!(a.device().same_device(b.device()), DeviceMismatch)?;
                 let la = a.layout();
                 let lb = b.layout();
-                let broadcast_result = broadcast_layout_to_first(la, lb);
+                let default_order = a.device().default_order();
+                let broadcast_result = broadcast_layout_to_first(la, lb, default_order);
                 if !a.layout().is_broadcasted() && broadcast_result.is_ok() {
                     let (la_b, _) = broadcast_result?;
                     if la_b == *la {
                         return $TensorOpAPI::$op_f(a, &b);
                     }
                 }
-                let broadcast_result = broadcast_layout_to_first(lb, la);
+                let broadcast_result = broadcast_layout_to_first(lb, la, default_order);
                 if !b.layout().is_broadcasted() && broadcast_result.is_ok() {
                     let (lb_b, _) = broadcast_result?;
                     if lb_b == *lb {
@@ -524,11 +528,12 @@ macro_rules! impl_binary_with_output {
             let lc = c.layout();
             let la = a.layout();
             let lb = b.layout();
+            let default_order = c.device().default_order();
             // all layouts should be broadcastable to lc
             // we can first generate broadcasted shape, then check this
-            let (lc_b, la_b) = broadcast_layout_to_first(lc, la)?;
+            let (lc_b, la_b) = broadcast_layout_to_first(lc, la, default_order)?;
             rstsr_assert_eq!(lc_b, *lc, InvalidLayout)?;
-            let (lc_b, lb_b) = broadcast_layout_to_first(lc, lb)?;
+            let (lc_b, lb_b) = broadcast_layout_to_first(lc, lb, default_order)?;
             rstsr_assert_eq!(lc_b, *lc, InvalidLayout)?;
             // op provided by device
             let device = c.device().clone();

--- a/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_arithmetic.rs
@@ -166,7 +166,7 @@ macro_rules! impl_binary_arithmetic_ref {
                 let lc = if lc_from_a == lc_from_b {
                     lc_from_a
                 } else {
-                    match FlagOrder::default() {
+                    match a.device().default_order() {
                         RowMajor => la_b.shape().c(),
                         ColMajor => la_b.shape().f(),
                     }

--- a/rstsr-core/src/tensor/operators/op_binary_assign.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_assign.rs
@@ -189,8 +189,6 @@ mod test {
         let c = linspace((1.0, 6.0, 6));
         let mut c = c.into_shape_assume_contig([2, 3]);
         let b = linspace((2.0, 6.0, 3));
-        // let mut c_mut = c.view_mut();
-        // c_mut += &b;
         *&mut c.view_mut() += &b;
         let c_ref = vec![3., 6., 9., 6., 9., 12.].into();
         assert!(allclose_f64(&c, &c_ref));

--- a/rstsr-core/src/tensor/operators/op_binary_assign.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_assign.rs
@@ -176,7 +176,6 @@ mod test {
     use super::*;
 
     #[test]
-    #[allow(clippy::deref_addrof)]
     fn test_add_assign() {
         // contiguous
         let mut c = linspace((1.0, 5.0, 5));
@@ -188,23 +187,41 @@ mod test {
         let c_ref = vec![5., 10., 15., 20., 25.].into();
         assert!(allclose_f64(&c, &c_ref));
 
-        // broadcast
-        // [2, 3] + [3]
-        let c = linspace((1.0, 6.0, 6));
-        let mut c = c.into_shape_assume_contig([2, 3]);
-        let b = linspace((2.0, 6.0, 3));
-        *&mut c.view_mut() += &b;
-        let c_ref = vec![3., 6., 9., 6., 9., 12.].into();
-        assert!(allclose_f64(&c, &c_ref));
+        #[cfg(not(feature = "col_major"))]
+        {
+            // broadcast
+            // [2, 3] + [3]
+            let c = linspace((1.0, 6.0, 6));
+            let mut c = c.into_shape_assume_contig([2, 3]);
+            let b = linspace((2.0, 6.0, 3));
+            *&mut c.view_mut() += &b;
+            let c_ref = vec![3., 6., 9., 6., 9., 12.].into();
+            assert!(allclose_f64(&c, &c_ref));
 
-        // scalar
-        c *= 2.0;
-        let c_ref = vec![6., 12., 18., 12., 18., 24.].into();
-        assert!(allclose_f64(&c, &c_ref));
+            // scalar
+            c *= 2.0;
+            let c_ref = vec![6., 12., 18., 12., 18., 24.].into();
+            assert!(allclose_f64(&c, &c_ref));
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // broadcast
+            // [3, 2] + [3]
+            let c = linspace((1.0, 6.0, 6));
+            let mut c = c.into_shape_assume_contig([3, 2]);
+            let b = linspace((2.0, 6.0, 3));
+            *&mut c.view_mut() += &b;
+            let c_ref = vec![3., 6., 9., 6., 9., 12.];
+            assert!(allclose_f64(&c.raw().into(), &c_ref.into()));
+
+            // scalar
+            c *= 2.0;
+            let c_ref = vec![6., 12., 18., 12., 18., 24.];
+            assert!(allclose_f64(&c.raw().into(), &c_ref.into()));
+        }
     }
 
     #[test]
-    #[allow(clippy::deref_addrof)]
     fn test_sub_assign() {
         // contiguous
         let mut c = linspace((1.0, 5.0, 5));
@@ -213,15 +230,31 @@ mod test {
         let c_ref = vec![-1., -2., -3., -4., -5.].into();
         assert!(allclose_f64(&c, &c_ref));
 
-        // broadcast
-        // [2, 3] + [3]
-        let c = linspace((1.0, 6.0, 6));
-        let mut c = c.into_shape_assume_contig([2, 3]);
-        let b = linspace((2.0, 6.0, 3));
-        // let mut c_mut = c.view_mut();
-        // c_mut += &b;
-        *&mut c.view_mut() -= &b;
-        let c_ref = vec![-1., -2., -3., 2., 1., 0.].into();
-        assert!(allclose_f64(&c, &c_ref));
+        #[cfg(not(feature = "col_major"))]
+        {
+            // broadcast
+            // [2, 3] + [3]
+            let c = linspace((1.0, 6.0, 6));
+            let mut c = c.into_shape_assume_contig([2, 3]);
+            let b = linspace((2.0, 6.0, 3));
+            // let mut c_mut = c.view_mut();
+            // c_mut += &b;
+            *&mut c.view_mut() -= &b;
+            let c_ref = vec![-1., -2., -3., 2., 1., 0.].into();
+            assert!(allclose_f64(&c, &c_ref));
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // broadcast
+            // [3, 2] + [3]
+            let c = linspace((1.0, 6.0, 6));
+            let mut c = c.into_shape_assume_contig([3, 2]);
+            let b = linspace((2.0, 6.0, 3));
+            // let mut c_mut = c.view_mut();
+            // c_mut += &b;
+            *&mut c.view_mut() -= &b;
+            let c_ref = vec![-1., -2., -3., 2., 1., 0.];
+            assert!(allclose_f64(&c.raw().into(), &c_ref.into()));
+        }
     }
 }

--- a/rstsr-core/src/tensor/operators/op_binary_assign.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_assign.rs
@@ -97,9 +97,13 @@ macro_rules! impl_binary_assign {
                 rstsr_assert!(a.device().same_device(b.device()), DeviceMismatch)?;
                 let la = a.layout();
                 let lb = b.layout();
+                let default_order = a.device().default_order();
                 // check layout broadcast
-                let (la_b, lb_b) =
-                    broadcast_layout_to_first(&la.to_dim::<IxD>()?, &lb.to_dim::<IxD>()?)?;
+                let (la_b, lb_b) = broadcast_layout_to_first(
+                    &la.to_dim::<IxD>()?,
+                    &lb.to_dim::<IxD>()?,
+                    default_order,
+                )?;
                 rstsr_assert_eq!(la_b, la.to_dim::<IxD>()?, InvalidLayout)?;
                 // op provided by device
                 let device = a.device().clone();

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -166,42 +166,88 @@ mod test {
 
     #[test]
     fn test_pow() {
-        let a = arange(6u32).into_shape([2, 3]);
-        let b = arange(3u32);
-        let c = pow(&a, &b);
-        println!("{:?}", c);
-        assert_eq!(c.reshape([6]).to_vec(), vec![1, 1, 4, 1, 4, 25]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = arange(6u32).into_shape([2, 3]);
+            let b = arange(3u32);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1, 1, 4, 1, 4, 25]);
 
-        let a = arange(6.0).into_shape([2, 3]);
+            let a = arange(6.0).into_shape([2, 3]);
 
-        let b = arange(3.0);
-        let c = pow(&a, &b);
-        println!("{:?}", c);
-        assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
+            let b = arange(3.0);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
 
-        let b = arange(3);
-        let c = pow(&a, &b);
-        println!("{:?}", c);
-        assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
+            let b = arange(3);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let a = arange(6u32).into_shape([3, 2]);
+            let b = arange(3u32);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1, 1, 4, 1, 4, 25]);
+
+            let a = arange(6.0).into_shape([3, 2]);
+
+            let b = arange(3.0);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
+
+            let b = arange(3);
+            let c = pow(&a, &b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![1.0, 1.0, 4.0, 1.0, 4.0, 25.0]);
+        }
     }
 
     #[test]
     fn test_floor_divide() {
-        let a = arange(6u32).into_shape([2, 3]);
-        let b = asarray(vec![1, 2, 2]);
-        let c = a.floor_divide(&b);
-        println!("{:?}", c);
-        assert_eq!(c.reshape([6]).to_vec(), vec![0, 0, 1, 3, 2, 2]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = arange(6u32).into_shape([2, 3]);
+            let b = asarray(vec![1, 2, 2]);
+            let c = a.floor_divide(&b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0, 0, 1, 3, 2, 2]);
 
-        let a = arange(6.0).into_shape([2, 3]);
+            let a = arange(6.0).into_shape([2, 3]);
 
-        let b = asarray(vec![1.0, 2.0, 2.0]);
-        let c = a.floor_divide(&b);
-        println!("{:?}", c);
-        assert_eq!(c.reshape([6]).to_vec(), vec![0.0, 0.0, 1.0, 3.0, 2.0, 2.0]);
+            let b = asarray(vec![1.0, 2.0, 2.0]);
+            let c = a.floor_divide(&b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0.0, 0.0, 1.0, 3.0, 2.0, 2.0]);
 
-        let b = asarray(vec![0.0, 2.0, 2.0]);
-        let c = a.floor_divide_f(&b);
-        println!("{:?}", c);
+            let b = asarray(vec![0.0, 2.0, 2.0]);
+            let c = a.floor_divide_f(&b);
+            println!("{:?}", c);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            // [3, 2] + [3]
+            let a = arange(6u32).into_shape([3, 2]);
+            let b = asarray(vec![1, 2, 2]);
+            let c = a.floor_divide(&b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0, 0, 1, 3, 2, 2]);
+
+            let a = arange(6.0).into_shape([3, 2]);
+
+            let b = asarray(vec![1.0, 2.0, 2.0]);
+            let c = a.floor_divide(&b);
+            println!("{:?}", c);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0.0, 0.0, 1.0, 3.0, 2.0, 2.0]);
+
+            let b = asarray(vec![0.0, 2.0, 2.0]);
+            let c = a.floor_divide_f(&b);
+            println!("{:?}", c);
+        }
     }
 }

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -48,7 +48,8 @@ macro_rules! trait_binary {
                 // check and broadcast layout
                 let la = self.layout();
                 let lb = b.layout();
-                let (la_b, lb_b) = broadcast_layout(la, lb)?;
+                let default_order = self.device().default_order();
+                let (la_b, lb_b) = broadcast_layout(la, lb, default_order)?;
                 let lc_from_a = layout_for_array_copy(&la_b, TensorIterOrder::default())?;
                 let lc_from_b = layout_for_array_copy(&lb_b, TensorIterOrder::default())?;
                 let lc = if lc_from_a == lc_from_b {

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -54,9 +54,9 @@ macro_rules! trait_binary {
                 let lc = if lc_from_a == lc_from_b {
                     lc_from_a
                 } else {
-                    match TensorOrder::default() {
-                        TensorOrder::C => la_b.shape().c(),
-                        TensorOrder::F => la_b.shape().f(),
+                    match FlagOrder::default() {
+                        RowMajor => la_b.shape().c(),
+                        ColMajor => la_b.shape().f(),
                     }
                 };
 

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -54,7 +54,7 @@ macro_rules! trait_binary {
                 let lc = if lc_from_a == lc_from_b {
                     lc_from_a
                 } else {
-                    match FlagOrder::default() {
+                    match self.device().default_order() {
                         RowMajor => la_b.shape().c(),
                         ColMajor => la_b.shape().f(),
                     }

--- a/rstsr-core/src/tensor/operators/op_tri.rs
+++ b/rstsr-core/src/tensor/operators/op_tri.rs
@@ -31,9 +31,9 @@ where
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
-            _ => match TensorOrder::default() {
-                TensorOrder::C => la_shape.c(),
-                TensorOrder::F => la_shape.f(),
+            _ => match FlagOrder::default() {
+                RowMajor => la_shape.c(),
+                ColMajor => la_shape.f(),
             },
         };
 
@@ -98,9 +98,9 @@ where
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
-            _ => match TensorOrder::default() {
-                TensorOrder::C => la_shape.c(),
-                TensorOrder::F => la_shape.f(),
+            _ => match FlagOrder::default() {
+                RowMajor => la_shape.c(),
+                ColMajor => la_shape.f(),
             },
         };
 

--- a/rstsr-core/src/tensor/operators/op_tri.rs
+++ b/rstsr-core/src/tensor/operators/op_tri.rs
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_pack_tri() {
         let a = {
-            let a = arange((48., &DeviceCpuSerial));
+            let a = arange((48., &DeviceCpuSerial::default()));
             let storage_a = a.into_raw_parts().0;
             Tensor::new(storage_a, [3, 4, 4].f())
         };
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn test_correctness() {
         let a = {
-            let a = arange((16., &DeviceCpuSerial));
+            let a = arange((16., &DeviceCpuSerial::default()));
             let storage_a = a.into_raw_parts().0;
             Tensor::new(storage_a, [4, 4].c())
         };

--- a/rstsr-core/src/tensor/operators/op_tri.rs
+++ b/rstsr-core/src/tensor/operators/op_tri.rs
@@ -31,7 +31,7 @@ where
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
-            _ => match FlagOrder::default() {
+            _ => match self.device().default_order() {
                 RowMajor => la_shape.c(),
                 ColMajor => la_shape.f(),
             },
@@ -98,7 +98,7 @@ where
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
-            _ => match FlagOrder::default() {
+            _ => match self.device().default_order() {
                 RowMajor => la_shape.c(),
                 ColMajor => la_shape.f(),
             },

--- a/rstsr-core/src/tensor/operators/op_tri.rs
+++ b/rstsr-core/src/tensor/operators/op_tri.rs
@@ -13,21 +13,46 @@ where
     pub fn pack_tri_f(&self, uplo: FlagUpLo) -> Result<Tensor<T, B, D::SmallerOne>> {
         // layouts manuplication
         let lb = self.layout().to_dim::<IxD>()?;
-        let (lb_rest, lb_inner) = lb.dim_split_at(-2)?;
 
-        // check last two dimensions are equal
-        rstsr_assert_eq!(
-            lb_inner.shape()[0],
-            lb_inner.shape()[1],
-            InvalidLayout,
-            "Last two dimensions should be the same for pack_tri."
-        )?;
-        let n: usize = lb_inner.shape()[0];
-        let n_tp = n * (n + 1) / 2;
+        // generate layout for output
+        let default_order = self.device().default_order();
+        let la_shape = match default_order {
+            RowMajor => {
+                // check last two dimensions are equal
+                let (lb_rest, lb_inner) = lb.dim_split_at(-2)?;
+                rstsr_assert_eq!(
+                    lb_inner.shape()[0],
+                    lb_inner.shape()[1],
+                    InvalidLayout,
+                    "Last two dimensions should be the same for pack_tri."
+                )?;
+                let n: usize = lb_inner.shape()[0];
+                let n_tp = n * (n + 1) / 2;
 
-        // layouts for output
-        let mut la_shape = lb_rest.shape().to_vec();
-        la_shape.push(n_tp);
+                // layouts for output
+                let mut la_shape = lb_rest.shape().to_vec();
+                la_shape.push(n_tp);
+                la_shape
+            },
+            ColMajor => {
+                // check first two dimensions are equal
+                let (lb_inner, lb_rest) = lb.dim_split_at(2)?;
+                rstsr_assert_eq!(
+                    lb_inner.shape()[0],
+                    lb_inner.shape()[1],
+                    InvalidLayout,
+                    "First two dimensions should be the same for pack_tri."
+                )?;
+                let n: usize = lb_inner.shape()[0];
+                let n_tp = n * (n + 1) / 2;
+
+                // layouts for output
+                let mut la_shape = vec![n_tp];
+                la_shape.append(&mut lb_rest.shape().to_vec());
+                la_shape
+            },
+        };
+
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
@@ -79,22 +104,45 @@ where
     pub fn unpack_tri(&self, uplo: FlagUpLo, symm: FlagSymm) -> Result<Tensor<T, B, D::LargerOne>> {
         // layouts manuplication
         let lb = self.layout().to_dim::<IxD>()?;
-        let (lb_rest, lb_inner) = lb.dim_split_at(-1)?;
 
-        // check last two dimensions are equal
-        let n_tp: usize = lb_inner.shape()[0];
-        let n: usize = (2 * n_tp).to_f64().unwrap().sqrt().floor().to_usize().unwrap();
-        rstsr_assert_eq!(
-            n * (n + 1) / 2,
-            n_tp,
-            InvalidLayout,
-            "Last dimension should be triangular number for unpack_tri."
-        )?;
+        let default_order = self.device().default_order();
+        let la_shape = match default_order {
+            RowMajor => {
+                // check last two dimensions are equal
+                let (lb_rest, lb_inner) = lb.dim_split_at(-1)?;
+                let n_tp: usize = lb_inner.shape()[0];
+                let n: usize = (2 * n_tp).to_f64().unwrap().sqrt().floor().to_usize().unwrap();
+                rstsr_assert_eq!(
+                    n * (n + 1) / 2,
+                    n_tp,
+                    InvalidLayout,
+                    "Last dimension should be triangular number for unpack_tri."
+                )?;
 
-        // layouts for output
-        let mut la_shape = lb_rest.shape().to_vec();
-        la_shape.push(n);
-        la_shape.push(n);
+                // layouts for output
+                let mut la_shape = lb_rest.shape().to_vec();
+                la_shape.append(&mut vec![n, n]);
+                la_shape
+            },
+            ColMajor => {
+                // check first two dimensions are equal
+                let (lb_inner, lb_rest) = lb.dim_split_at(1)?;
+                let n_tp: usize = lb_inner.shape()[0];
+                let n: usize = (2 * n_tp).to_f64().unwrap().sqrt().floor().to_usize().unwrap();
+                rstsr_assert_eq!(
+                    n * (n + 1) / 2,
+                    n_tp,
+                    InvalidLayout,
+                    "First dimension should be triangular number for unpack_tri."
+                )?;
+
+                // layouts for output
+                let mut la_shape = vec![n, n];
+                la_shape.append(&mut lb_rest.shape().to_vec());
+                la_shape
+            },
+        };
+
         let la = match (lb.c_prefer(), lb.f_prefer()) {
             (true, false) => la_shape.c(),
             (false, true) => la_shape.f(),
@@ -140,32 +188,67 @@ mod tests {
 
     #[test]
     fn test_pack_tri() {
-        let a = {
-            let a = arange((48., &DeviceCpuSerial::default()));
-            let storage_a = a.into_raw_parts().0;
-            Tensor::new(storage_a, [3, 4, 4].f())
-        };
-        let a_triu = a.pack_tril();
-        println!("{:?}", a_triu);
-        println!("{:?}", a.slice(0));
-        println!("{:?}", a_triu.slice(0).to_vec());
-        assert_eq!(a_triu.slice(1).to_vec(), [1., 4., 16., 7., 19., 31., 10., 22., 34., 46.]);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let a = {
+                let a = arange((48., &DeviceCpuSerial::default()));
+                let storage_a = a.into_raw_parts().0;
+                Tensor::new(storage_a, [3, 4, 4].f())
+            };
+            let a_triu = a.pack_tril();
+            println!("{:?}", a_triu);
+            println!("{:?}", a.slice(0));
+            println!("{:?}", a_triu.slice(0).to_vec());
+            assert_eq!(a_triu.slice(1).to_vec(), [1., 4., 16., 7., 19., 31., 10., 22., 34., 46.]);
 
-        let b = a_triu.unpack_tril(FlagSymm::Sy);
-        println!("{:?}", b);
-        assert_eq!(b.slice((0, 1)).to_vec(), [3., 15., 18., 21.]);
+            let b = a_triu.unpack_tril(FlagSymm::Sy);
+            println!("{:?}", b);
+            assert_eq!(b.slice((0, 1)).to_vec(), [3., 15., 18., 21.]);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let a = {
+                let a = arange((48., &DeviceCpuSerial::default()));
+                let storage_a = a.into_raw_parts().0;
+                Tensor::new(storage_a, [4, 4, 3].c())
+            };
+            let a_triu = a.pack_triu();
+            println!("{:?}", a_triu);
+            println!("{:?}", a.slice((.., 0)));
+            println!("{:?}", a_triu.slice((.., 0)).to_vec());
+            assert_eq!(a_triu.slice((.., 1)).to_vec(), [
+                1., 4., 16., 7., 19., 31., 10., 22., 34., 46.
+            ]);
+
+            let b = a_triu.unpack_triu(FlagSymm::Sy);
+            println!("{:?}", b);
+            assert_eq!(b.slice((.., 1, 0)).to_vec(), [3., 15., 18., 21.]);
+        }
     }
 
     #[test]
     #[cfg(feature = "rayon")]
     fn test_par_pack_tril_compiles() {
-        use num::complex::c64;
-        let a = linspace((c64(-2.0, 1.5), c64(1.7, -2.3), 256 * 256 * 256))
-            .into_layout([4, 64, 256, 256].f());
-        let a_tril = a.pack_tril();
-        println!("{:20.5}", a_tril);
-        let b = a_tril.unpack_tril(FlagSymm::Ah);
-        println!("{:20.5}", b);
+        #[cfg(not(feature = "col_major"))]
+        {
+            use num::complex::c64;
+            let a = linspace((c64(-2.0, 1.5), c64(1.7, -2.3), 256 * 256 * 256))
+                .into_layout([4, 64, 256, 256].f());
+            let a_tril = a.pack_tril();
+            println!("{:20.5}", a_tril);
+            let b = a_tril.unpack_tril(FlagSymm::Ah);
+            println!("{:20.5}", b);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            use num::complex::c64;
+            let a = linspace((c64(-2.0, 1.5), c64(1.7, -2.3), 256 * 256 * 256))
+                .into_layout([256, 256, 64, 4].c());
+            let a_tril = a.pack_tril();
+            println!("{:20.5}", a_tril);
+            let b = a_tril.unpack_tril(FlagSymm::Ah);
+            println!("{:20.5}", b);
+        }
     }
 
     #[test]

--- a/rstsr-core/src/tensor/operators/op_unary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_unary_common.rs
@@ -253,7 +253,7 @@ mod test {
 
     #[test]
     fn test_cpuserial() {
-        let a = linspace((1.0, 5.0, 5, &DeviceCpuSerial));
+        let a = linspace((1.0, 5.0, 5, &DeviceCpuSerial::default()));
         let b = a.sin();
         println!("{:}", b);
     }

--- a/rstsr-core/src/tensor/operators/op_with_func.rs
+++ b/rstsr-core/src/tensor/operators/op_with_func.rs
@@ -69,7 +69,7 @@ where
     let lc = if lc_from_a == lc_from_b {
         lc_from_a
     } else {
-        match FlagOrder::default() {
+        match a.device().default_order() {
             RowMajor => la_b.shape().c(),
             ColMajor => la_b.shape().f(),
         }

--- a/rstsr-core/src/tensor/operators/op_with_func.rs
+++ b/rstsr-core/src/tensor/operators/op_with_func.rs
@@ -69,9 +69,9 @@ where
     let lc = if lc_from_a == lc_from_b {
         lc_from_a
     } else {
-        match TensorOrder::default() {
-            TensorOrder::C => la_b.shape().c(),
-            TensorOrder::F => la_b.shape().f(),
+        match FlagOrder::default() {
+            RowMajor => la_b.shape().c(),
+            ColMajor => la_b.shape().f(),
         }
     };
     // generate empty c

--- a/rstsr-core/src/tensor/operators/op_with_func.rs
+++ b/rstsr-core/src/tensor/operators/op_with_func.rs
@@ -28,11 +28,12 @@ where
     let lc = c.layout();
     let la = a.layout();
     let lb = b.layout();
+    let default_order = c.device().default_order();
     // all layouts should be broadcastable to lc
     // we can first generate broadcasted shape, then check this
-    let (lc_b, la_b) = broadcast_layout_to_first(lc, la)?;
+    let (lc_b, la_b) = broadcast_layout_to_first(lc, la, default_order)?;
     rstsr_assert_eq!(lc_b, *lc, InvalidLayout)?;
-    let (lc_b, lb_b) = broadcast_layout_to_first(lc, lb)?;
+    let (lc_b, lb_b) = broadcast_layout_to_first(lc, lb, default_order)?;
     rstsr_assert_eq!(lc_b, *lc, InvalidLayout)?;
     // op provided by device
     let device = c.device().clone();
@@ -62,14 +63,15 @@ where
     rstsr_assert!(a.device().same_device(b.device()), DeviceMismatch)?;
     let la = a.layout();
     let lb = b.layout();
-    let (la_b, lb_b) = broadcast_layout(la, lb)?;
+    let default_order = a.device().default_order();
+    let (la_b, lb_b) = broadcast_layout(la, lb, default_order)?;
     // generate output layout
     let lc_from_a = layout_for_array_copy(&la_b, TensorIterOrder::K)?;
     let lc_from_b = layout_for_array_copy(&lb_b, TensorIterOrder::K)?;
     let lc = if lc_from_a == lc_from_b {
         lc_from_a
     } else {
-        match a.device().default_order() {
+        match default_order {
             RowMajor => la_b.shape().c(),
             ColMajor => la_b.shape().f(),
         }
@@ -104,9 +106,10 @@ where
     rstsr_assert!(a.device().same_device(b.device()), DeviceMismatch)?;
     let la = a.layout();
     let lb = b.layout();
+    let default_order = a.device().default_order();
     // all layouts should be broadcastable to lc
     // we can first generate broadcasted shape, then check this
-    let (la_b, lb_b) = broadcast_layout_to_first(la, lb)?;
+    let (la_b, lb_b) = broadcast_layout_to_first(la, lb, default_order)?;
     rstsr_assert_eq!(la_b, *la, InvalidLayout)?;
     // op provided by device
     let device = a.device().clone();

--- a/rstsr-core/src/tensor/reduction.rs
+++ b/rstsr-core/src/tensor/reduction.rs
@@ -278,14 +278,15 @@ mod test {
     #[test]
     fn test_sum_all() {
         // DeviceCpuSerial
-        let a = arange((24, &DeviceCpuSerial));
+        let a = arange((24, &DeviceCpuSerial::default()));
         let s = sum_all(&a);
         assert_eq!(s, 276);
 
         // np.arange(3240).reshape(12, 15, 18)
         //   .swapaxes(-1, -2)[2:-3, 1:-4:2, -1:3:-2].sum()
-        let a_owned =
-            arange((3240, &DeviceCpuSerial)).into_shape([12, 15, 18]).into_swapaxes(-1, -2);
+        let a_owned = arange((3240, &DeviceCpuSerial::default()))
+            .into_shape([12, 15, 18])
+            .into_swapaxes(-1, -2);
         let a = a_owned.i((slice!(2, -3), slice!(1, -4, 2), slice!(-1, 3, -2)));
         let s = a.sum_all();
         assert_eq!(s, 446586);
@@ -314,8 +315,9 @@ mod test {
     #[test]
     fn test_sum_axes() {
         // DeviceCpuSerial
-        let a =
-            arange((3240, &DeviceCpuSerial)).into_shape([4, 6, 15, 9]).into_transpose([2, 0, 3, 1]);
+        let a = arange((3240, &DeviceCpuSerial::default()))
+            .into_shape([4, 6, 15, 9])
+            .into_transpose([2, 0, 3, 1]);
         let s = a.sum_axes([0, -2]);
         println!("{:?}", s);
         assert_eq!(s[[0, 1]], 27270);
@@ -335,7 +337,7 @@ mod test {
     fn test_min() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 3, 7, 2, 8, 1, 6, 10, 5];
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default()));
         println!("{:}", a);
         let m = a.min_axes(0);
         assert_eq!(m.to_vec(), vec![2, 3, 1]);
@@ -359,7 +361,7 @@ mod test {
     #[test]
     fn test_mean() {
         // DeviceCpuSerial
-        let a = arange((24.0, &DeviceCpuSerial)).into_shape((2, 3, 4));
+        let a = arange((24.0, &DeviceCpuSerial::default())).into_shape((2, 3, 4));
         let m = a.mean_all();
         assert_eq!(m, 11.5);
 
@@ -389,7 +391,7 @@ mod test {
     fn test_var() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 3, 7, 2, 8, 1, 6, 10, 5];
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial)).mapv(|x| x as f64);
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default())).mapv(|x| x as f64);
 
         let m = a.var_all();
         println!("{:}", m);
@@ -424,7 +426,7 @@ mod test {
     fn test_std() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 3, 7, 2, 8, 1, 6, 10, 5];
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial)).mapv(|x| x as f64);
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default())).mapv(|x| x as f64);
 
         let m = a.std_all();
         println!("{:}", m);
@@ -445,7 +447,7 @@ mod test {
             .zip(vi.iter())
             .map(|(r, i)| num::Complex::new(r.to_f64().unwrap(), i.to_f64().unwrap()))
             .collect::<Vec<_>>();
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default()));
 
         let m = a.std_all();
         println!("{:}", m);
@@ -491,7 +493,7 @@ mod test {
             .zip(vi.iter())
             .map(|(r, i)| num::Complex::new(r.to_f64().unwrap(), i.to_f64().unwrap()))
             .collect::<Vec<_>>();
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default()));
 
         let m = a.l2_norm_all();
         println!("{:}", m);
@@ -538,7 +540,7 @@ mod test {
     fn test_unraveled_argmin() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 7, 1, 2, 1, 8, 6, 10, 5];
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default()));
         println!("{:}", a);
         // [[ 8 4 2]
         //  [ 9 7 1]
@@ -564,7 +566,7 @@ mod test {
     fn test_argmin() {
         // DeviceCpuSerial
         let v = vec![8, 4, 2, 9, 7, 1, 2, 1, 8, 6, 10, 5];
-        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial));
+        let a = asarray((&v, [4, 3].c(), &DeviceCpuSerial::default()));
         println!("{:}", a);
         // [[ 8 4 2]
         //  [ 9 7 1]

--- a/rstsr-core/tests/tensor_sum.rs
+++ b/rstsr-core/tests/tensor_sum.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "col_major"))]
+
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
@@ -8,7 +10,6 @@ mod test {
     use super::*;
 
     #[test]
-    #[cfg(not(feature = "col_major"))]
     fn test_tensor_sum_leading() {
         let n = 512;
         let time = Instant::now();
@@ -65,7 +66,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(not(feature = "col_major"))]
     fn test_tensor_sum_last() {
         let n = 512;
         let time = Instant::now();

--- a/rstsr-core/tests/tensor_sum.rs
+++ b/rstsr-core/tests/tensor_sum.rs
@@ -16,7 +16,7 @@ mod test {
             let mut rng = StdRng::seed_from_u64(42);
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
-            let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial));
+            let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial::default()));
             b_full.sum_axes(0)
         };
         println!("{:} usec", time.elapsed().as_micros());
@@ -72,7 +72,7 @@ mod test {
             let mut rng = StdRng::seed_from_u64(42);
 
             let vec_b: Vec<f64> = (0..4 * n * n).map(|_| rng.gen()).collect::<_>();
-            let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial));
+            let b_full = rt::asarray((vec_b, [4, n, n], &DeviceCpuSerial::default()));
             b_full.sum_axes([-1, -2])
         };
         println!("{:} usec", time.elapsed().as_micros());

--- a/rstsr-core/tests/tensor_sum.rs
+++ b/rstsr-core/tests/tensor_sum.rs
@@ -8,6 +8,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[cfg(not(feature = "col_major"))]
     fn test_tensor_sum_leading() {
         let n = 512;
         let time = Instant::now();
@@ -64,6 +65,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(feature = "col_major"))]
     fn test_tensor_sum_last() {
         let n = 512;
         let time = Instant::now();

--- a/rstsr-openblas/src/conversion.rs
+++ b/rstsr-openblas/src/conversion.rs
@@ -88,7 +88,7 @@ mod test {
 
     #[test]
     fn test_device_conversion_cpu_serial() {
-        let device_serial = DeviceCpuSerial {};
+        let device_serial = DeviceCpuSerial::default();
         let device_openblas = DeviceBLAS::new(0);
         let a = linspace((1.0, 5.0, 5, &device_openblas));
         let b = a.to_device(&device_serial);

--- a/rstsr-openblas/src/creation.rs
+++ b/rstsr-openblas/src/creation.rs
@@ -7,7 +7,7 @@ where
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.empty_impl(len)?;
+        let storage = DeviceCpuSerial::default().empty_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -16,7 +16,7 @@ where
     where
         T: Clone,
     {
-        let storage = DeviceCpuSerial.full_impl(len, fill)?;
+        let storage = DeviceCpuSerial::default().full_impl(len, fill)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -40,19 +40,19 @@ where
     Self: DeviceRawAPI<T, Raw = Vec<T>>,
 {
     fn zeros_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.zeros_impl(len)?;
+        let storage = DeviceCpuSerial::default().zeros_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
 
     fn ones_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.ones_impl(len)?;
+        let storage = DeviceCpuSerial::default().ones_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
 
     fn arange_int_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.arange_int_impl(len)?;
+        let storage = DeviceCpuSerial::default().arange_int_impl(len)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -69,7 +69,7 @@ where
         end: T,
         step: T,
     ) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.arange_impl(start, end, step)?;
+        let storage = DeviceCpuSerial::default().arange_impl(start, end, step)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -87,7 +87,7 @@ where
         n: usize,
         endpoint: bool,
     ) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
-        let storage = DeviceCpuSerial.linspace_impl(start, end, n, endpoint)?;
+        let storage = DeviceCpuSerial::default().linspace_impl(start, end, n, endpoint)?;
         let (data, _) = storage.into_raw_parts();
         Ok(Storage::new(data, self.clone()))
     }
@@ -102,14 +102,14 @@ where
     where
         D: DimAPI,
     {
-        DeviceCpuSerial.tril_impl(raw, layout, k)
+        DeviceCpuSerial::default().tril_impl(raw, layout, k)
     }
 
     fn triu_impl<D>(&self, raw: &mut Self::Raw, layout: &Layout<D>, k: isize) -> Result<()>
     where
         D: DimAPI,
     {
-        DeviceCpuSerial.triu_impl(raw, layout, k)
+        DeviceCpuSerial::default().triu_impl(raw, layout, k)
     }
 }
 

--- a/rstsr-openblas/src/device.rs
+++ b/rstsr-openblas/src/device.rs
@@ -37,7 +37,17 @@ impl Default for DeviceBLAS {
 
 impl DeviceBaseAPI for DeviceBLAS {
     fn same_device(&self, other: &Self) -> bool {
-        self.get_num_threads() == other.get_num_threads()
+        let same_num_threads = self.get_num_threads() == other.get_num_threads();
+        let same_default_order = self.default_order() == other.default_order();
+        same_num_threads && same_default_order
+    }
+
+    fn default_order(&self) -> FlagOrder {
+        self.base.default_order()
+    }
+
+    fn set_default_order(&mut self, order: FlagOrder) {
+        self.base.set_default_order(order);
     }
 }
 
@@ -105,6 +115,7 @@ impl<T> DeviceStorageAPI<T> for DeviceBLAS {
 }
 
 impl<T> DeviceAPI<T> for DeviceBLAS {}
+
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
     T: ComplexFloat + Send + Sync,

--- a/rstsr/Cargo.toml
+++ b/rstsr/Cargo.toml
@@ -22,6 +22,8 @@ std = ["rstsr-core/std"]
 rayon = ["rstsr-core/rayon"]
 faer = ["rstsr-core/faer"]
 faer_as_default = ["rstsr-core/faer_as_default"]
+row_major = ["rstsr-core/row_major"]
+col_major = ["rstsr-core/col_major"]
 dispatch_dim_layout_iter = ["rstsr-core/dispatch_dim_layout_iter"]
 
 # rstsr-openblas features


### PR DESCRIPTION
This PR will try to introduce column-major support.

For row-major, we have used NumPy's convention for broadcasting (including elementwise and matmul) and reshaping.

For col-major, we will limit broadcasting ability, and reshape function will behave differently. The convention will try to be similar to Julia's. I'm not very familiar to Julia, and I'll try to implement col-major by my comprehension.

- [x] broadcasting ability similar to Julia (seems to be the inverse of NumPy's)
- [x] limit matmul to 1-D/2-D only, and do not allow higher dimension matmul for col-major cases (row-major still available for higher dimension broadcasted matmul)
- [x] update and check reshape functionality
- [x] check iterators
- [x] update many unittests that requires linspace/arange followed by reshape
- [x] behavior of pack/unpack triangular