### PR TITLE
Add tensor function `index_select`

### DIFF
--- a/rstsr-core/src/device_cpu_serial/adv_indexing.rs
+++ b/rstsr-core/src/device_cpu_serial/adv_indexing.rs
@@ -1,17 +1,11 @@
-//! Advanced indexing related device traits.
-//!
-//! Currently, full support of advanced indexing is not available. However, it
-//! is still possible to index one axis by list.
-
 use crate::prelude_dev::*;
 
-pub trait DeviceIndexSelectAPI<T, D>
+impl<T, D> DeviceIndexSelectAPI<T, D> for DeviceCpuSerial
 where
+    T: Clone,
     D: DimAPI + DimSmallerOneAPI,
     D::SmallerOne: DimAPI,
-    Self: DeviceAPI<T>,
 {
-    /// Index select on one axis.
     fn index_select(
         &self,
         c: &mut <Self as DeviceRawAPI<T>>::Raw,
@@ -20,5 +14,7 @@ where
         la: &Layout<D>,
         axis: usize,
         indices: &[usize],
-    ) -> Result<()>;
+    ) -> Result<()> {
+        index_select_cpu_serial(c, lc, a, la, axis, indices)
+    }
 }

--- a/rstsr-core/src/device_cpu_serial/mod.rs
+++ b/rstsr-core/src/device_cpu_serial/mod.rs
@@ -1,5 +1,6 @@
 //! Backend for CPU, serial only.
 
+pub mod adv_indexing;
 pub mod assignment;
 pub mod creation;
 pub mod device;

--- a/rstsr-core/src/device_faer/rayon_auto_impl/adv_indexing.rs
+++ b/rstsr-core/src/device_faer/rayon_auto_impl/adv_indexing.rs
@@ -1,0 +1,1 @@
+../../feature_rayon/auto_impl/adv_indexing.rs

--- a/rstsr-core/src/feature_rayon/auto_impl/adv_indexing.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/adv_indexing.rs
@@ -1,0 +1,21 @@
+use crate::prelude_dev::*;
+
+impl<T, D> DeviceIndexSelectAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + Send + Sync,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    fn index_select(
+        &self,
+        c: &mut <Self as DeviceRawAPI<T>>::Raw,
+        lc: &Layout<D>,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+        axis: usize,
+        indices: &[usize],
+    ) -> Result<()> {
+        let pool = self.get_current_pool();
+        index_select_cpu_rayon(c, lc, a, la, axis, indices, pool)
+    }
+}

--- a/rstsr-core/src/feature_rayon/auto_impl/mod.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/mod.rs
@@ -1,3 +1,4 @@
+pub mod adv_indexing;
 pub mod assignment;
 pub mod op_binary_arithmetic;
 pub mod op_binary_common;

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -50,6 +50,7 @@ pub mod rstsr_structs {
 }
 
 pub mod rstsr_funcs {
+    pub use crate::tensor::adv_indexing::{index_select, index_select_f};
     pub use crate::tensor::asarray::{asarray, asarray_f};
     pub use crate::tensor::creation::{
         arange, arange_f, empty, empty_f, empty_like, empty_like_f, eye, eye_f, full, full_f,

--- a/rstsr-core/src/prelude_dev.rs
+++ b/rstsr-core/src/prelude_dev.rs
@@ -18,6 +18,7 @@ pub use rstsr_common::prelude_dev::*;
 
 pub use rstsr_native_impl::prelude_dev::*;
 
+pub use crate::storage::adv_indexing::*;
 pub use crate::storage::assignment::*;
 pub use crate::storage::combined_trait::*;
 pub use crate::storage::conversion::*;

--- a/rstsr-core/src/storage/adv_indexing.rs
+++ b/rstsr-core/src/storage/adv_indexing.rs
@@ -1,0 +1,23 @@
+//! Advanced indexing related device traits.
+//!
+//! Currently, full support of advanced indexing is not available. However, it
+//! is still possible to index one axis by list.
+
+use crate::prelude_dev::*;
+
+pub trait DeviceIndexSelectAPI<T, D>
+where
+    D: DimAPI,
+    Self: DeviceAPI<T>,
+{
+    /// Index select on one axis.
+    fn index_select(
+        &self,
+        c: &mut <Self as DeviceRawAPI<T>>::Raw,
+        lc: &Layout<D>,
+        a: &<Self as DeviceRawAPI<T>>::Raw,
+        la: &Layout<D>,
+        axis: usize,
+        indices: &[usize],
+    ) -> Result<()>;
+}

--- a/rstsr-core/src/storage/mod.rs
+++ b/rstsr-core/src/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod adv_indexing;
 pub mod assignment;
 pub mod combined_trait;
 pub mod conversion;
@@ -8,6 +9,7 @@ pub mod matmul;
 pub mod operators;
 pub mod reduction;
 
+pub use adv_indexing::*;
 pub use assignment::*;
 pub use combined_trait::*;
 pub use conversion::*;

--- a/rstsr-core/src/tensor/adv_indexing.rs
+++ b/rstsr-core/src/tensor/adv_indexing.rs
@@ -116,26 +116,55 @@ mod test {
 
     #[test]
     fn test_index_select() {
-        let device = DeviceCpuSerial::default();
-        let a = linspace((1.0, 24.0, 24, &device)).into_shape((2, 3, 4));
-        let b = a.index_select(0, [0, 0, 1, -1]);
-        assert!(fingerprint(&b) - -31.94175930917264 < 1e-8);
-        let b = a.index_select(1, [0, 0, 1, -1]);
-        assert!(fingerprint(&b) - 3.5719025258942088 < 1e-8);
-        let b = a.index_select(2, [0, 0, 1, -1]);
-        assert!(fingerprint(&b) - -25.648600916145096 < 1e-8);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let device = DeviceCpuSerial::default();
+            let a = linspace((1.0, 24.0, 24, &device)).into_shape((2, 3, 4));
+            let b = a.index_select(0, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - -31.94175930917264 < 1e-8);
+            let b = a.index_select(1, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - 3.5719025258942088 < 1e-8);
+            let b = a.index_select(2, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - -25.648600916145096 < 1e-8);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let device = DeviceCpuSerial::default();
+            let a = linspace((1.0, 24.0, 24, &device)).into_shape((4, 3, 2));
+            let b = a.index_select(2, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - -31.94175930917264 < 1e-8);
+            let b = a.index_select(1, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - 3.5719025258942088 < 1e-8);
+            let b = a.index_select(0, [0, 0, 1, -1]);
+            assert!(fingerprint(&b) - -25.648600916145096 < 1e-8);
+        }
     }
 
     #[test]
     fn test_index_select_default_device() {
-        let device = DeviceCpu::default();
-        let a = linspace((1.0, 2.0, 256 * 256 * 256, &device)).into_shape((256, 256, 256));
-        let sel = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
-        let b = a.index_select(0, &sel);
-        assert!(fingerprint(&b) - 0.9357016252766746 < 1e-10);
-        let b = a.index_select(1, &sel);
-        assert!(fingerprint(&b) - 1.012193909979973 < 1e-10);
-        let b = a.index_select(2, &sel);
-        assert!(fingerprint(&b) - 1.010735112247236 < 1e-10);
+        #[cfg(not(feature = "col_major"))]
+        {
+            let device = DeviceCpu::default();
+            let a = linspace((1.0, 2.0, 256 * 256 * 256, &device)).into_shape((256, 256, 256));
+            let sel = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+            let b = a.index_select(0, &sel);
+            assert!(fingerprint(&b) - 0.9357016252766746 < 1e-10);
+            let b = a.index_select(1, &sel);
+            assert!(fingerprint(&b) - 1.012193909979973 < 1e-10);
+            let b = a.index_select(2, &sel);
+            assert!(fingerprint(&b) - 1.010735112247236 < 1e-10);
+        }
+        #[cfg(feature = "col_major")]
+        {
+            let device = DeviceCpu::default();
+            let a = linspace((1.0, 2.0, 256 * 256 * 256, &device)).into_shape((256, 256, 256));
+            let sel = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+            let b = a.index_select(2, &sel);
+            assert!(fingerprint(&b) - 0.9357016252766746 < 1e-10);
+            let b = a.index_select(1, &sel);
+            assert!(fingerprint(&b) - 1.012193909979973 < 1e-10);
+            let b = a.index_select(0, &sel);
+            assert!(fingerprint(&b) - 1.010735112247236 < 1e-10);
+        }
     }
 }

--- a/rstsr-core/src/tensor/adv_indexing.rs
+++ b/rstsr-core/src/tensor/adv_indexing.rs
@@ -125,4 +125,17 @@ mod test {
         let b = a.index_select(2, [0, 0, 1, -1]);
         assert!(fingerprint(&b) - -25.648600916145096 < 1e-8);
     }
+
+    #[test]
+    fn test_index_select_default_device() {
+        let device = DeviceCpu::default();
+        let a = linspace((1.0, 2.0, 256 * 256 * 256, &device)).into_shape((256, 256, 256));
+        let sel = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+        let b = a.index_select(0, &sel);
+        assert!(fingerprint(&b) - 0.9357016252766746 < 1e-10);
+        let b = a.index_select(1, &sel);
+        assert!(fingerprint(&b) - 1.012193909979973 < 1e-10);
+        let b = a.index_select(2, &sel);
+        assert!(fingerprint(&b) - 1.010735112247236 < 1e-10);
+    }
 }

--- a/rstsr-core/src/tensor/adv_indexing.rs
+++ b/rstsr-core/src/tensor/adv_indexing.rs
@@ -1,0 +1,108 @@
+//! Advanced indexing related tensor manuplications.
+//!
+//! Currently, full support of advanced indexing is not available. However, it
+//! is still possible to index one axis by list.
+
+use crate::prelude_dev::*;
+
+pub fn index_select_f<R, T, B, D, I>(
+    tensor: &TensorAny<R, T, B, D>,
+    axis: isize,
+    indices: I,
+) -> Result<Tensor<T, B, D>>
+where
+    R: DataAPI<Data = B::Raw>,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceIndexSelectAPI<T, D> + DeviceCreationAnyAPI<T>,
+    I: TryInto<AxesIndex<isize>>,
+    Error: From<I::Error>,
+{
+    // TODO: output layout control (TensorIterOrder::K or default layout)
+    let device = tensor.device().clone();
+    let tensor_layout = tensor.layout();
+    let ndim = tensor_layout.ndim();
+    // check axis and index
+    let axis = if axis < 0 { ndim as isize + axis } else { axis };
+    rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "Invalid axis that exceeds ndim.")?;
+    let axis = axis as usize;
+    let nshape: usize = tensor_layout.shape()[axis];
+    let indices = indices.try_into()?;
+    let indices = indices
+        .as_ref()
+        .iter()
+        .map(|&i| -> Result<usize> {
+            let i = if i < 0 { nshape as isize + i } else { i };
+            rstsr_pattern!(
+                i,
+                0..nshape as isize,
+                InvalidLayout,
+                "Invalid index that exceeds shape length at axis {}.",
+                axis
+            )?;
+            Ok(i as usize)
+        })
+        .collect::<Result<Vec<usize>>>()?;
+    let mut out_shape = tensor_layout.shape().as_ref().to_vec();
+    out_shape[axis] = indices.len();
+    let out_layout = out_shape.new_contig(None, device.default_order()).into_dim()?;
+    let mut out_storage = unsafe { device.empty_impl(out_layout.size())? };
+    device.index_select(
+        out_storage.raw_mut(),
+        &out_layout,
+        tensor.storage().raw(),
+        tensor_layout,
+        axis,
+        &indices,
+    )?;
+    TensorBase::new_f(out_storage, out_layout)
+}
+
+/// Returns a new tensor, which indexes the input tensor along dimension `axis`
+/// using the entries in `indices`.
+///
+/// # See also
+///
+/// This function should be similar to PyTorch's [`torch.index_select`](https://docs.pytorch.org/docs/stable/generated/torch.index_select.html).
+pub fn index_select<R, T, B, D, I>(
+    tensor: &TensorAny<R, T, B, D>,
+    axis: isize,
+    indices: I,
+) -> Tensor<T, B, D>
+where
+    R: DataAPI<Data = B::Raw>,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceIndexSelectAPI<T, D> + DeviceCreationAnyAPI<T>,
+    I: TryInto<AxesIndex<isize>>,
+    Error: From<I::Error>,
+{
+    index_select_f(tensor, axis, indices).unwrap()
+}
+
+impl<R, T, B, D> TensorAny<R, T, B, D>
+where
+    R: DataAPI<Data = B::Raw>,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceIndexSelectAPI<T, D> + DeviceCreationAnyAPI<T>,
+{
+    pub fn index_select_f<I>(&self, axis: isize, indices: I) -> Result<Tensor<T, B, D>>
+    where
+        I: TryInto<AxesIndex<isize>>,
+        Error: From<I::Error>,
+    {
+        index_select_f(self, axis, indices)
+    }
+
+    /// Returns a new tensor, which indexes the input tensor along dimension
+    /// `axis` using the entries in `indices`.
+    ///
+    /// # See also
+    ///
+    /// This function should be similar to PyTorch's [`torch.index_select`](https://docs.pytorch.org/docs/stable/generated/torch.index_select.html).
+    pub fn index_select<I>(&self, axis: isize, indices: I) -> Tensor<T, B, D>
+    where
+        I: TryInto<AxesIndex<isize>>,
+        Error: From<I::Error>,
+    {
+        index_select(self, axis, indices)
+    }
+}

--- a/rstsr-core/src/tensor/mod.rs
+++ b/rstsr-core/src/tensor/mod.rs
@@ -1,3 +1,4 @@
+pub mod adv_indexing;
 pub mod asarray;
 pub mod assignment;
 pub mod creation;

--- a/rstsr-native-impl/src/cpu_rayon/adv_indexing.rs
+++ b/rstsr-native-impl/src/cpu_rayon/adv_indexing.rs
@@ -1,0 +1,75 @@
+use crate::prelude_dev::*;
+
+pub fn index_select_cpu_rayon<T, D>(
+    c: &mut [T],
+    lc: &Layout<D>,
+    a: &[T],
+    la: &Layout<D>,
+    axis: usize,
+    indices: &[usize],
+    pool: Option<&ThreadPool>,
+) -> Result<()>
+where
+    T: Clone + Send + Sync,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    // if not in pool environment, use serial
+    if pool.is_none() {
+        return index_select_cpu_serial(c, lc, a, la, axis, indices);
+    }
+
+    // basic check
+    let ndim = lc.ndim();
+    rstsr_assert_eq!(ndim, la.ndim(), InvalidLayout, "Input and output ndim should same.")?;
+    rstsr_pattern!(axis, 0..ndim, InvalidLayout, "Invalid axis that exceeds ndim.")?;
+    rstsr_assert_eq!(lc.shape()[axis], indices.len(), InvalidLayout, "Invalid index length.")?;
+    rstsr_pattern!(
+        *indices.iter().max().unwrap_or(&0),
+        0..la.shape()[axis],
+        InvalidLayout,
+        "Index out of range.",
+    )?;
+
+    // determine how iteration should be performed
+    let axis_contig_c = lc.stride()[axis] == 1;
+    let size_indices = indices.len();
+
+    if axis_contig_c {
+        let lc_rest = lc.clone().dim_select(axis as isize, 0)?;
+        let la_rest = la.clone().dim_select(axis as isize, 0)?;
+        let layouts_rest = translate_to_col_major(&[&lc_rest, &la_rest], TensorIterOrder::K)?;
+        let lc_rest = &layouts_rest[0];
+        let la_rest = &layouts_rest[1];
+
+        let axis_contig_a = la.stride()[axis] == 1;
+        if axis_contig_a {
+            // both axis are contiguous
+            let func = |(idx_c, idx_a): (usize, usize)| unsafe {
+                let c_ptr = c.as_ptr().add(idx_c) as *mut T;
+                (0..size_indices).for_each(|idx| {
+                    *c_ptr.add(idx) = a[idx_a + indices[idx]].clone();
+                });
+            };
+            let task = || layout_col_major_dim_dispatch_par_2(lc_rest, la_rest, func);
+            pool.map_or_else(task, |pool| pool.install(task))
+        } else {
+            let axis_stride_a = la.stride()[axis];
+            let func = |(idx_c, idx_a): (usize, usize)| unsafe {
+                let c_ptr = c.as_ptr().add(idx_c) as *mut T;
+                (0..size_indices).for_each(|idx| {
+                    let idx_a_out = idx_a as isize + axis_stride_a * indices[idx] as isize;
+                    *c_ptr.add(idx) = a[idx_a_out as usize].clone();
+                });
+            };
+            let task = || layout_col_major_dim_dispatch_par_2(lc_rest, la_rest, func);
+            pool.map_or_else(task, |pool| pool.install(task))
+        }
+    } else {
+        (0..size_indices).try_for_each(|idx| {
+            let lc_selected = lc.dim_select(axis as isize, idx as isize)?;
+            let la_selected = la.dim_select(axis as isize, indices[idx] as isize)?;
+            assign_cpu_rayon(c, &lc_selected, a, &la_selected, pool)
+        })
+    }
+}

--- a/rstsr-native-impl/src/cpu_rayon/mod.rs
+++ b/rstsr-native-impl/src/cpu_rayon/mod.rs
@@ -1,3 +1,4 @@
+pub mod adv_indexing;
 pub mod assignment;
 pub mod matmul_naive;
 pub mod op_tri;

--- a/rstsr-native-impl/src/cpu_serial/adv_indexing.rs
+++ b/rstsr-native-impl/src/cpu_serial/adv_indexing.rs
@@ -1,0 +1,76 @@
+use crate::prelude_dev::*;
+
+pub fn index_select_cpu_serial<T, D>(
+    c: &mut [T],
+    lc: &Layout<D>,
+    a: &[T],
+    la: &Layout<D>,
+    axis: usize,
+    indices: &[usize],
+) -> Result<()>
+where
+    T: Clone,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    // This function need to handle two kind of cases:
+    //
+    // 1. Indexed axis is contiguous
+    //
+    // In this case, all other axes are iterated in general manner, and let the
+    // indexed axis perform `c[...][i] = a[...][indices[i]]` by the inner iteration.
+    //
+    // 2. Indexed axis is not contiguous
+    //
+    // In this case, we just perform `c[i] = a[indices[i]]` at outer iteration.
+
+    // basic check
+    let ndim = lc.ndim();
+    rstsr_assert_eq!(ndim, la.ndim(), InvalidLayout, "Input and output ndim should same.")?;
+    rstsr_pattern!(axis, 0..ndim, InvalidLayout, "Invalid axis that exceeds ndim.")?;
+    rstsr_assert_eq!(lc.shape()[axis], indices.len(), InvalidLayout, "Invalid index length.")?;
+    rstsr_pattern!(
+        *indices.iter().max().unwrap_or(&0),
+        0..la.shape()[axis],
+        InvalidLayout,
+        "Index out of range.",
+    )?;
+
+    // determine how iteration should be performed
+    let axis_contig_c = lc.stride()[axis] == 1;
+    let size_indices = indices.len();
+
+    if axis_contig_c {
+        let lc_rest = lc.clone().dim_select(axis as isize, 0)?;
+        let la_rest = la.clone().dim_select(axis as isize, 0)?;
+        let layouts_rest = translate_to_col_major(&[&lc_rest, &la_rest], TensorIterOrder::K)?;
+        let lc_rest = &layouts_rest[0];
+        let la_rest = &layouts_rest[1];
+
+        let axis_contig_a = la.stride()[axis] == 1;
+        if axis_contig_a {
+            // both axis are contiguous
+            let func = |(idx_c, idx_a): (usize, usize)| {
+                (0..size_indices).for_each(|idx| {
+                    c[idx_c + idx] = a[idx_a + indices[idx]].clone();
+                });
+            };
+            layout_col_major_dim_dispatch_2(lc_rest, la_rest, func)
+        } else {
+            let axis_stride_a = la.stride()[axis];
+            let func = |(idx_c, idx_a): (usize, usize)| {
+                (0..size_indices).for_each(|idx| {
+                    let idx_a_out = idx_a as isize + axis_stride_a * indices[idx] as isize;
+                    c[idx_c + idx] = a[idx_a_out as usize].clone();
+                });
+            };
+            layout_col_major_dim_dispatch_2(lc_rest, la_rest, func)
+        }
+    } else {
+        (0..size_indices).try_for_each(|idx| {
+            let lc_selected = lc.dim_select(axis as isize, idx as isize)?;
+            let la_selected = la.dim_select(axis as isize, indices[idx] as isize)?;
+            assign_cpu_serial(c, &lc_selected, a, &la_selected)
+        })
+    }
+}

--- a/rstsr-native-impl/src/cpu_serial/mod.rs
+++ b/rstsr-native-impl/src/cpu_serial/mod.rs
@@ -1,3 +1,4 @@
+pub mod adv_indexing;
 pub mod assignment;
 pub mod matmul_naive;
 pub mod op_tri;

--- a/rstsr-native-impl/src/prelude_dev.rs
+++ b/rstsr-native-impl/src/prelude_dev.rs
@@ -1,5 +1,6 @@
 pub(crate) use rstsr_common::prelude_dev::*;
 
+pub use crate::cpu_serial::adv_indexing::*;
 pub use crate::cpu_serial::assignment::*;
 pub use crate::cpu_serial::matmul_naive::*;
 pub use crate::cpu_serial::op_tri::*;

--- a/rstsr-native-impl/src/prelude_dev.rs
+++ b/rstsr-native-impl/src/prelude_dev.rs
@@ -10,6 +10,7 @@ pub use crate::cpu_serial::transpose::*;
 
 #[cfg(feature = "rayon")]
 mod cpu_rayon {
+    pub use crate::cpu_rayon::adv_indexing::*;
     pub use crate::cpu_rayon::assignment::*;
     pub use crate::cpu_rayon::matmul_naive::*;
     pub use crate::cpu_rayon::op_tri::*;

--- a/rstsr-openblas/src/rayon_auto_impl/adv_indexing.rs
+++ b/rstsr-openblas/src/rayon_auto_impl/adv_indexing.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/adv_indexing.rs


### PR DESCRIPTION
Current implementation of `index_select` is similar to PyTorch's [`index_select`](https://docs.pytorch.org/docs/stable/generated/torch.index_select.html).

There are still some tasks to do in future:
- index_select with output
- output tensor layout currently determined by device's default FlagOrder; it is better to use `TensorIterOrder::K`, but I haven't realized that.