### PR TITLE
Update v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.3.2 -- 2025-05-19
+
+Summary
+- Added linalg functions for `DeviceFaer` ([#28](https://github.com/RESTGroup/rstsr/pull/28)).
+
+API Breaking Change (user should not feel that):
+- updates Faer version to v0.22, seems that v0.20/v0.21 changes handling logic for complex values
+- Conversion from/to Faer made simple (but API breaking)
+- Matmul made simple (but API breaking), now requires `faer::traits::ComplexField` type (trait impl based), instead of manually dispatch types (macro_rules based)
+
+Enhancements:
+- Functions added: cholesky, det, eigh (does not include generalized eigh), eigvalsh (same to eigh), inv, pinv, solve_general, svdvals
+
 ## v0.3.1 -- 2025-05-16
 
 API Breaking Change:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -21,15 +21,15 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.1" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.2" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.1" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.1" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.1" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.2" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.2" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.2" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.1" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.1" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.1" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.2" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.2" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.2" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies


### PR DESCRIPTION
## v0.3.2 -- 2025-05-19

Summary
- Added linalg functions for `DeviceFaer` ([#28](https://github.com/RESTGroup/rstsr/pull/28)).

API Breaking Change (user should not feel that):
- updates Faer version to v0.22, seems that v0.20/v0.21 changes handling logic for complex values
- Conversion from/to Faer made simple (but API breaking)
- Matmul made simple (but API breaking), now requires `faer::traits::ComplexField` type (trait impl based), instead of manually dispatch types (macro_rules based)

Enhancements:
- Functions added: cholesky, det, eigh (does not include generalized eigh), eigvalsh (same to eigh), inv, pinv, solve_general, svdvals