### PR TITLE
Fix for conversion to self-device

### DIFF
--- a/rstsr-core/src/device_cpu_serial/conversion.rs
+++ b/rstsr-core/src/device_cpu_serial/conversion.rs
@@ -1,0 +1,38 @@
+use crate::prelude_dev::*;
+
+impl<'a, R, T, D> DeviceChangeAPI<'a, DeviceCpuSerial, R, T, D> for DeviceCpuSerial
+where
+    T: Clone + Send + Sync + 'a,
+    D: DimAPI,
+    R: DataCloneAPI<Data = Vec<T>>,
+{
+    type Repr = R;
+    type ReprTo = DataRef<'a, Vec<T>>;
+
+    fn change_device(
+        tensor: TensorAny<R, T, DeviceCpuSerial, D>,
+        device: &DeviceCpuSerial,
+    ) -> Result<TensorAny<Self::Repr, T, DeviceCpuSerial, D>> {
+        let (storage, layout) = tensor.into_raw_parts();
+        let (data, _) = storage.into_raw_parts();
+        let storage = Storage::new(data, device.clone());
+        let tensor = TensorAny::new(storage, layout);
+        Ok(tensor)
+    }
+
+    fn into_device(
+        tensor: TensorAny<R, T, DeviceCpuSerial, D>,
+        device: &DeviceCpuSerial,
+    ) -> Result<TensorAny<DataOwned<Vec<T>>, T, DeviceCpuSerial, D>> {
+        let tensor = tensor.into_owned();
+        DeviceChangeAPI::change_device(tensor, device)
+    }
+
+    fn to_device(
+        tensor: &'a TensorAny<R, T, DeviceCpuSerial, D>,
+        device: &DeviceCpuSerial,
+    ) -> Result<TensorView<'a, T, DeviceCpuSerial, D>> {
+        let view = tensor.view();
+        DeviceChangeAPI::change_device(view, device)
+    }
+}

--- a/rstsr-core/src/device_cpu_serial/mod.rs
+++ b/rstsr-core/src/device_cpu_serial/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod adv_indexing;
 pub mod assignment;
+pub mod conversion;
 pub mod creation;
 pub mod device;
 pub mod matmul;


### PR DESCRIPTION
Previously, self-device conversion has not been implemented.
Self-device conversion may be useful for row/col-major change, or number of threads change.