### PR TITLE
Github Action Update

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,11 +23,12 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz in rstsr-test-manifest
+      - name: Install release-plz
         uses: release-plz/action@v0.5
-        with:
-          command: release
-          manifest_path: ./rstsr-test-manifest/Cargo.toml
+      - name: Run release-plz in rstsr-test-manifest
+        run: |
+          cd rstsr-test-manifest
+          release-plz release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,6 +25,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install release-plz
         uses: release-plz/action@v0.5
+        with:
+          command: update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,6 +25,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install release-plz
         uses: release-plz/action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Run release-plz in rstsr-test-manifest
         run: |
           cd rstsr-test-manifest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,20 +23,6 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Install release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: update
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Run release-plz in rstsr-test-manifest
-        run: |
-          cd rstsr-test-manifest
-          release-plz release --git-token $GITHUB_TOKEN
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run release-plz in rstsr-test-manifest
         run: |
           cd rstsr-test-manifest
-          release-plz release
+          release-plz release --git-token $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
     "rstsr-openblas-ffi",
     "rstsr-dtype-traits",
     "rstsr-blas-traits",
-    "rstsr-test-manifest",
     "rstsr-linalg-traits",
 ]
 
@@ -25,11 +24,12 @@ rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.2.6
 # members without core
 rstsr-openblas-ffi = { path = "./rstsr-openblas-ffi", default-features = false, version = "0.2.6" }
 rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.2.6" }
-rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false, version = "0.2.6" }
 # members
 rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.2.6" }
 rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.2.6" }
 rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.2.6" }
+# develop dependencies that should not publish
+rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # basic dependencies
 num = { version = "0.4" }
 thiserror = { version = "1.0" }


### PR DESCRIPTION
This github action update tries to avoid hard dev-dependency of crate rstsr-test-manifest that causes release-plz release action failure.
c.f. https://github.com/release-plz/release-plz/issues/1316#issuecomment-1972081110