### PR TITLE
Faer enhancements

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install rustfmt
+        run: rustup component add rustfmt
       - name: rustfmt
         run: cargo fmt --all -- --check
   
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install rustfmt
+        run: rustup component add clippy
       - name: clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install rustfmt
+      - name: Install clippy
         run: rustup component add clippy
       - name: clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
       - name: rustfmt
         run: cargo fmt --all -- --check
   
@@ -18,5 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
       - name: clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: linalg-test
-        run: cargo test -p rstsr-linalg-traits --test --features="faer"
+        run: cargo test -p rstsr-linalg-traits --test "*" --features="faer"

--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: linalg-test
-        run: cargo test -p rstsr-linalg-traits --lib
+        run: cargo test -p rstsr-linalg-traits --lib --features="faer"

--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -29,10 +29,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: integrationtest
         run: cargo test -p rstsr-core --test "*"
-
-  linalg-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: linalg-test
-        run: cargo test -p rstsr-linalg-traits --test "*" --features="faer"

--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: linalg-test
-        run: cargo test -p rstsr-linalg-traits --lib --features="faer"
+        run: cargo test -p rstsr-linalg-traits --test --features="faer"

--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -29,3 +29,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: integrationtest
         run: cargo test -p rstsr-core --test "*"
+
+  linalg-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: linalg-test
+        run: cargo test -p rstsr-linalg-traits --lib

--- a/.github/workflows/rstsr-linalg-traits.yml
+++ b/.github/workflows/rstsr-linalg-traits.yml
@@ -1,0 +1,30 @@
+name: rstsr-lianlg-traits tests
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  unittests-faer-lianlg:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v2
+    - name: conda environment setup
+      run: |
+        conda init; source $HOME/.bashrc; conda activate
+        conda install -y numpy scipy
+    - name: manifest initialization
+      run: |
+        conda init; source $HOME/.bashrc; conda activate
+        cd rstsr-test-manifest/resources
+        python gen_rand_vec.py
+    - name: validate manifest (func_validation_f64)
+      run: |
+        conda init; source $HOME/.bashrc; conda activate
+        cd rstsr-openblas/tests/test_linalg_func
+        python func_validation_f64.py
+    - name: test faer implementation
+      run: cargo test -p rstsr-linalg-traits --test "*" --features="faer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ duplicate = { version = "2.0" }
 rayon = { version = "1.10" }
 faer = { version = "0.22" }
 faer-ext = { version = "0.6" }
-faer-entity = { version = "0.20" }
 # dev dependencies
 npyz = { version = "0.8", features = ["complex"] }
 anyhow = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ derive_builder = { version = "0.20" }
 duplicate = { version = "2.0" }
 # optional dependencies
 rayon = { version = "1.10" }
-faer = { version = "0.22" }
+faer = { version = "0.22", default-features = false, features = ["rayon", "linalg"] }
 faer-ext = { version = "0.6" }
 # dev dependencies
 npyz = { version = "0.8", features = ["complex"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,16 +37,15 @@ rstsr-lapack-ffi = { version = "0.2.0" }
 rstsr-openblas-ffi = { version = "0.3.1" }
 # basic dependencies
 num = { version = "0.4" }
-thiserror = { version = "1.0" }
 itertools = { version = "0.13" }
 half = { version = "2.4", features = ["num-traits"] }
 derive_builder = { version = "0.20" }
 duplicate = { version = "2.0" }
 # optional dependencies
 rayon = { version = "1.10" }
-faer = { version = "0.19" }
-faer-ext = { version = "0.3" }
-faer-entity = { version = "0.19" }
+faer = { version = "0.22" }
+faer-ext = { version = "0.6" }
+faer-entity = { version = "0.20" }
 # dev dependencies
 npyz = { version = "0.8", features = ["complex"] }
 anyhow = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ cpu-time = { version = "1.0" }
 [profile.coverage]
 inherits = "dev"
 opt-level = 0
+
+[profile.dev]
+opt-level = 2

--- a/rstsr-blas-traits/src/util/util_tensor.rs
+++ b/rstsr-blas-traits/src/util/util_tensor.rs
@@ -1,4 +1,3 @@
-use num::complex::ComplexFloat;
 use rstsr_core::prelude::*;
 use rstsr_core::prelude_dev::*;
 
@@ -11,8 +10,11 @@ pub fn overwritable_convert<T, B, D>(
     a: TensorReference<'_, T, B, D>,
 ) -> Result<TensorMutable<'_, T, B, D>>
 where
-    T: ComplexFloat,
-    B: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, D>,
+    T: Clone,
+    B: DeviceAPI<T, Raw = Vec<T>>
+        + DeviceCreationAnyAPI<T>
+        + OpAssignArbitaryAPI<T, D, D>
+        + OpAssignAPI<T, D>,
     D: DimAPI,
 {
     let order = match (a.f_prefer(), a.c_prefer()) {
@@ -39,8 +41,11 @@ pub fn overwritable_convert_with_order<T, B, D>(
     order: FlagOrder,
 ) -> Result<TensorMutable<'_, T, B, D>>
 where
-    T: ComplexFloat,
-    B: DeviceAPI<T, Raw = Vec<T>> + DeviceComplexFloatAPI<T, D>,
+    T: Clone,
+    B: DeviceAPI<T, Raw = Vec<T>>
+        + DeviceCreationAnyAPI<T>
+        + OpAssignArbitaryAPI<T, D, D>
+        + OpAssignAPI<T, D>,
     D: DimAPI,
 {
     let a = if a.is_ref() {

--- a/rstsr-common/src/alloc_vec.rs
+++ b/rstsr-common/src/alloc_vec.rs
@@ -81,15 +81,12 @@ pub unsafe fn aligned_uninitialized_vec<T, const N: usize>(
     } else {
         let sizeof = core::mem::size_of::<T>();
         let pointer = aligned_alloc(size * sizeof, alignment)?;
-        if pointer.is_none() {
-            // 0-sized case has been handled above, so if pointer is none, it is mostly
-            // out-of-memory error
-            rstsr_raise!(RuntimeError, "Allocation failed (probably due to out-of-memory)")?
-        } else {
-            let pointer = pointer.unwrap();
+        if let Some(pointer) = pointer {
             let mut v = Vec::from_raw_parts(pointer.as_ptr() as *mut T, size, size);
             unsafe { v.set_len(size) };
             return Ok(v);
+        } else {
+            rstsr_raise!(RuntimeError, "Allocation failed (probably due to out-of-memory)")?
         }
     }
 }

--- a/rstsr-common/src/error.rs
+++ b/rstsr-common/src/error.rs
@@ -27,6 +27,7 @@ pub enum Error {
     RayonError(String),
 
     ErrorCode(i32, String),
+    FaerError(String),
 
     Miscellaneous(String),
 }

--- a/rstsr-core/Cargo.toml
+++ b/rstsr-core/Cargo.toml
@@ -19,7 +19,6 @@ half = { workspace = true }
 rayon = { workspace = true, optional = true }
 faer = { workspace = true, optional = true }
 faer-ext = { workspace = true, optional = true }
-faer-entity = { workspace = true, optional = true }
 derive_builder = { workspace = true }
 duplicate = { workspace = true }
 
@@ -35,7 +34,7 @@ cpu-time = { workspace = true }
 default = ["row_major", "aligned_alloc", "faer", "faer_as_default"]
 std = ["rstsr-common/std"]
 rayon = ["dep:rayon", "rstsr-common/rayon", "rstsr-native-impl/rayon"]
-faer = ["rayon", "dep:faer", "dep:faer-ext", "dep:faer-entity"]
+faer = ["rayon", "dep:faer", "dep:faer-ext"]
 faer_as_default = []
 
 # Row-major or Col-major will be contractidary features.

--- a/rstsr-core/src/device_faer/matmul.rs
+++ b/rstsr-core/src/device_faer/matmul.rs
@@ -49,7 +49,7 @@ where
 
     // type check and dispatch
     macro_rules! impl_gemm_dispatch {
-        ($ty: ty, $fn_gemm_name: ident, $fn_syrk_name: ident) => {
+        ($ty: ty) => {
             if (same_type::<TA, $ty>() && same_type::<TB, $ty>() && same_type::<TC, $ty>()) {
                 let a_slice = unsafe { from_raw_parts(a.as_ptr() as *const $ty, a.len()) };
                 let b_slice = unsafe { from_raw_parts(b.as_ptr() as *const $ty, b.len()) };
@@ -57,19 +57,19 @@ where
                 let alpha = unsafe { *(&alpha as *const TC as *const $ty) };
                 let beta = unsafe { *(&beta as *const TC as *const $ty) };
                 if able_syrk {
-                    $fn_syrk_name(c_slice, lc, a_slice, la, alpha, beta, pool)?;
+                    gemm_with_syrk_faer(c_slice, lc, a_slice, la, alpha, beta, pool)?;
                 } else {
-                    $fn_gemm_name(c_slice, lc, a_slice, la, b_slice, lb, alpha, beta, pool)?;
+                    gemm_faer(c_slice, lc, a_slice, la, b_slice, lb, alpha, beta, pool)?;
                 }
                 return Ok(());
             }
         };
     }
 
-    impl_gemm_dispatch!(f32, gemm_faer_f32, gemm_with_syrk_faer_f32);
-    impl_gemm_dispatch!(f64, gemm_faer_f64, gemm_with_syrk_faer_f64);
-    impl_gemm_dispatch!(Complex<f32>, gemm_faer_c32, gemm_with_syrk_faer_c32);
-    impl_gemm_dispatch!(Complex<f64>, gemm_faer_c64, gemm_with_syrk_faer_c64);
+    impl_gemm_dispatch!(f32);
+    impl_gemm_dispatch!(f64);
+    impl_gemm_dispatch!(Complex<f32>);
+    impl_gemm_dispatch!(Complex<f64>);
 
     // not able to be accelarated by faer
     // fallback to naive implementation

--- a/rstsr-core/src/device_faer/matmul_impl.rs
+++ b/rstsr-core/src/device_faer/matmul_impl.rs
@@ -238,8 +238,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use num::complex::ComplexFloat;
-
     use super::*;
     use std::time::Instant;
 
@@ -303,7 +301,7 @@ mod test {
         let c = a % b;
         let sum_c = c.raw().iter().sum::<c32>();
 
-        assert!(sum_c.re() - -78.0 < 1e-5);
-        assert!(sum_c.im() - 270.0 < 1e-5);
+        assert!(sum_c.re - -78.0 < 1e-5);
+        assert!(sum_c.im - 270.0 < 1e-5);
     }
 }

--- a/rstsr-core/src/device_faer/matmul_impl.rs
+++ b/rstsr-core/src/device_faer/matmul_impl.rs
@@ -5,32 +5,30 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::prelude_dev::*;
-use num::complex::Complex;
+use core::num::NonZeroUsize;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use num::Num;
 use rayon::prelude::*;
 
 const PARALLEL_SWITCH: usize = 64;
 
 /* #region gemm */
 
-#[duplicate_item(
-     ty             ty_faer                     fn_name       ;
-    [f32]          [f32]                       [gemm_faer_f32];
-    [f64]          [f64]                       [gemm_faer_f64];
-    [Complex<f32>] [faer::complex_native::c32] [gemm_faer_c32];
-    [Complex<f64>] [faer::complex_native::c64] [gemm_faer_c64];
-)]
-pub fn fn_name(
-    c: &mut [ty],
+pub fn gemm_faer<T>(
+    c: &mut [T],
     lc: &Layout<Ix2>,
-    a: &[ty],
+    a: &[T],
     la: &Layout<Ix2>,
-    b: &[ty],
+    b: &[T],
     lb: &Layout<Ix2>,
-    alpha: ty,
-    beta: ty,
+    alpha: T,
+    beta: T,
     pool: Option<&ThreadPool>,
 ) -> Result<()>
-where {
+where
+    T: ComplexField + Num + MulAssign<T>,
+{
     let nthreads = pool.map_or_else(|| 1, |pool| pool.current_num_threads());
 
     // shape check
@@ -42,8 +40,8 @@ where {
     rstsr_assert_eq!(sc[1], sb[1], InvalidLayout)?;
 
     let faer_a = unsafe {
-        faer::mat::from_raw_parts::<ty_faer>(
-            a.as_ptr().add(la.offset()) as *const ty_faer,
+        MatRef::from_raw_parts(
+            a.as_ptr().add(la.offset()) as *const T,
             la.shape()[0],
             la.shape()[1],
             la.stride()[0],
@@ -51,8 +49,8 @@ where {
         )
     };
     let faer_b = unsafe {
-        faer::mat::from_raw_parts::<ty_faer>(
-            b.as_ptr().add(lb.offset()) as *const ty_faer,
+        MatRef::from_raw_parts(
+            b.as_ptr().add(lb.offset()) as *const T,
             lb.shape()[0],
             lb.shape()[1],
             lb.stride()[0],
@@ -60,22 +58,38 @@ where {
         )
     };
     let faer_c = unsafe {
-        faer::mat::from_raw_parts_mut::<ty_faer>(
-            c.as_mut_ptr().add(lc.offset()) as *mut ty_faer,
+        MatMut::from_raw_parts_mut(
+            c.as_mut_ptr().add(lc.offset()) as *mut T,
             lc.shape()[0],
             lc.shape()[1],
             lc.stride()[0],
             lc.stride()[1],
         )
     };
-    faer::linalg::matmul::matmul(
-        faer_c,
-        faer_a,
-        faer_b,
-        Some(beta.into()),
-        alpha.into(),
-        faer::Parallelism::Rayon(nthreads),
-    );
+
+    if beta == T::zero() {
+        faer::linalg::matmul::matmul(
+            faer_c,
+            faer::Accum::Replace,
+            faer_a,
+            faer_b,
+            alpha,
+            faer::Par::Rayon(NonZeroUsize::new(nthreads).unwrap()),
+        );
+    } else {
+        if beta != T::one() {
+            // perform inplace multiplication
+            op_muta_numb_func_cpu_rayon(c, lc, beta, &mut |vc, vb| *vc *= vb.clone(), pool)?;
+        }
+        faer::linalg::matmul::matmul(
+            faer_c,
+            faer::Accum::Add,
+            faer_a,
+            faer_b,
+            alpha,
+            faer::Par::Rayon(NonZeroUsize::new(nthreads).unwrap()),
+        );
+    }
     return Ok(());
 }
 
@@ -83,23 +97,19 @@ where {
 
 /* #region syrk */
 
-#[duplicate_item(
-     ty             ty_faer                     fn_name       ;
-    [f32]          [f32]                       [syrk_faer_f32];
-    [f64]          [f64]                       [syrk_faer_f64];
-    [Complex<f32>] [faer::complex_native::c32] [syrk_faer_c32];
-    [Complex<f64>] [faer::complex_native::c64] [syrk_faer_c64];
-)]
-pub fn fn_name(
-    c: &mut [ty],
+pub fn syrk_faer<T>(
+    c: &mut [T],
     lc: &Layout<Ix2>,
-    a: &[ty],
+    a: &[T],
     la: &Layout<Ix2>,
     uplo: FlagUpLo,
-    alpha: ty,
-    beta: ty,
+    alpha: T,
+    beta: T,
     pool: Option<&ThreadPool>,
-) -> Result<()> {
+) -> Result<()>
+where
+    T: ComplexField + Num + MulAssign<T>,
+{
     let nthreads = pool.map_or_else(|| 1, |pool| pool.current_num_threads());
 
     // shape check
@@ -109,8 +119,8 @@ pub fn fn_name(
     rstsr_assert_eq!(sc[0], sa[0], InvalidLayout)?;
 
     let faer_a = unsafe {
-        faer::mat::from_raw_parts::<ty_faer>(
-            a.as_ptr().add(la.offset()) as *const ty_faer,
+        MatRef::from_raw_parts(
+            a.as_ptr().add(la.offset()) as *const T,
             la.shape()[0],
             la.shape()[1],
             la.stride()[0],
@@ -118,8 +128,8 @@ pub fn fn_name(
         )
     };
     let faer_at = unsafe {
-        faer::mat::from_raw_parts::<ty_faer>(
-            a.as_ptr().add(la.offset()) as *const ty_faer,
+        MatRef::from_raw_parts(
+            a.as_ptr().add(la.offset()) as *const T,
             la.shape()[1],
             la.shape()[0],
             la.stride()[1],
@@ -127,8 +137,8 @@ pub fn fn_name(
         )
     };
     let faer_c = unsafe {
-        faer::mat::from_raw_parts_mut::<ty_faer>(
-            c.as_mut_ptr().add(lc.offset()) as *mut ty_faer,
+        MatMut::from_raw_parts_mut(
+            c.as_mut_ptr().add(lc.offset()) as *mut T,
             lc.shape()[0],
             lc.shape()[1],
             lc.stride()[0],
@@ -141,36 +151,51 @@ pub fn fn_name(
         FlagUpLo::U => BlockStructure::TriangularUpper,
         FlagUpLo::L => BlockStructure::TriangularLower,
     };
-    faer::linalg::matmul::triangular::matmul(
-        faer_c,
-        block_structure,
-        faer_a,
-        BlockStructure::Rectangular,
-        faer_at,
-        BlockStructure::Rectangular,
-        Some(beta.into()),
-        alpha.into(),
-        faer::Parallelism::Rayon(nthreads),
-    );
+    if beta == T::zero() {
+        faer::linalg::matmul::triangular::matmul(
+            faer_c,
+            block_structure,
+            faer::Accum::Replace,
+            faer_a,
+            BlockStructure::Rectangular,
+            faer_at,
+            BlockStructure::Rectangular,
+            alpha,
+            faer::Par::Rayon(NonZeroUsize::new(nthreads).unwrap()),
+        );
+    } else {
+        if beta != T::one() {
+            // perform inplace multiplication
+            op_muta_numb_func_cpu_rayon(c, lc, beta, &mut |vc, vb| *vc *= vb.clone(), pool)?;
+        }
+        faer::linalg::matmul::triangular::matmul(
+            faer_c,
+            block_structure,
+            faer::Accum::Add,
+            faer_a,
+            BlockStructure::Rectangular,
+            faer_at,
+            BlockStructure::Rectangular,
+            alpha,
+            faer::Par::Rayon(NonZeroUsize::new(nthreads).unwrap()),
+        );
+    }
+
     return Ok(());
 }
 
-#[duplicate_item(
-     ty             fn_name                   gemm_name       syrk_name     ;
-    [f32]          [gemm_with_syrk_faer_f32] [gemm_faer_f32] [syrk_faer_f32];
-    [f64]          [gemm_with_syrk_faer_f64] [gemm_faer_f64] [syrk_faer_f64];
-    [Complex<f32>] [gemm_with_syrk_faer_c32] [gemm_faer_c32] [syrk_faer_c32];
-    [Complex<f64>] [gemm_with_syrk_faer_c64] [gemm_faer_c64] [syrk_faer_c64];
-)]
-pub fn fn_name(
-    c: &mut [ty],
+pub fn gemm_with_syrk_faer<T>(
+    c: &mut [T],
     lc: &Layout<Ix2>,
-    a: &[ty],
+    a: &[T],
     la: &Layout<Ix2>,
-    alpha: ty,
-    beta: ty,
+    alpha: T,
+    beta: T,
     pool: Option<&ThreadPool>,
-) -> Result<()> {
+) -> Result<()>
+where
+    T: ComplexField + Num + MulAssign<T>,
+{
     let nthreads = pool.map_or_else(|| 1, |pool| pool.current_num_threads());
 
     // This function performs c = beta * c + alpha * a * a^T
@@ -178,10 +203,10 @@ pub fn fn_name(
     // full gemm (in order not to allocate a temporary buffer)
     // beta is usually zero, in that normal use case of tensor multiplication
     // usually do not involve output matrix c
-    if beta != <ty>::from(0.0) {
-        gemm_name(c, lc, a, la, a, &la.reverse_axes(), alpha, beta, pool)?;
+    if beta != T::zero() {
+        gemm_faer(c, lc, a, la, a, &la.reverse_axes(), alpha, beta, pool)?;
     } else {
-        syrk_name(c, lc, a, la, FlagUpLo::L, alpha, beta, pool)?;
+        syrk_faer(c, lc, a, la, FlagUpLo::L, alpha, beta, pool)?;
         // symmetrize
         let n = lc.shape()[0];
         if n < PARALLEL_SWITCH || nthreads == 1 {
@@ -189,7 +214,7 @@ pub fn fn_name(
                 for j in 0..i {
                     let idx_ij = unsafe { lc.index_uncheck(&[i, j]) as usize };
                     let idx_ji = unsafe { lc.index_uncheck(&[j, i]) as usize };
-                    c[idx_ji] = c[idx_ij];
+                    c[idx_ji] = c[idx_ij].clone();
                 }
             }
         } else {
@@ -199,8 +224,8 @@ pub fn fn_name(
                     (0..i).for_each(|j| unsafe {
                         let idx_ij = lc.index_uncheck(&[i, j]) as usize;
                         let idx_ji = lc.index_uncheck(&[j, i]) as usize;
-                        let c_ptr_ji = c.as_ptr().add(idx_ji) as *mut ty;
-                        *c_ptr_ji = c[idx_ij];
+                        let c_ptr_ji = c.as_ptr().add(idx_ji) as *mut T;
+                        *c_ptr_ji = c[idx_ij].clone();
                     });
                 });
             });
@@ -235,13 +260,13 @@ mod test {
         let pool = Some(&pool);
 
         let start = Instant::now();
-        gemm_faer_f64(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        gemm_faer(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
         println!("time: {:?}", start.elapsed());
         let start = Instant::now();
-        gemm_faer_f64(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        gemm_faer(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
         println!("time: {:?}", start.elapsed());
         let start = Instant::now();
-        gemm_faer_f64(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        gemm_faer(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
         println!("time: {:?}", start.elapsed());
     }
 
@@ -253,7 +278,7 @@ mod test {
         let lc = [2, 2].c();
         let pool = rayon::ThreadPoolBuilder::new().num_threads(16).build().unwrap();
         let pool = Some(&pool);
-        syrk_faer_f64(&mut c, &lc, &a, &la, FlagUpLo::L, 2.0, 1.0, pool).unwrap();
+        syrk_faer(&mut c, &lc, &a, &la, FlagUpLo::L, 2.0, 1.0, pool).unwrap();
         println!("{c:?}");
     }
 

--- a/rstsr-linalg-traits/Cargo.toml
+++ b/rstsr-linalg-traits/Cargo.toml
@@ -16,3 +16,11 @@ rstsr-dtype-traits = { workspace = true }
 num = { workspace = true }
 duplicate = { workspace = true }
 derive_builder = { workspace = true }
+faer = { workspace = true, optional = true }
+
+[dev-dependencies]
+rstsr = { path = "../rstsr", default-features = false, features = ["linalg"] }
+rstsr-test-manifest = { workspace = true }
+
+[features]
+faer = ["rstsr-core/faer", "dep:faer"]

--- a/rstsr-linalg-traits/src/faer_impl/cholesky.rs
+++ b/rstsr-linalg-traits/src/faer_impl/cholesky.rs
@@ -1,4 +1,4 @@
-use crate::prelude_dev::*;
+use crate::traits_def::CholeskyAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
@@ -108,12 +108,4 @@ where
         let a = self;
         CholeskyAPI::<DeviceFaer>::cholesky_f((a, None))
     }
-}
-
-#[test]
-fn playground() {
-    let a = vec![1.0, 0.0, 1.0, 0.0, 4.0, 2.0, 1.0, 2.0, 9.0];
-    let a = asarray((a, &DeviceFaer::default())).into_shape([3, 3]);
-    let l = cholesky_f((&a, Some(Lower))).unwrap();
-    println!("{l:?}");
 }

--- a/rstsr-linalg-traits/src/faer_impl/cholesky.rs
+++ b/rstsr-linalg-traits/src/faer_impl/cholesky.rs
@@ -1,0 +1,109 @@
+use crate::prelude_dev::*;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_core::prelude_dev::*;
+
+pub fn faer_impl_cholesky_f<T>(
+    a: TensorView<'_, T, DeviceFaer, Ix2>,
+    uplo: Option<FlagUpLo>,
+) -> Result<Tensor<T, DeviceFaer, Ix2>>
+where
+    T: ComplexField,
+{
+    let uplo = uplo.unwrap_or(match a.device().default_order() {
+        RowMajor => Lower,
+        ColMajor => Upper,
+    });
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+    let faer_uplo = match uplo {
+        Lower => faer::Side::Lower,
+        Upper => faer::Side::Upper,
+    };
+
+    // llt computation
+    let result =
+        faer_a.llt(faer_uplo).map_err(|e| rstsr_error!(FaerError, "Faer cholesky error: {e}"))?;
+
+    // faer always returns lower triangular matrix
+    let result = match uplo {
+        Lower => result.L(),
+        Upper => result.L().transpose(),
+    };
+    // convert to rstsr tensor with certain layout
+    let result = result.into_rstsr().into_contig(a.device().default_order());
+    Ok(result)
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> CholeskyAPI<DeviceFaer> for (Tr, Option<FlagUpLo>)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, D>;
+    fn cholesky_f(self) -> Result<Self::Out> {
+        let (a, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a = a.view().into_dim::<Ix2>();
+        let result = faer_impl_cholesky_f(a.view(), uplo)?;
+        let result = result.into_dim::<IxD>().into_dim::<D>();
+        Ok(result)
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> CholeskyAPI<DeviceFaer> for (Tr, FlagUpLo)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, D>;
+    fn cholesky_f(self) -> Result<Self::Out> {
+        let (a, uplo) = self;
+        CholeskyAPI::<DeviceFaer>::cholesky_f((a, Some(uplo)))
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> CholeskyAPI<DeviceFaer> for Tr
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, D>;
+    fn cholesky_f(self) -> Result<Self::Out> {
+        let a = self;
+        CholeskyAPI::<DeviceFaer>::cholesky_f((a, None))
+    }
+}
+
+#[test]
+fn playground() {
+    let a = vec![1.0, 0.0, 1.0, 0.0, 4.0, 2.0, 1.0, 2.0, 9.0];
+    let a = asarray((a, &DeviceFaer::default())).into_shape([3, 3]);
+    let l = cholesky_f((&a, Some(Lower))).unwrap();
+    println!("{l:?}");
+}

--- a/rstsr-linalg-traits/src/faer_impl/det.rs
+++ b/rstsr-linalg-traits/src/faer_impl/det.rs
@@ -2,11 +2,10 @@ use crate::traits_def::DetAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
-use rstsr_dtype_traits::ReImAPI;
 
 pub fn faer_impl_det_f<T>(a: TensorView<'_, T, DeviceFaer, Ix2>) -> Result<T::Real>
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
 {
     // set parallel mode
     let pool = a.device().get_current_pool();
@@ -26,7 +25,7 @@ where
 
     // det computation
     let result = faer_a.determinant();
-    let result = result.real();
+    let result = T::real_part_impl(&result);
 
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
@@ -42,7 +41,7 @@ where
 )]
 impl<ImplType> DetAPI<DeviceFaer> for Tr
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
     D: DimAPI,
 {
     type Out = T::Real;

--- a/rstsr-linalg-traits/src/faer_impl/det.rs
+++ b/rstsr-linalg-traits/src/faer_impl/det.rs
@@ -1,9 +1,8 @@
+use crate::traits_def::DetAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
 use rstsr_dtype_traits::ReImAPI;
-
-use crate::traits_def::DetAPI;
 
 pub fn faer_impl_det_f<T>(a: TensorView<'_, T, DeviceFaer, Ix2>) -> Result<T::Real>
 where

--- a/rstsr-linalg-traits/src/faer_impl/det.rs
+++ b/rstsr-linalg-traits/src/faer_impl/det.rs
@@ -1,0 +1,62 @@
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_core::prelude_dev::*;
+use rstsr_dtype_traits::ReImAPI;
+
+use crate::traits_def::DetAPI;
+
+pub fn faer_impl_det_f<T>(a: TensorView<'_, T, DeviceFaer, Ix2>) -> Result<T::Real>
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+{
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+
+    // det computation
+    let result = faer_a.determinant();
+    let result = result.real();
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    return Ok(result);
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> DetAPI<DeviceFaer> for Tr
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+    D: DimAPI,
+{
+    type Out = T::Real;
+    fn det_f(self) -> Result<Self::Out> {
+        rstsr_assert_eq!(
+            self.ndim(),
+            2,
+            InvalidLayout,
+            "Currently we can only handle 2-D matrix."
+        )?;
+        let a = self;
+        let a_view = a.view().into_dim::<Ix2>();
+        let result = faer_impl_det_f(a_view.into())?;
+        Ok(result)
+    }
+}

--- a/rstsr-linalg-traits/src/faer_impl/eigh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigh.rs
@@ -9,7 +9,7 @@ pub fn faer_impl_eigh_f<T>(
     uplo: Option<FlagUpLo>,
 ) -> Result<(Tensor<T::Real, DeviceFaer, Ix1>, Tensor<T, DeviceFaer, Ix2>)>
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
 {
     // TODO: It seems faer is suspeciously slow on eigh function?
     // However, tests shows that results are correct.
@@ -45,7 +45,7 @@ where
 
     // convert eigenvalues to real
     let eigenvalues: TensorView<T, DeviceFaer, _> = result.S().column_vector().into_rstsr();
-    let eigenvalues = eigenvalues.real();
+    let eigenvalues = eigenvalues.mapv(|v| T::real_part_impl(&v));
     let eigenvectors = result.U().into_rstsr().into_contig(a.device().default_order());
 
     // restore parallel mode
@@ -62,7 +62,7 @@ where
 )]
 impl<ImplType> EighAPI<DeviceFaer> for (Tr, Option<FlagUpLo>)
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
     D: DimAPI + DimSmallerOneAPI,
     D::SmallerOne: DimAPI,
 {

--- a/rstsr-linalg-traits/src/faer_impl/eigh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigh.rs
@@ -1,9 +1,8 @@
+use crate::traits_def::{EighAPI, EighResult};
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
 use rstsr_dtype_traits::ReImAPI;
-
-use crate::traits_def::{EighAPI, EighResult};
 
 pub fn faer_impl_eigh_f<T>(
     a: TensorView<'_, T, DeviceFaer, Ix2>,

--- a/rstsr-linalg-traits/src/faer_impl/eigh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigh.rs
@@ -1,0 +1,124 @@
+use faer::linalg::solvers::SelfAdjointEigen;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_core::prelude_dev::*;
+use rstsr_dtype_traits::ReImAPI;
+
+use crate::traits_def::{EighAPI, EighResult};
+
+pub fn faer_impl_eigh_f<T>(
+    a: TensorView<'_, T, DeviceFaer, Ix2>,
+    uplo: Option<FlagUpLo>,
+) -> Result<(Tensor<T::Real, DeviceFaer, Ix1>, Tensor<T, DeviceFaer, Ix2>)>
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+{
+    // TODO: It seems faer is suspeciously slow on eigh function?
+    // However, tests shows that results are correct.
+
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    let uplo = uplo.unwrap_or(match a.device().default_order() {
+        RowMajor => Lower,
+        ColMajor => Upper,
+    });
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+    let faer_uplo = match uplo {
+        Lower => faer::Side::Lower,
+        Upper => faer::Side::Upper,
+    };
+
+    // eigen value computation
+    let time = std::time::Instant::now();
+    let result = SelfAdjointEigen::new(faer_a, faer_uplo)
+        .map_err(|e| rstsr_error!(FaerError, "Faer SelfAdjointEigen error: {e:?}"))?;
+    println!("Faer eig time: {:?}", time.elapsed());
+
+    // convert eigenvalues to real
+    let time = std::time::Instant::now();
+    let eigenvalues: TensorView<T, DeviceFaer, _> = result.S().column_vector().into_rstsr();
+    let eigenvalues = eigenvalues.real();
+    let eigenvectors = result.U().into_rstsr().into_contig(a.device().default_order());
+    println!("RSTSR convert time: {:?}", time.elapsed());
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    return Ok((eigenvalues, eigenvectors));
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> EighAPI<DeviceFaer> for (Tr, Option<FlagUpLo>)
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
+    fn eigh_f(self) -> Result<Self::Out> {
+        let (a, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a = a.view().into_dim::<Ix2>();
+        let result = faer_impl_eigh_f(a.view(), uplo)?;
+        let result = EighResult {
+            eigenvalues: result.0.into_dim::<IxD>().into_dim::<D::SmallerOne>(),
+            eigenvectors: result.1.into_owned().into_dim::<IxD>().into_dim::<D>(),
+        };
+        Ok(result)
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> EighAPI<DeviceFaer> for (Tr, FlagUpLo)
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
+    fn eigh_f(self) -> Result<Self::Out> {
+        let (a, uplo) = self;
+        EighAPI::<DeviceFaer>::eigh_f((a, Some(uplo)))
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> EighAPI<DeviceFaer> for Tr
+where
+    T: ComplexField + ReImAPI<Out = T::Real>,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+{
+    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
+    fn eigh_f(self) -> Result<Self::Out> {
+        let a = self;
+        EighAPI::<DeviceFaer>::eigh_f((a, None))
+    }
+}

--- a/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
@@ -1,16 +1,15 @@
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
-use rstsr_dtype_traits::ReImAPI;
 
-use crate::traits_def::{EighAPI, EighResult};
+use crate::traits_def::EigvalshAPI;
 
-pub fn faer_impl_eigh_f<T>(
+pub fn faer_impl_eigvalsh_f<T>(
     a: TensorView<'_, T, DeviceFaer, Ix2>,
     uplo: Option<FlagUpLo>,
-) -> Result<(Tensor<T::Real, DeviceFaer, Ix1>, Tensor<T, DeviceFaer, Ix2>)>
+) -> Result<Tensor<T::Real, DeviceFaer, Ix1>>
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
 {
     // TODO: It seems faer is suspeciously slow on eigh function?
     // However, tests shows that results are correct.
@@ -41,18 +40,14 @@ where
 
     // eigen value computation
     let result = faer_a
-        .self_adjoint_eigen(faer_uplo)
+        .self_adjoint_eigenvalues(faer_uplo)
         .map_err(|e| rstsr_error!(FaerError, "Faer SelfAdjointEigen error: {e:?}"))?;
-
-    // convert eigenvalues to real
-    let eigenvalues: TensorView<T, DeviceFaer, _> = result.S().column_vector().into_rstsr();
-    let eigenvalues = eigenvalues.real();
-    let eigenvectors = result.U().into_rstsr().into_contig(a.device().default_order());
+    let eigenvalues = asarray((result, a.device())).into_dim::<Ix1>();
 
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok((eigenvalues, eigenvectors));
+    return Ok(eigenvalues);
 }
 
 #[duplicate_item(
@@ -61,22 +56,19 @@ where
    [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
    [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
 )]
-impl<ImplType> EighAPI<DeviceFaer> for (Tr, Option<FlagUpLo>)
+impl<ImplType> EigvalshAPI<DeviceFaer> for (Tr, Option<FlagUpLo>)
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
     D: DimAPI + DimSmallerOneAPI,
     D::SmallerOne: DimAPI,
 {
-    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
-    fn eigh_f(self) -> Result<Self::Out> {
+    type Out = Tensor<T::Real, DeviceFaer, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
         let (a, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
         let a = a.view().into_dim::<Ix2>();
-        let result = faer_impl_eigh_f(a.view(), uplo)?;
-        let result = EighResult {
-            eigenvalues: result.0.into_dim::<IxD>().into_dim::<D::SmallerOne>(),
-            eigenvectors: result.1.into_owned().into_dim::<IxD>().into_dim::<D>(),
-        };
+        let result = faer_impl_eigvalsh_f(a.view(), uplo)?;
+        let result = result.into_dim::<IxD>().into_dim::<D::SmallerOne>();
         Ok(result)
     }
 }
@@ -87,16 +79,16 @@ where
    [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
    [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
 )]
-impl<ImplType> EighAPI<DeviceFaer> for (Tr, FlagUpLo)
+impl<ImplType> EigvalshAPI<DeviceFaer> for (Tr, FlagUpLo)
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
     D: DimAPI + DimSmallerOneAPI,
     D::SmallerOne: DimAPI,
 {
-    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
-    fn eigh_f(self) -> Result<Self::Out> {
+    type Out = Tensor<T::Real, DeviceFaer, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
         let (a, uplo) = self;
-        EighAPI::<DeviceFaer>::eigh_f((a, Some(uplo)))
+        EigvalshAPI::<DeviceFaer>::eigvalsh_f((a, Some(uplo)))
     }
 }
 
@@ -106,15 +98,15 @@ where
    [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
    [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
 )]
-impl<ImplType> EighAPI<DeviceFaer> for Tr
+impl<ImplType> EigvalshAPI<DeviceFaer> for Tr
 where
-    T: ComplexField + ReImAPI<Out = T::Real>,
+    T: ComplexField,
     D: DimAPI + DimSmallerOneAPI,
     D::SmallerOne: DimAPI,
 {
-    type Out = EighResult<Tensor<T::Real, DeviceFaer, D::SmallerOne>, Tensor<T, DeviceFaer, D>>;
-    fn eigh_f(self) -> Result<Self::Out> {
+    type Out = Tensor<T::Real, DeviceFaer, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
         let a = self;
-        EighAPI::<DeviceFaer>::eigh_f((a, None))
+        EigvalshAPI::<DeviceFaer>::eigvalsh_f((a, None))
     }
 }

--- a/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
@@ -1,8 +1,7 @@
+use crate::traits_def::EigvalshAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
-
-use crate::traits_def::EigvalshAPI;
 
 pub fn faer_impl_eigvalsh_f<T>(
     a: TensorView<'_, T, DeviceFaer, Ix2>,

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -1,5 +1,5 @@
 use crate::traits_def::InvAPI;
-use faer::linalg::solvers::{DenseSolveCore, Svd};
+use faer::linalg::solvers::DenseSolveCore;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
@@ -27,8 +27,7 @@ where
     };
 
     // det computation
-    let svd_result =
-        Svd::new(faer_a).map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
+    let svd_result = faer_a.svd().map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
     let result = svd_result.inverse();
 
     // convert to rstsr tensor with certain layout

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -1,9 +1,8 @@
+use crate::traits_def::InvAPI;
 use faer::linalg::solvers::{DenseSolveCore, Svd};
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use rstsr_core::prelude_dev::*;
-
-use crate::traits_def::InvAPI;
 
 pub fn faer_impl_inv_f<T>(
     a: TensorView<'_, T, DeviceFaer, Ix2>,

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -1,0 +1,68 @@
+use faer::linalg::solvers::{DenseSolveCore, Svd};
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_core::prelude_dev::*;
+
+use crate::traits_def::InvAPI;
+
+pub fn faer_impl_inv_f<T>(
+    a: TensorView<'_, T, DeviceFaer, Ix2>,
+) -> Result<Tensor<T, DeviceFaer, Ix2>>
+where
+    T: ComplexField,
+{
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+
+    // det computation
+    let svd_result =
+        Svd::new(faer_a).map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
+    let result = svd_result.inverse();
+
+    // convert to rstsr tensor with certain layout
+    let result = result.as_ref().into_rstsr().into_contig(a.device().default_order());
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    return Ok(result);
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> InvAPI<DeviceFaer> for Tr
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, Ix2>;
+    fn inv_f(self) -> Result<Self::Out> {
+        rstsr_assert_eq!(
+            self.ndim(),
+            2,
+            InvalidLayout,
+            "Currently we can only handle 2-D matrix."
+        )?;
+        let a = self;
+        let a_view = a.view().into_dim::<Ix2>();
+        let result = faer_impl_inv_f(a_view.into())?;
+        Ok(result)
+    }
+}

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -50,7 +50,7 @@ where
     T: ComplexField,
     D: DimAPI,
 {
-    type Out = Tensor<T, DeviceFaer, Ix2>;
+    type Out = Tensor<T, DeviceFaer, D>;
     fn inv_f(self) -> Result<Self::Out> {
         rstsr_assert_eq!(
             self.ndim(),
@@ -60,7 +60,7 @@ where
         )?;
         let a = self;
         let a_view = a.view().into_dim::<Ix2>();
-        let result = faer_impl_inv_f(a_view.into())?;
-        Ok(result)
+        let result = faer_impl_inv_f(a_view)?;
+        Ok(result.into_dim::<IxD>().into_dim::<D>())
     }
 }

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -1,3 +1,4 @@
 pub mod cholesky;
 pub mod det;
 pub mod eigh;
+pub mod eigvalsh;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -4,5 +4,6 @@ pub mod eigh;
 pub mod eigvalsh;
 pub mod inv;
 pub mod pinv;
+pub mod solve_general;
 pub mod svd;
 pub mod svdvals;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -4,3 +4,4 @@ pub mod eigh;
 pub mod eigvalsh;
 pub mod inv;
 pub mod pinv;
+pub mod svd;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -1,0 +1,1 @@
+pub mod cholesky;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -1,2 +1,3 @@
 pub mod cholesky;
+pub mod det;
 pub mod eigh;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -1,1 +1,2 @@
 pub mod cholesky;
+pub mod eigh;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -3,3 +3,4 @@ pub mod det;
 pub mod eigh;
 pub mod eigvalsh;
 pub mod inv;
+pub mod pinv;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -2,3 +2,4 @@ pub mod cholesky;
 pub mod det;
 pub mod eigh;
 pub mod eigvalsh;
+pub mod inv;

--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -5,3 +5,4 @@ pub mod eigvalsh;
 pub mod inv;
 pub mod pinv;
 pub mod svd;
+pub mod svdvals;

--- a/rstsr-linalg-traits/src/faer_impl/pinv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/pinv.rs
@@ -1,5 +1,4 @@
 use crate::traits_def::{PinvAPI, PinvResult};
-use faer::linalg::solvers::Svd;
 use faer::prelude::*;
 use faer::traits::ComplexField;
 use num::{complex::ComplexFloat, Bounded, Float, FromPrimitive, Zero};
@@ -47,7 +46,7 @@ where
 
     // svd computation
     let svd_result =
-        Svd::new_thin(faer_a).map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
+        faer_a.thin_svd().map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
     let (u, s, v) = (svd_result.U(), svd_result.S(), svd_result.V());
 
     // return to rstsr tensors

--- a/rstsr-linalg-traits/src/faer_impl/pinv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/pinv.rs
@@ -1,0 +1,126 @@
+use crate::traits_def::{PinvAPI, PinvResult};
+use faer::linalg::solvers::Svd;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use num::{complex::ComplexFloat, Bounded, Float, FromPrimitive, Zero};
+use rstsr_core::prelude_dev::*;
+use rstsr_dtype_traits::MinMaxAPI;
+
+pub fn faer_impl_pinv_f<T>(
+    a: TensorView<'_, T, DeviceFaer, Ix2>,
+    atol: Option<<T as ComplexField>::Real>,
+    rtol: Option<<T as ComplexField>::Real>,
+) -> Result<PinvResult<Tensor<T, DeviceFaer, Ix2>>>
+where
+    T: ComplexField
+        + ComplexFloat<Real = <T as ComplexField>::Real>
+        + DivAssign<<T as ComplexField>::Real>
+        + Send
+        + Sync
+        + 'static,
+    <T as ComplexField>::Real: Float + FromPrimitive + Zero + Send + Sync + MinMaxAPI + Bounded,
+{
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    // compute rcond value
+    let atol = atol.unwrap_or(<T as ComplexField>::Real::zero());
+    let rtol = rtol.unwrap_or({
+        let [m, n]: [usize; 2] = *a.shape();
+        let mnmax = <T as ComplexField>::Real::from_usize(Ord::max(m, n)).unwrap();
+        mnmax * <T as ComplexField>::Real::epsilon()
+    });
+
+    // transform to faer matrix
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+
+    // svd computation
+    let svd_result =
+        Svd::new_thin(faer_a).map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
+    let (u, s, v) = (svd_result.U(), svd_result.S(), svd_result.V());
+
+    // return to rstsr tensors
+    let u = u.into_rstsr().into_owned();
+    let s = s.column_vector().into_rstsr();
+    let v = v.into_rstsr();
+
+    // compute pinv
+    let s = s.mapv(|x| x.re());
+    let maxs = s.max_all();
+    let val = atol + rtol * maxs;
+    let rank = s.raw().iter().take_while(|&&x| x > val).count();
+    let mut u = u.into_slice((.., ..rank));
+    u /= s.i((None, ..rank));
+    let a_pinv = v.i((.., ..rank)) % u.t();
+    let pinv = a_pinv.conj().into_dim::<Ix2>();
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    Ok(PinvResult { pinv, rank })
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> PinvAPI<DeviceFaer> for (Tr, <T as ComplexField>::Real, <T as ComplexField>::Real)
+where
+    T: ComplexField
+        + ComplexFloat<Real = <T as ComplexField>::Real>
+        + DivAssign<<T as ComplexField>::Real>
+        + Send
+        + Sync
+        + 'static,
+    <T as ComplexField>::Real: Float + FromPrimitive + Zero + Send + Sync + MinMaxAPI + Bounded,
+    D: DimAPI,
+{
+    type Out = PinvResult<Tensor<T, DeviceFaer, Ix2>>;
+    fn pinv_f(self) -> Result<Self::Out> {
+        let (a, atol, rtol) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let result = faer_impl_pinv_f(a_view, Some(atol), Some(rtol))?;
+        Ok(result)
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> PinvAPI<DeviceFaer> for Tr
+where
+    T: ComplexField
+        + ComplexFloat<Real = <T as ComplexField>::Real>
+        + DivAssign<<T as ComplexField>::Real>
+        + Send
+        + Sync
+        + 'static,
+    <T as ComplexField>::Real: Float + FromPrimitive + Zero + Send + Sync + MinMaxAPI + Bounded,
+    D: DimAPI,
+{
+    type Out = PinvResult<Tensor<T, DeviceFaer, Ix2>>;
+    fn pinv_f(self) -> Result<Self::Out> {
+        let a = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let result = faer_impl_pinv_f(a_view, None, None)?;
+        Ok(result)
+    }
+}

--- a/rstsr-linalg-traits/src/faer_impl/solve_general.rs
+++ b/rstsr-linalg-traits/src/faer_impl/solve_general.rs
@@ -1,0 +1,150 @@
+use crate::traits_def::SolveGeneralAPI;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_blas_traits::prelude_dev::*;
+use rstsr_core::prelude_dev::*;
+
+pub fn faer_impl_solve_general_f<'b, T>(
+    a: TensorReference<'_, T, DeviceFaer, Ix2>,
+    b: TensorReference<'b, T, DeviceFaer, Ix2>,
+) -> Result<TensorMutable<'b, T, DeviceFaer, Ix2>>
+where
+    T: ComplexField,
+{
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+
+    // solve linear system
+    let svd_result = faer_a.svd().map_err(|e| rstsr_error!(FaerError, "Faer SVD error: {e:?}"))?;
+
+    // handle b for mutable
+    let mut b = overwritable_convert(b)?;
+    let mut b_view = b.view_mut().into_dim::<Ix2>();
+    let faer_b = unsafe {
+        MatMut::from_raw_parts_mut(
+            b_view.as_mut_ptr().add(b_view.offset()),
+            b_view.shape()[0],
+            b_view.shape()[1],
+            b_view.stride()[0],
+            b_view.stride()[1],
+        )
+    };
+
+    svd_result.solve_in_place(faer_b);
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    Ok(b.clone_to_mut())
+}
+
+#[duplicate_item(
+    ImplType                                                       TrA                                TrB                              ;
+   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceFaer, D>] [&TensorAny<Rb, T, DeviceFaer, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceFaer, D> ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceFaer, D>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D,                                                       ] [TensorView<'_, T, DeviceFaer, D>] [TensorView<'_, T, DeviceFaer, D>];
+)]
+impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, D>;
+    fn solve_general_f(self) -> Result<Self::Out> {
+        let (a, b) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = b.view().into_dim::<Ix2>();
+        let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
+        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+    }
+}
+
+#[duplicate_item(
+    ImplType                              TrA                                TrB                             ;
+   ['b, T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ] [TensorMut<'b, T, DeviceFaer, D>];
+   ['b, T, D,                          ] [TensorView<'_, T, DeviceFaer, D>] [TensorMut<'b, T, DeviceFaer, D>];
+   [    T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ] [Tensor<T, DeviceFaer, D>       ];
+   [    T, D,                          ] [TensorView<'_, T, DeviceFaer, D>] [Tensor<T, DeviceFaer, D>       ];
+)]
+impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = TrB;
+    fn solve_general_f(self) -> Result<Self::Out> {
+        let (a, mut b) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = b.view_mut().into_dim::<Ix2>();
+        let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
+        result.clone_to_mut();
+        Ok(b)
+    }
+}
+
+#[duplicate_item(
+    ImplType                          TrA                               TrB                              ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceFaer, D>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceFaer, D>       ] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [TensorView<'_, T, DeviceFaer, D>];
+)]
+impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, D>;
+    fn solve_general_f(self) -> Result<Self::Out> {
+        let (mut a, b) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let b_view = b.view().into_dim::<Ix2>();
+        let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
+        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+    }
+}
+
+#[duplicate_item(
+    ImplType                              TrA                               TrB                             ;
+   ['b, T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [TensorMut<'b, T, DeviceFaer, D>];
+   [    T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [Tensor<T, DeviceFaer, D>       ];
+   ['b, T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [TensorMut<'b, T, DeviceFaer, D>];
+   [    T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [Tensor<T, DeviceFaer, D>       ];
+)]
+impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = TrB;
+    fn solve_general_f(self) -> Result<Self::Out> {
+        let (mut a, mut b) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let b_view = b.view_mut().into_dim::<Ix2>();
+        let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
+        result.clone_to_mut();
+        Ok(b)
+    }
+}

--- a/rstsr-linalg-traits/src/faer_impl/svd.rs
+++ b/rstsr-linalg-traits/src/faer_impl/svd.rs
@@ -65,19 +65,25 @@ where
 impl<ImplType> SVDAPI<DeviceFaer> for (Tr, bool)
 where
     T: ComplexField,
-    D: DimAPI,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
 {
     type Out = SVDResult<
-        Tensor<T, DeviceFaer, Ix2>,
-        Tensor<T::Real, DeviceFaer, Ix1>,
-        Tensor<T, DeviceFaer, Ix2>,
+        Tensor<T, DeviceFaer, D>,
+        Tensor<T::Real, DeviceFaer, D::SmallerOne>,
+        Tensor<T, DeviceFaer, D>,
     >;
     fn svd_f(self) -> Result<Self::Out> {
         let (a, full_matrices) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
         let a_view = a.view().into_dim::<Ix2>();
-        let result = faer_impl_svd_f(a_view.into(), full_matrices)?;
-        Ok(result)
+        let result = faer_impl_svd_f(a_view, full_matrices)?;
+        // convert dimensions
+        Ok(SVDResult {
+            u: result.u.into_dim::<IxD>().into_dim::<D>(),
+            s: result.s.into_dim::<IxD>().into_dim::<D::SmallerOne>(),
+            vt: result.vt.into_dim::<IxD>().into_dim::<D>(),
+        })
     }
 }
 
@@ -90,12 +96,13 @@ where
 impl<ImplType> SVDAPI<DeviceFaer> for Tr
 where
     T: ComplexField,
-    D: DimAPI,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
 {
     type Out = SVDResult<
-        Tensor<T, DeviceFaer, Ix2>,
-        Tensor<T::Real, DeviceFaer, Ix1>,
-        Tensor<T, DeviceFaer, Ix2>,
+        Tensor<T, DeviceFaer, D>,
+        Tensor<T::Real, DeviceFaer, D::SmallerOne>,
+        Tensor<T, DeviceFaer, D>,
     >;
     fn svd_f(self) -> Result<Self::Out> {
         SVDAPI::<DeviceFaer>::svd_f((self, true))

--- a/rstsr-linalg-traits/src/faer_impl/svd.rs
+++ b/rstsr-linalg-traits/src/faer_impl/svd.rs
@@ -1,0 +1,103 @@
+use crate::traits_def::{SVDResult, SVDAPI};
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use rstsr_core::prelude_dev::*;
+
+pub fn faer_impl_svd_f<T>(
+    a: TensorView<'_, T, DeviceFaer, Ix2>,
+    full_matrices: bool,
+) -> Result<
+    SVDResult<
+        Tensor<T, DeviceFaer, Ix2>,
+        Tensor<T::Real, DeviceFaer, Ix1>,
+        Tensor<T, DeviceFaer, Ix2>,
+    >,
+>
+where
+    T: ComplexField,
+{
+    // set parallel mode
+    let pool = a.device().get_current_pool();
+    let faer_par_orig = faer::get_global_parallelism();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+    faer::set_global_parallelism(faer_par);
+
+    let faer_a = unsafe {
+        MatRef::from_raw_parts(
+            a.as_ptr().add(a.offset()),
+            a.shape()[0],
+            a.shape()[1],
+            a.stride()[0],
+            a.stride()[1],
+        )
+    };
+
+    // svd computation
+    let svd_result = match full_matrices {
+        true => faer_a.svd().map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?,
+        false => faer_a.thin_svd().map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?,
+    };
+    let (u, s, v) = (svd_result.U(), svd_result.S(), svd_result.V());
+
+    // return to rstsr tensors
+    let u = u.into_rstsr().into_owned();
+    let s = s.column_vector().into_rstsr();
+    let v = v.into_rstsr();
+
+    let result = SVDResult {
+        u: u.into_contig(a.device().default_order()),
+        s: s.mapv(|v| T::real_part_impl(&v)).into_contig(a.device().default_order()),
+        vt: v.into_reverse_axes().into_contig(a.device().default_order()),
+    };
+
+    // restore parallel mode
+    faer::set_global_parallelism(faer_par_orig);
+
+    return Ok(result);
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> SVDAPI<DeviceFaer> for (Tr, bool)
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = SVDResult<
+        Tensor<T, DeviceFaer, Ix2>,
+        Tensor<T::Real, DeviceFaer, Ix1>,
+        Tensor<T, DeviceFaer, Ix2>,
+    >;
+    fn svd_f(self) -> Result<Self::Out> {
+        let (a, full_matrices) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let result = faer_impl_svd_f(a_view.into(), full_matrices)?;
+        Ok(result)
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceFaer, D>];
+   [T, D                           ] [Tensor<T, DeviceFaer, D>        ];
+)]
+impl<ImplType> SVDAPI<DeviceFaer> for Tr
+where
+    T: ComplexField,
+    D: DimAPI,
+{
+    type Out = SVDResult<
+        Tensor<T, DeviceFaer, Ix2>,
+        Tensor<T::Real, DeviceFaer, Ix1>,
+        Tensor<T, DeviceFaer, Ix2>,
+    >;
+    fn svd_f(self) -> Result<Self::Out> {
+        SVDAPI::<DeviceFaer>::svd_f((self, true))
+    }
+}

--- a/rstsr-linalg-traits/src/lib.rs
+++ b/rstsr-linalg-traits/src/lib.rs
@@ -5,3 +5,6 @@ pub mod prelude;
 pub mod prelude_dev;
 pub mod ref_impl_blas;
 pub mod traits_def;
+
+#[cfg(feature = "faer")]
+pub mod faer_impl;

--- a/rstsr-linalg-traits/src/ref_impl_blas.rs
+++ b/rstsr-linalg-traits/src/ref_impl_blas.rs
@@ -1,6 +1,7 @@
 use crate::traits_def::{EighArgs_, PinvResult, SVDArgs_};
 use num::{Float, FromPrimitive, Zero};
 use rstsr_blas_traits::prelude::*;
+use rstsr_core::prelude::rt;
 use rstsr_core::prelude_dev::*;
 
 /* #region cholesky */
@@ -272,7 +273,7 @@ where
         let diag_sgn = diag_vals.sign();
         let acc_sgn = diag_sgn.prod();
         let acc_sgn = if change_sign % 2 == 0 { acc_sgn } else { -acc_sgn };
-        let acc_abs = diag_abs.log().sum();
+        let acc_abs = rt::log(diag_abs).sum();
         Ok((acc_sgn, acc_abs))
     };
     device.with_blas_num_threads(nthreads, task)

--- a/rstsr-linalg-traits/tests/mod.rs
+++ b/rstsr-linalg-traits/tests/mod.rs
@@ -1,0 +1,1 @@
+mod test_faer_func;

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -59,4 +59,14 @@ mod test {
         let w = rt::linalg::eigvalsh((a.view(), Upper)).into();
         assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_inv() {
+        let device = DeviceFaer::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+
+        // immutable
+        let a_inv = rt::linalg::inv(a.view());
+        assert!((fingerprint(&a_inv) - 143.39005577037764).abs() < 1e-8);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -1,0 +1,22 @@
+use rstsr::prelude::*;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_test_manifest::get_vec;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cholesky() {
+        let device = DeviceFaer::default();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device));
+
+        // default
+        let c = rt::linalg::cholesky(b.view());
+        assert!((fingerprint(&c) - 43.21904478556176).abs() < 1e-8);
+
+        // upper
+        let c = rt::linalg::cholesky((b.view(), Upper));
+        assert!((fingerprint(&c) - -25.925655124816647).abs() < 1e-8);
+    }
+}

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -19,4 +19,20 @@ mod test {
         let c = rt::linalg::cholesky((b.view(), Upper));
         assert!((fingerprint(&c) - -25.925655124816647).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_eigh() {
+        let device = DeviceFaer::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+
+        // default, a
+        let (w, v) = rt::linalg::eigh(a.view()).into();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+
+        // upper, a
+        let (w, v) = rt::linalg::eigh((a.view(), Upper)).into();
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 6.973792268793419).abs() < 1e-8);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -69,4 +69,25 @@ mod test {
         let a_inv = rt::linalg::inv(a.view());
         assert!((fingerprint(&a_inv) - 143.39005577037764).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_pinv() {
+        let device = DeviceFaer::default();
+
+        // 1024 x 512
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - 0.0878262837784408).abs() < 1e-8);
+        assert_eq!(rank, 163);
+
+        // 512 x 1024
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - -0.3244041253699862).abs() < 1e-8);
+        assert_eq!(rank, 161);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -117,4 +117,21 @@ mod test {
         assert!((fingerprint(&u.abs()) - -3.716931052161584).abs() < 1e-8);
         assert!((fingerprint(&vt.abs()) - -0.32301437281530243).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_svdvals() {
+        let device = DeviceFaer::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+
+        // m < n
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 32.27742168207757).abs() < 1e-8);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -45,4 +45,18 @@ mod test {
         assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
         assert!((fingerprint(&v.abs()) - 6.973792268793419).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_eigvalsh() {
+        let device = DeviceFaer::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+
+        // default, a
+        let w = rt::linalg::eigvalsh(a.view()).into();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+
+        // upper, a
+        let w = rt::linalg::eigvalsh((a.view(), Upper)).into();
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -90,4 +90,31 @@ mod test {
         assert!((fingerprint(&a_pinv) - -0.3244041253699862).abs() < 1e-8);
         assert_eq!(rank, 161);
     }
+
+    #[test]
+    fn test_svd() {
+        let device = DeviceFaer::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let (u, s, vt) = rt::linalg::svd(a.view()).into();
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+
+        // full_matrices = false
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -9.144981428076894).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+
+        // m < n, full_matrices = false
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 32.27742168207757).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -3.716931052161584).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - -0.32301437281530243).abs() < 1e-8);
+    }
 }

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -21,6 +21,16 @@ mod test {
     }
 
     #[test]
+    fn test_det() {
+        let device = DeviceFaer::default();
+        let a_vec = get_vec::<f64>('a')[..5 * 5].to_vec();
+        let a = rt::asarray((a_vec, [5, 5].c(), &device));
+
+        let det = rt::linalg::det(a.view());
+        assert!((det - 3.9699917597338046).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_eigh() {
         let device = DeviceFaer::default();
         let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -92,6 +92,22 @@ mod test {
     }
 
     #[test]
+    fn test_solve_general() {
+        let device = DeviceFaer::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024 * 512].to_vec();
+        let mut b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - -1951.253447757597).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - -1951.253447757597).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_svd() {
         let device = DeviceFaer::default();
         let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();

--- a/rstsr-linalg-traits/tests/test_faer_func/mod.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/mod.rs
@@ -1,0 +1,1 @@
+mod func_f64;


### PR DESCRIPTION
This PR will try to implement linalg functions for Faer device.

API Breaking Change (user should not feel that):
- updates Faer version to v0.22, seems that v0.20/v0.21 changes handling logic for complex values
- Conversion from/to Faer made simple (but API breaking)
- Matmul made simple (but API breaking), now requires `faer::traits::ComplexField` type (trait impl based), instead of manually dispatch types (macro_rules based)

Enhancements:
- functions added: cholesky, det, eigh (does not include generalized eigh), eigvalsh (same to eigh), inv, pinv, solve_general, svdvals