### PR TITLE
Fix faer linalg implementation for tensor views with offset != 0

### DIFF
--- a/rstsr-core/src/device_faer/conversion.rs
+++ b/rstsr-core/src/device_faer/conversion.rs
@@ -16,7 +16,8 @@ where
     fn into_faer(self) -> Self::Faer {
         let [nrows, ncols] = *self.shape();
         let [row_stride, col_stride] = *self.stride();
-        let ptr = self.raw().as_ptr();
+        let offset = self.offset();
+        let ptr = unsafe { self.raw().as_ptr().add(offset) };
         unsafe { MatRef::from_raw_parts(ptr, nrows, ncols, row_stride, col_stride) }
     }
 }
@@ -30,7 +31,8 @@ where
     fn into_faer(mut self) -> Self::Faer {
         let [nrows, ncols] = *self.shape();
         let [row_stride, col_stride] = *self.stride();
-        let ptr = self.raw_mut().as_mut_ptr();
+        let offset = self.offset();
+        let ptr = unsafe { self.raw_mut().as_mut_ptr().add(offset) };
         unsafe { MatMut::from_raw_parts_mut(ptr, nrows, ncols, row_stride, col_stride) }
     }
 }

--- a/rstsr-linalg-traits/Cargo.toml
+++ b/rstsr-linalg-traits/Cargo.toml
@@ -17,10 +17,11 @@ num = { workspace = true }
 duplicate = { workspace = true }
 derive_builder = { workspace = true }
 faer = { workspace = true, optional = true }
+faer-ext = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstsr = { path = "../rstsr", default-features = false, features = ["linalg"] }
 rstsr-test-manifest = { workspace = true }
 
 [features]
-faer = ["rstsr-core/faer", "dep:faer"]
+faer = ["rstsr-core/faer", "dep:faer", "dep:faer-ext"]

--- a/rstsr-linalg-traits/src/faer_impl/cholesky.rs
+++ b/rstsr-linalg-traits/src/faer_impl/cholesky.rs
@@ -1,6 +1,7 @@
 use crate::traits_def::CholeskyAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
+use faer_ext::IntoFaer;
 use rstsr_core::prelude_dev::*;
 
 pub fn faer_impl_cholesky_f<T>(
@@ -11,7 +12,8 @@ where
     T: ComplexField,
 {
     // set parallel mode
-    let pool = a.device().get_current_pool();
+    let device = a.device().clone();
+    let pool = device.get_current_pool();
     let faer_par_orig = faer::get_global_parallelism();
     let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
     faer::set_global_parallelism(faer_par);
@@ -20,15 +22,7 @@ where
         RowMajor => Lower,
         ColMajor => Upper,
     });
-    let faer_a = unsafe {
-        MatRef::from_raw_parts(
-            a.as_ptr().add(a.offset()),
-            a.shape()[0],
-            a.shape()[1],
-            a.stride()[0],
-            a.stride()[1],
-        )
-    };
+    let faer_a = a.into_faer();
     let faer_uplo = match uplo {
         Lower => faer::Side::Lower,
         Upper => faer::Side::Upper,
@@ -44,7 +38,7 @@ where
         Upper => result.L().transpose(),
     };
     // convert to rstsr tensor with certain layout
-    let result = result.into_rstsr().into_contig(a.device().default_order());
+    let result = result.into_rstsr().into_contig(device.default_order());
 
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);

--- a/rstsr-linalg-traits/src/faer_impl/det.rs
+++ b/rstsr-linalg-traits/src/faer_impl/det.rs
@@ -1,6 +1,7 @@
 use crate::traits_def::DetAPI;
 use faer::prelude::*;
 use faer::traits::ComplexField;
+use faer_ext::IntoFaer;
 use rstsr_core::prelude_dev::*;
 
 pub fn faer_impl_det_f<T>(a: TensorView<'_, T, DeviceFaer, Ix2>) -> Result<T::Real>
@@ -13,15 +14,7 @@ where
     let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
     faer::set_global_parallelism(faer_par);
 
-    let faer_a = unsafe {
-        MatRef::from_raw_parts(
-            a.as_ptr().add(a.offset()),
-            a.shape()[0],
-            a.shape()[1],
-            a.stride()[0],
-            a.stride()[1],
-        )
-    };
+    let faer_a = a.into_faer();
 
     // det computation
     let result = faer_a.determinant();

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -2,6 +2,7 @@ use crate::traits_def::InvAPI;
 use faer::linalg::solvers::DenseSolveCore;
 use faer::prelude::*;
 use faer::traits::ComplexField;
+use faer_ext::IntoFaer;
 use rstsr_core::prelude_dev::*;
 
 pub fn faer_impl_inv_f<T>(
@@ -11,27 +12,20 @@ where
     T: ComplexField,
 {
     // set parallel mode
-    let pool = a.device().get_current_pool();
+    let device = a.device().clone();
+    let pool = device.get_current_pool();
     let faer_par_orig = faer::get_global_parallelism();
     let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
     faer::set_global_parallelism(faer_par);
 
-    let faer_a = unsafe {
-        MatRef::from_raw_parts(
-            a.as_ptr().add(a.offset()),
-            a.shape()[0],
-            a.shape()[1],
-            a.stride()[0],
-            a.stride()[1],
-        )
-    };
+    let faer_a = a.into_faer();
 
     // det computation
     let svd_result = faer_a.svd().map_err(|e| rstsr_error!(FaerError, "Faer SvD error: {e:?}"))?;
     let result = svd_result.inverse();
 
     // convert to rstsr tensor with certain layout
-    let result = result.as_ref().into_rstsr().into_contig(a.device().default_order());
+    let result = result.as_ref().into_rstsr().into_contig(device.default_order());
 
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -21,6 +21,17 @@ mod test {
     }
 
     #[test]
+    fn test_cholesky_submatrix() {
+        let device = DeviceFaer::default();
+        let vec_b: Vec<f64> = vec![0.0, 1.0, 2.0, 1.0, 5.0, 1.5, 2.0, 1.5, 8.0];
+        let b = rt::asarray((vec_b, [3, 3].c(), &device));
+
+        let b_view = b.i((1..3, 1..3));
+        let c = rt::linalg::cholesky(b_view);
+        assert!((fingerprint(&c) - -0.7633202592326889).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_det() {
         let device = DeviceFaer::default();
         let a_vec = get_vec::<f64>('a')[..5 * 5].to_vec();

--- a/rstsr-openblas/tests/test_linalg_func/func_f64.rs
+++ b/rstsr-openblas/tests/test_linalg_func/func_f64.rs
@@ -25,6 +25,17 @@ mod test {
     }
 
     #[test]
+    fn test_cholesky_submatrix() {
+        let device = DeviceBLAS::default();
+        let vec_b: Vec<f64> = vec![0.0, 1.0, 2.0, 1.0, 5.0, 1.5, 2.0, 1.5, 8.0];
+        let b = rt::asarray((vec_b, [3, 3].c(), &device));
+
+        let b_view = b.i((1..3, 1..3));
+        let c = rt::linalg::cholesky(b_view);
+        assert!((fingerprint(&c) - -0.7633202592326889).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_det() {
         let device = DeviceBLAS::default();
         let a_vec = get_vec::<f64>('a')[..5 * 5].to_vec();


### PR DESCRIPTION
This PR will fix the case where linalg functions gives wrong results when offset != 0.

Also fixes previous implementation of `IntoFaer` for the same problem.