### PR TITLE
Update v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.4 -- 2025-05-20
+
+Bug Fix:
+- Fix rayon parallel in `op_muta_refb_func_cpu_rayon` ([#32](https://github.com/RESTGroup/rstsr/pull/32))
+- Fix for conversion to self-device ([#33](https://github.com/RESTGroup/rstsr/pull/33))
+
 ## v0.3.3 -- 2025-05-19
 
 Bug Fix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -21,15 +21,15 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.3" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.4" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.3" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.3" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.3" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.4" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.4" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.4" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.3" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.3" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.3" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.4" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.4" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.4" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies


### PR DESCRIPTION
## v0.3.4 -- 2025-05-20

Bug Fix:
- Fix rayon parallel in `op_muta_refb_func_cpu_rayon` ([#32](https://github.com/RESTGroup/rstsr/pull/32))
- Fix for conversion to self-device ([#33](https://github.com/RESTGroup/rstsr/pull/33))