### PR TITLE
Update v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3 -- 2025-05-19
+
+Bug Fix:
+- Fix Faer linalg functions when tensor offset != 0 ([#30](https://github.com/RESTGroup/rstsr/pull/30)).
+
 ## v0.3.2 -- 2025-05-19
 
 Summary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -21,15 +21,15 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.2" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.3" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.2" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.2" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.2" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.3" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.3" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.3" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.2" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.2" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.2" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.3" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.3" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.3" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies


### PR DESCRIPTION
## v0.3.3 -- 2025-05-19

Bug Fix:
- Fix Faer linalg functions when tensor offset != 0 ([#30](https://github.com/RESTGroup/rstsr/pull/30)).