### PR TITLE
Fix too strict stride check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ inherits = "dev"
 opt-level = 0
 
 [profile.dev]
-opt-level = 2
+opt-level = 0

--- a/rstsr-linalg-traits/src/faer_impl/det.rs
+++ b/rstsr-linalg-traits/src/faer_impl/det.rs
@@ -23,7 +23,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok(result);
+    Ok(result)
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/src/faer_impl/eigh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigh.rs
@@ -45,7 +45,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok((eigenvalues, eigenvectors));
+    Ok((eigenvalues, eigenvectors))
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
+++ b/rstsr-linalg-traits/src/faer_impl/eigvalsh.rs
@@ -40,7 +40,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok(eigenvalues);
+    Ok(eigenvalues)
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/src/faer_impl/inv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/inv.rs
@@ -30,7 +30,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok(result);
+    Ok(result)
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/src/faer_impl/pinv.rs
+++ b/rstsr-linalg-traits/src/faer_impl/pinv.rs
@@ -44,7 +44,7 @@ where
 
     // compute pinv
     let s = s.mapv(|x| T::real_part_impl(&x));
-    let maxs = s.raw().iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap().clone();
+    let maxs = *s.raw().iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
     let val = atol + rtol * maxs;
     let rank = s.raw().iter().take_while(|&&x| x > val).count();
     let mut u = u.into_slice((.., ..rank));

--- a/rstsr-linalg-traits/src/faer_impl/svd.rs
+++ b/rstsr-linalg-traits/src/faer_impl/svd.rs
@@ -47,7 +47,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok(result);
+    Ok(result)
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/src/faer_impl/svdvals.rs
+++ b/rstsr-linalg-traits/src/faer_impl/svdvals.rs
@@ -28,7 +28,7 @@ where
     // restore parallel mode
     faer::set_global_parallelism(faer_par_orig);
 
-    return Ok(result);
+    Ok(result)
 }
 
 #[duplicate_item(

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -63,11 +63,11 @@ mod test {
         let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
 
         // default, a
-        let w = rt::linalg::eigvalsh(a.view()).into();
+        let w = rt::linalg::eigvalsh(a.view());
         assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
 
         // upper, a
-        let w = rt::linalg::eigvalsh((a.view(), Upper)).into();
+        let w = rt::linalg::eigvalsh((a.view(), Upper));
         assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
     }
 


### PR DESCRIPTION
Fix:
- Fix some kinds of slicing (especially step larger than 1) that previously cause stride check incorrectly failed.