### PR TITLE
Update v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.3.1 -- 2025-05-16
+
+API Breaking Change:
+- Remove `ge`, `gt`, `ne`, ... in traits `TensorGreaterAPI`, `TensorNotEqualAPI`, ... ([#25](https://github.com/RESTGroup/rstsr/pull/25))
+
+Enhancements:
+- linalg: functions added: slogdet, det, svd, eigvalsh, svdvals, pinv ([#23](https://github.com/RESTGroup/rstsr/pull/23))
+- Summation to boolean tensor ([#25](https://github.com/RESTGroup/rstsr/pull/25))
+- Basic advanced indexing function `index_select` ([#26](https://github.com/RESTGroup/rstsr/pull/26))
+- Added TensorCow support for binary arithmetic operations ([#22](https://github.com/RESTGroup/rstsr/pull/22))
+
+Something for fun:
+- Changed logo to be ABBA-like style ([#24](https://github.com/RESTGroup/rstsr/pull/24))
+
 ## v0.3.0 -- 2025-05-09
 
 API Breaking Change:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -21,15 +21,15 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.0" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.1" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.0" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.0" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.0" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.1" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.1" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.1" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.0" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.0" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.0" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.1" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.1" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.1" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies


### PR DESCRIPTION
## v0.3.1 -- 2025-05-16

API Breaking Change:
- Remove `ge`, `gt`, `ne`, ... in traits `TensorGreaterAPI`, `TensorNotEqualAPI`, ... ([#25](https://github.com/RESTGroup/rstsr/pull/25))

Enhancements:
- linalg: functions added: slogdet, det, svd, eigvalsh, svdvals, pinv ([#23](https://github.com/RESTGroup/rstsr/pull/23))
- Summation to boolean tensor ([#25](https://github.com/RESTGroup/rstsr/pull/25))
- Basic advanced indexing function `index_select` ([#26](https://github.com/RESTGroup/rstsr/pull/26))
- Added TensorCow support for binary arithmetic operations ([#22](https://github.com/RESTGroup/rstsr/pull/22))

Something for fun:
- Changed logo to be ABBA-like style ([#24](https://github.com/RESTGroup/rstsr/pull/24))