### PR TITLE
Modification to some core operations

### DIFF
--- a/rstsr-core/src/device_cpu_serial/reduction.rs
+++ b/rstsr-core/src/device_cpu_serial/reduction.rs
@@ -535,3 +535,39 @@ where
         Ok(result)
     }
 }
+
+impl<D> OpSumBoolAPI<D> for DeviceCpuSerial
+where
+    D: DimAPI,
+{
+    fn sum_all(&self, a: &Vec<bool>, la: &Layout<D>) -> Result<usize> {
+        let f_init = || 0;
+        let f = |acc, x| match x {
+            true => acc + 1,
+            false => acc,
+        };
+        let f_sum = |acc1, acc2| acc1 + acc2;
+        let f_out = |acc| acc;
+
+        reduce_all_cpu_serial(a, la, f_init, f, f_sum, f_out)
+    }
+
+    fn sum_axes(
+        &self,
+        a: &Vec<bool>,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<Vec<usize>>, usize, Self>, Layout<IxD>)> {
+        let f_init = || 0;
+        let f = |acc, x| match x {
+            true => acc + 1,
+            false => acc,
+        };
+        let f_sum = |acc1, acc2| acc1 + acc2;
+        let f_out = |acc| acc;
+
+        let (out, layout_out) =
+            reduce_axes_cpu_serial(a, &la.to_dim()?, axes, f_init, f, f_sum, f_out)?;
+        Ok((Storage::new(out.into(), self.clone()), layout_out))
+    }
+}

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -28,6 +28,7 @@ pub mod rstsr_traits {
     pub use crate::tensor::ownership_conversion::{
         TensorIntoOwnedAPI, TensorViewAPI, TensorViewMutAPI,
     };
+    pub use crate::tensor::reduction::TensorSumBoolAPI;
 
     #[cfg(feature = "rayon")]
     pub use crate::feature_rayon::DeviceRayonAPI;

--- a/rstsr-core/src/prelude_dev.rs
+++ b/rstsr-core/src/prelude_dev.rs
@@ -43,6 +43,7 @@ pub use crate::tensor::iterator_axes::*;
 pub use crate::tensor::iterator_elem::*;
 pub use crate::tensor::manuplication::*;
 pub use crate::tensor::ownership_conversion::*;
+pub use crate::tensor::reduction::TensorSumBoolAPI;
 pub use crate::tensor::tensor_mutable::*;
 
 pub use crate::prelude::rstsr_traits::*;

--- a/rstsr-core/src/storage/reduction.rs
+++ b/rstsr-core/src/storage/reduction.rs
@@ -1,64 +1,70 @@
 use crate::prelude_dev::*;
 
-macro_rules! trait_reduction {
-    ($OpReduceAPI: ident, $func: ident, $func_all: ident) => {
-        pub trait $OpReduceAPI<T, D>
-        where
-            D: DimAPI,
-            Self: DeviceAPI<T> + DeviceAPI<Self::TOut>,
-        {
-            type TOut;
-            fn $func_all(
-                &self,
-                a: &<Self as DeviceRawAPI<T>>::Raw,
-                la: &Layout<D>,
-            ) -> Result<Self::TOut>;
-            fn $func(
-                &self,
-                a: &<Self as DeviceRawAPI<T>>::Raw,
-                la: &Layout<D>,
-                axes: &[isize],
-            ) -> Result<(
-                Storage<DataOwned<<Self as DeviceRawAPI<Self::TOut>>::Raw>, Self::TOut, Self>,
-                Layout<IxD>,
-            )>;
-        }
-    };
+#[allow(clippy::type_complexity)]
+#[duplicate_item(
+    OpReduceAPI   func           func_all    ;
+   [OpSumAPI   ] [sum_axes    ] [sum_all    ];
+   [OpMinAPI   ] [min_axes    ] [min_all    ];
+   [OpMaxAPI   ] [max_axes    ] [max_all    ];
+   [OpProdAPI  ] [prod_axes   ] [prod_all   ];
+   [OpMeanAPI  ] [mean_axes   ] [mean_all   ];
+   [OpVarAPI   ] [var_axes    ] [var_all    ];
+   [OpStdAPI   ] [std_axes    ] [std_all    ];
+   [OpL2NormAPI] [l2_norm_axes] [l2_norm_all];
+   [OpArgMinAPI] [argmin_axes ] [argmin_all ];
+   [OpArgMaxAPI] [argmax_axes ] [argmax_all ];
+)]
+pub trait OpReduceAPI<T, D>
+where
+    D: DimAPI,
+    Self: DeviceAPI<T> + DeviceAPI<Self::TOut>,
+{
+    type TOut;
+    fn func_all(&self, a: &<Self as DeviceRawAPI<T>>::Raw, la: &Layout<D>) -> Result<Self::TOut>;
+    fn func(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(
+        Storage<DataOwned<<Self as DeviceRawAPI<Self::TOut>>::Raw>, Self::TOut, Self>,
+        Layout<IxD>,
+    )>;
 }
 
-trait_reduction!(OpSumAPI, sum_axes, sum_all);
-trait_reduction!(OpMinAPI, min_axes, min_all);
-trait_reduction!(OpMaxAPI, max_axes, max_all);
-trait_reduction!(OpProdAPI, prod_axes, prod_all);
-trait_reduction!(OpMeanAPI, mean_axes, mean_all);
-trait_reduction!(OpVarAPI, var_axes, var_all);
-trait_reduction!(OpStdAPI, std_axes, std_all);
-trait_reduction!(OpL2NormAPI, l2_norm_axes, l2_norm_all);
-trait_reduction!(OpArgMinAPI, argmin_axes, argmin_all);
-trait_reduction!(OpArgMaxAPI, argmax_axes, argmax_all);
-
-macro_rules! trait_reduction_arg {
-    ($OpReduceAPI: ident, $func: ident, $func_all: ident) => {
-        pub trait $OpReduceAPI<T, D>
-        where
-            D: DimAPI,
-            Self: DeviceAPI<T>,
-        {
-            fn $func_all(&self, a: &<Self as DeviceRawAPI<T>>::Raw, la: &Layout<D>) -> Result<D>;
-            fn $func(
-                &self,
-                a: &<Self as DeviceRawAPI<T>>::Raw,
-                la: &Layout<D>,
-                axes: &[isize],
-            ) -> Result<(
-                Storage<DataOwned<<Self as DeviceRawAPI<IxD>>::Raw>, IxD, Self>,
-                Layout<IxD>,
-            )>
-            where
-                Self: DeviceAPI<IxD>;
-        }
-    };
+#[allow(clippy::type_complexity)]
+#[duplicate_item(
+    OpReduceAPI            func                    func_all             ;
+   [OpUnraveledArgMinAPI] [unraveled_argmin_axes] [unraveled_argmin_all];
+   [OpUnraveledArgMaxAPI] [unraveled_argmax_axes] [unraveled_argmax_all];
+)]
+pub trait OpReduceAPI<T, D>
+where
+    D: DimAPI,
+    Self: DeviceAPI<T>,
+{
+    fn func_all(&self, a: &<Self as DeviceRawAPI<T>>::Raw, la: &Layout<D>) -> Result<D>;
+    fn func(
+        &self,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<<Self as DeviceRawAPI<IxD>>::Raw>, IxD, Self>, Layout<IxD>)>
+    where
+        Self: DeviceAPI<IxD>;
 }
 
-trait_reduction_arg!(OpUnraveledArgMinAPI, unraveled_argmin_axes, unraveled_argmin_all);
-trait_reduction_arg!(OpUnraveledArgMaxAPI, unraveled_argmax_axes, unraveled_argmax_all);
+#[allow(clippy::type_complexity)]
+pub trait OpSumBoolAPI<D>
+where
+    D: DimAPI,
+    Self: DeviceAPI<bool> + DeviceAPI<usize>,
+{
+    fn sum_all(&self, a: &<Self as DeviceRawAPI<bool>>::Raw, la: &Layout<D>) -> Result<usize>;
+    fn sum_axes(
+        &self,
+        a: &<Self as DeviceRawAPI<bool>>::Raw,
+        la: &Layout<D>,
+        axes: &[isize],
+    ) -> Result<(Storage<DataOwned<<Self as DeviceRawAPI<usize>>::Raw>, usize, Self>, Layout<IxD>)>;
+}

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -288,5 +288,8 @@ mod test {
         assert_eq!(c.raw(), &[false, false, true, false, false, true]);
         let c = ge(a.view(), &b);
         assert_eq!(c.raw(), &[true, false, true, false, true, true]);
+
+        let c_sum = c.sum();
+        assert_eq!(c_sum, 4);
     }
 }

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -10,94 +10,122 @@ Exception functions:
 
 /* #region tensor traits */
 
-macro_rules! trait_binary {
-    ($op: ident, $op_f: ident, $TensorOpAPI: ident, $DeviceOpAPI: ident, $($op2: ident, $op2_f: ident),*) => {
-        pub trait $TensorOpAPI<TRB> {
-            type Output;
-            fn $op_f(&self, b: &TRB) -> Result<Self::Output>;
-            fn $op(&self, b: &TRB) -> Self::Output {
-                self.$op_f(b).unwrap()
-            }
-
-            $(
-                fn $op2_f(&self, b: &TRB) -> Result<Self::Output> {
-                    self.$op_f(b)
-                }
-                fn $op2(&self, b: &TRB) -> Self::Output {
-                    self.$op(b)
-                }
-            )*
-        }
-
-        impl<RA, TA, DA, RB, TB, DB, B> $TensorOpAPI<TensorAny<RB, TB, B, DB>> for TensorAny<RA, TA, B, DA>
-        where
-            RA: DataAPI<Data = <B as DeviceRawAPI<TA>>::Raw>,
-            RB: DataAPI<Data = <B as DeviceRawAPI<TB>>::Raw>,
-            DA: DimAPI + DimMaxAPI<DB>,
-            DB: DimAPI,
-            DA::Max: DimAPI,
-            B: $DeviceOpAPI<TA, TB, DA::Max>,
-            B: DeviceAPI<TA> + DeviceAPI<TB> + DeviceAPI<B::TOut> + DeviceCreationAnyAPI<B::TOut>,
-        {
-            type Output = Tensor<B::TOut, B, DA::Max>;
-
-            fn $op_f(&self, b: &TensorAny<RB, TB, B, DB>) -> Result<Self::Output> {
-                // check device
-                rstsr_assert!(self.device().same_device(b.device()), DeviceMismatch)?;
-
-                // check and broadcast layout
-                let la = self.layout();
-                let lb = b.layout();
-                let default_order = self.device().default_order();
-                let (la_b, lb_b) = broadcast_layout(la, lb, default_order)?;
-                let lc_from_a = layout_for_array_copy(&la_b, TensorIterOrder::default())?;
-                let lc_from_b = layout_for_array_copy(&lb_b, TensorIterOrder::default())?;
-                let lc = if lc_from_a == lc_from_b {
-                    lc_from_a
-                } else {
-                    match self.device().default_order() {
-                        RowMajor => la_b.shape().c(),
-                        ColMajor => la_b.shape().f(),
-                    }
-                };
-
-                // perform operation and return
-                let device = self.device();
-                let mut storage_c = unsafe { device.empty_impl(lc.bounds_index()?.1)? };
-                device.op_mutc_refa_refb(
-                    storage_c.raw_mut(),
-                    &lc,
-                    self.raw(),
-                    &la_b,
-                    b.raw(),
-                    &lb_b,
-                )?;
-                Tensor::new_f(storage_c, lc)
-            }
-        }
-    };
+#[duplicate_item(
+    op              op_f              TensorOpAPI             DeviceOpAPI           ;
+   [atan2        ] [atan2_f        ] [TensorATan2API       ] [DeviceATan2API       ];
+   [copysign     ] [copysign_f     ] [TensorCopySignAPI    ] [DeviceCopySignAPI    ];
+   [equal        ] [equal_f        ] [TensorEqualAPI       ] [DeviceEqualAPI       ];
+   [floor_divide ] [floor_divide_f ] [TensorFloorDivideAPI ] [DeviceFloorDivideAPI ];
+   [greater      ] [greater_f      ] [TensorGreaterAPI     ] [DeviceGreaterAPI     ];
+   [greater_equal] [greater_equal_f] [TensorGreaterEqualAPI] [DeviceGreaterEqualAPI];
+   [hypot        ] [hypot_f        ] [TensorHypotAPI       ] [DeviceHypotAPI       ];
+   [less         ] [less_f         ] [TensorLessAPI        ] [DeviceLessAPI        ];
+   [less_equal   ] [less_equal_f   ] [TensorLessEqualAPI   ] [DeviceLessEqualAPI   ];
+   [log_add_exp  ] [log_add_exp_f  ] [TensorLogAddExpAPI   ] [DeviceLogAddExpAPI   ];
+   [maximum      ] [maximum_f      ] [TensorMaximumAPI     ] [DeviceMaximumAPI     ];
+   [minimum      ] [minimum_f      ] [TensorMinimumAPI     ] [DeviceMinimumAPI     ];
+   [not_equal    ] [not_equal_f    ] [TensorNotEqualAPI    ] [DeviceNotEqualAPI    ];
+   [pow          ] [pow_f          ] [TensorPowAPI         ] [DevicePowAPI         ];
+)]
+pub trait TensorOpAPI<TRB> {
+    type Output;
+    fn op_f(self, b: TRB) -> Result<Self::Output>;
+    fn op(self, b: TRB) -> Self::Output
+    where
+        Self: Sized,
+    {
+        self.op_f(b).unwrap()
+    }
 }
 
-#[rustfmt::skip]
-mod trait_binary {
+#[duplicate_item(
+    op              op_f              TensorOpAPI             DeviceOpAPI           ;
+   [atan2        ] [atan2_f        ] [TensorATan2API       ] [DeviceATan2API       ];
+   [copysign     ] [copysign_f     ] [TensorCopySignAPI    ] [DeviceCopySignAPI    ];
+   [equal        ] [equal_f        ] [TensorEqualAPI       ] [DeviceEqualAPI       ];
+   [floor_divide ] [floor_divide_f ] [TensorFloorDivideAPI ] [DeviceFloorDivideAPI ];
+   [greater      ] [greater_f      ] [TensorGreaterAPI     ] [DeviceGreaterAPI     ];
+   [greater_equal] [greater_equal_f] [TensorGreaterEqualAPI] [DeviceGreaterEqualAPI];
+   [hypot        ] [hypot_f        ] [TensorHypotAPI       ] [DeviceHypotAPI       ];
+   [less         ] [less_f         ] [TensorLessAPI        ] [DeviceLessAPI        ];
+   [less_equal   ] [less_equal_f   ] [TensorLessEqualAPI   ] [DeviceLessEqualAPI   ];
+   [log_add_exp  ] [log_add_exp_f  ] [TensorLogAddExpAPI   ] [DeviceLogAddExpAPI   ];
+   [maximum      ] [maximum_f      ] [TensorMaximumAPI     ] [DeviceMaximumAPI     ];
+   [minimum      ] [minimum_f      ] [TensorMinimumAPI     ] [DeviceMinimumAPI     ];
+   [not_equal    ] [not_equal_f    ] [TensorNotEqualAPI    ] [DeviceNotEqualAPI    ];
+   [pow          ] [pow_f          ] [TensorPowAPI         ] [DevicePowAPI         ];
+)]
+mod impl_trait_binary {
     use super::*;
-    trait_binary!(atan2         , atan2_f           , TensorATan2API            , DeviceATan2API            ,               );
-    trait_binary!(copysign      , copysign_f        , TensorCopySignAPI         , DeviceCopySignAPI         ,               );
-    trait_binary!(equal         , equal_f           , TensorEqualAPI            , DeviceEqualAPI            , eq, eq_f      );
-    trait_binary!(floor_divide  , floor_divide_f    , TensorFloorDivideAPI      , DeviceFloorDivideAPI      ,               );
-    trait_binary!(greater       , greater_f         , TensorGreaterAPI          , DeviceGreaterAPI          , gt, gt_f      );
-    trait_binary!(greater_equal , greater_equal_f   , TensorGreaterEqualAPI     , DeviceGreaterEqualAPI     , ge, ge_f      );
-    trait_binary!(hypot         , hypot_f           , TensorHypotAPI            , DeviceHypotAPI            ,               );
-    trait_binary!(less          , less_f            , TensorLessAPI             , DeviceLessAPI             , lt, lt_f      );
-    trait_binary!(less_equal    , less_equal_f      , TensorLessEqualAPI        , DeviceLessEqualAPI        , le, le_f      );
-    trait_binary!(log_add_exp   , log_add_exp_f     , TensorLogAddExpAPI        , DeviceLogAddExpAPI        ,               );
-    trait_binary!(maximum       , maximum_f         , TensorMaximumAPI          , DeviceMaximumAPI          , max, max_f    );
-    trait_binary!(minimum       , minimum_f         , TensorMinimumAPI          , DeviceMinimumAPI          , min, min_f    );
-    trait_binary!(not_equal     , not_equal_f       , TensorNotEqualAPI         , DeviceNotEqualAPI         , ne, ne_f      );
-    trait_binary!(pow           , pow_f             , TensorPowAPI              , DevicePowAPI              ,               );
-}
 
-pub use trait_binary::*;
+    impl<RA, TA, DA, RB, TB, DB, B> TensorOpAPI<&TensorAny<RB, TB, B, DB>> for &TensorAny<RA, TA, B, DA>
+    where
+        RA: DataAPI<Data = <B as DeviceRawAPI<TA>>::Raw>,
+        RB: DataAPI<Data = <B as DeviceRawAPI<TB>>::Raw>,
+        DA: DimAPI + DimMaxAPI<DB>,
+        DB: DimAPI,
+        DA::Max: DimAPI,
+        B: DeviceOpAPI<TA, TB, DA::Max>,
+        B: DeviceAPI<TA> + DeviceAPI<TB> + DeviceAPI<B::TOut> + DeviceCreationAnyAPI<B::TOut>,
+    {
+        type Output = Tensor<B::TOut, B, DA::Max>;
+
+        fn op_f(self, b: &TensorAny<RB, TB, B, DB>) -> Result<Self::Output> {
+            // check device
+            rstsr_assert!(self.device().same_device(b.device()), DeviceMismatch)?;
+
+            // check and broadcast layout
+            let la = self.layout();
+            let lb = b.layout();
+            let default_order = self.device().default_order();
+            let (la_b, lb_b) = broadcast_layout(la, lb, default_order)?;
+            let lc_from_a = layout_for_array_copy(&la_b, TensorIterOrder::default())?;
+            let lc_from_b = layout_for_array_copy(&lb_b, TensorIterOrder::default())?;
+            let lc = if lc_from_a == lc_from_b {
+                lc_from_a
+            } else {
+                match self.device().default_order() {
+                    RowMajor => la_b.shape().c(),
+                    ColMajor => la_b.shape().f(),
+                }
+            };
+
+            // perform operation and return
+            let device = self.device();
+            let mut storage_c = unsafe { device.empty_impl(lc.bounds_index()?.1)? };
+            device.op_mutc_refa_refb(
+                storage_c.raw_mut(),
+                &lc,
+                self.raw(),
+                &la_b,
+                b.raw(),
+                &lb_b,
+            )?;
+            Tensor::new_f(storage_c, lc)
+        }
+    }
+
+    #[duplicate_item(
+        ImplType                                                             TrA                         TrB                       ;
+       [TA, DA, TB, DB, B, R: DataAPI<Data = <B as DeviceRawAPI<TA>>::Raw>] [&TensorAny<R, TA, B, DA> ] [TensorView<'_, TB, B, DB>];
+       [TA, DA, TB, DB, B, R: DataAPI<Data = <B as DeviceRawAPI<TB>>::Raw>] [TensorView<'_, TA, B, DA>] [&TensorAny<R, TB, B, DB> ];
+       [TA, DA, TB, DB, B                                                 ] [TensorView<'_, TA, B, DA>] [TensorView<'_, TB, B, DB>];
+    )]
+    impl<ImplType> TensorOpAPI<TrB> for TrA
+    where
+        DA: DimAPI + DimMaxAPI<DB>,
+        DB: DimAPI,
+        DA::Max: DimAPI,
+        B: DeviceOpAPI<TA, TB, DA::Max>,
+        B: DeviceAPI<TA> + DeviceAPI<TB> + DeviceAPI<B::TOut> + DeviceCreationAnyAPI<B::TOut>,
+    {
+        type Output = Tensor<B::TOut, B, DA::Max>;
+
+        fn op_f(self, b: TrB) -> Result<Self::Output> {
+            TensorOpAPI::op_f(&self.view(), &b.view())
+        }
+    }
+}
 
 /* #endregion */
 
@@ -105,14 +133,14 @@ pub use trait_binary::*;
 
 macro_rules! func_binary {
     ($op: ident, $op_f: ident, $TensorOpAPI: ident, $DeviceOpAPI: ident, $($op2: ident, $op2_f: ident),*) => {
-        pub fn $op_f<TRA, TRB>(a: &TRA, b: &TRB) -> Result<TRA::Output>
+        pub fn $op_f<TRA, TRB>(a: TRA, b: TRB) -> Result<TRA::Output>
         where
             TRA: $TensorOpAPI<TRB>,
         {
             a.$op_f(b)
         }
 
-        pub fn $op<TRA, TRB>(a: &TRA, b: &TRB) -> TRA::Output
+        pub fn $op<TRA, TRB>(a: TRA, b: TRB) -> TRA::Output
         where
             TRA: $TensorOpAPI<TRB>,
         {
@@ -120,18 +148,18 @@ macro_rules! func_binary {
         }
 
         $(
-            pub fn $op2_f<TRA, TRB>(a: &TRA, b: &TRB) -> Result<TRA::Output>
+            pub fn $op2_f<TRA, TRB>(a: TRA, b: TRB) -> Result<TRA::Output>
             where
                 TRA: $TensorOpAPI<TRB>,
             {
-                a.$op2_f(b)
+                a.$op_f(b)
             }
 
-            pub fn $op2<TRA, TRB>(a: &TRA, b: &TRB) -> TRA::Output
+            pub fn $op2<TRA, TRB>(a: TRA, b: TRB) -> TRA::Output
             where
                 TRA: $TensorOpAPI<TRB>,
             {
-                a.$op2(b)
+                a.$op(b)
             }
         )*
     };
@@ -249,5 +277,16 @@ mod test {
             let c = a.floor_divide_f(&b);
             println!("{c:?}");
         }
+    }
+
+    #[test]
+    fn test_ge_gt() {
+        let a = asarray(vec![1., 2., 3., 4., 5., 6.]);
+        let b = asarray(vec![1., 3., 2., 5., 5., 2.]);
+
+        let c = gt(a.view(), &b);
+        assert_eq!(c.raw(), &[false, false, true, false, false, true]);
+        let c = ge(a.view(), &b);
+        assert_eq!(c.raw(), &[true, false, true, false, true, true]);
     }
 }


### PR DESCRIPTION
1. Remove `ge`, `gt`, `ne`, ... in traits `TensorGreaterAPI`, `TensorNotEqualAPI`, ...
   Those functions may clash with PartialOrd trait functions.
   However, `rt::gt` as general function (instead of trait function) still available.

2. Add implementation of summation to boolean tensor (returns usize that represents count of true values).
   Now `boolean_tensor.sum()` will give similar values to `np.sum(boolean_tensor)`. However, `rt::sum` can not be applied to boolean tensor due to trait current implementation rules.