### PR TITLE
Fix rayon parallel in `op_muta_refb_func_cpu_rayon`

### DIFF
--- a/rstsr-native-impl/src/cpu_rayon/op_with_func.rs
+++ b/rstsr-native-impl/src/cpu_rayon/op_with_func.rs
@@ -5,10 +5,7 @@ use rayon::prelude::*;
 const CONTIG_SWITCH: usize = 16;
 // This value is used to determine when to use parallel iteration.
 // Since current task is not intensive to each element, this value is large.
-// 64 kB for f64
-const PARALLEL_SWITCH: usize = 16384;
-// Currently, we do not make contiguous parts to be parallel. Only outer
-// iteration is parallelized.
+const PARALLEL_SWITCH: usize = 4096;
 
 /* #region op_func definition */
 
@@ -257,7 +254,7 @@ where
         } else {
             // parallel inner iteration
             let func = |(idx_a, idx_b)| unsafe {
-                (0..size_contig).for_each(|idx| {
+                (0..size_contig).into_par_iter().for_each(|idx| {
                     let a_ptr = a.as_ptr().add(idx_a + idx) as *mut TA;
                     f(&mut *a_ptr, &b[idx_b + idx]);
                 });


### PR DESCRIPTION
Fix:
- Previously `op_muta_refb_func_cpu_rayon` parallel inner iteration (when `size_contig >= PARALLEL_SWITCH`) is not actually paralleled. This can affect efficiency of many binary functions as well as mapping functions.

Changes:
- Lowered `PARALLEL_SWITCH` in `op_with_func` from 16384 to 4096.