### PR TITLE
Feature addition (meshgrid, concat, stack, bool_select)

### DIFF
--- a/rstsr-common/src/layout/indexer.rs
+++ b/rstsr-common/src/layout/indexer.rs
@@ -59,23 +59,29 @@ impl_from_int_into_indexer!(usize, isize, u32, i32, u64, i64);
 macro_rules! impl_into_axes_index {
     ($($t:ty),*) => {
         $(
-            impl From<$t> for AxesIndex<Indexer> {
-                fn from(index: $t) -> Self {
-                    AxesIndex::Val(index.into())
+            impl TryFrom<$t> for AxesIndex<Indexer> {
+                type Error = Error;
+
+                fn try_from(index: $t) -> Result<Self> {
+                    Ok(AxesIndex::Val(index.try_into()?))
                 }
             }
 
-            impl<const N: usize> From<[$t; N]> for AxesIndex<Indexer> {
-                fn from(index: [$t; N]) -> Self {
+            impl<const N: usize> TryFrom<[$t; N]> for AxesIndex<Indexer> {
+                type Error = Error;
+
+                fn try_from(index: [$t; N]) -> Result<Self> {
                     let index = index.iter().map(|v| v.clone().into()).collect::<Vec<_>>();
-                    AxesIndex::Vec(index)
+                    Ok(AxesIndex::Vec(index))
                 }
             }
 
-            impl From<Vec<$t>> for AxesIndex<Indexer> {
-                fn from(index: Vec<$t>) -> Self {
+            impl TryFrom<Vec<$t>> for AxesIndex<Indexer> {
+                type Error = Error;
+
+                fn try_from(index: Vec<$t>) -> Result<Self> {
                     let index = index.iter().map(|v| v.clone().into()).collect::<Vec<_>>();
-                    AxesIndex::Vec(index)
+                    Ok(AxesIndex::Vec(index))
                 }
             }
         )*

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -11,7 +11,7 @@ pub mod rstsr_traits {
         ArangeAPI, EmptyAPI, EmptyLikeAPI, EyeAPI, FullAPI, FullLikeAPI, LinspaceAPI, OnesAPI,
         OnesLikeAPI, TrilAPI, TriuAPI, ZerosAPI, ZerosLikeAPI,
     };
-    pub use crate::tensor::creation_from_tensor::{DiagAPI, MeshgridAPI};
+    pub use crate::tensor::creation_from_tensor::{ConcatAPI, DiagAPI, MeshgridAPI};
     pub use crate::tensor::operators::op_binary_common::{
         TensorATan2API, TensorCopySignAPI, TensorEqualAPI, TensorFloorDivideAPI, TensorGreaterAPI,
         TensorGreaterEqualAPI, TensorHypotAPI, TensorLessAPI, TensorLessEqualAPI,
@@ -57,7 +57,9 @@ pub mod rstsr_funcs {
         full_like, full_like_f, linspace, linspace_f, ones, ones_f, ones_like, ones_like_f, tril,
         tril_f, triu, triu_f, zeros, zeros_f, zeros_like, zeros_like_f,
     };
-    pub use crate::tensor::creation_from_tensor::{diag, diag_f, meshgrid, meshgrid_f};
+    pub use crate::tensor::creation_from_tensor::{
+        concat, concat_f, concatenate, concatenate_f, diag, diag_f, meshgrid, meshgrid_f,
+    };
     pub use crate::tensor::indexing::{
         diagonal, diagonal_f, diagonal_mut, diagonal_mut_f, into_diagonal, into_diagonal_f,
         into_diagonal_mut, into_diagonal_mut_f, into_slice, into_slice_f, slice, slice_f,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -52,7 +52,9 @@ pub mod rstsr_structs {
 }
 
 pub mod rstsr_funcs {
-    pub use crate::tensor::adv_indexing::{index_select, index_select_f};
+    pub use crate::tensor::adv_indexing::{
+        bool_select, bool_select_f, index_select, index_select_f,
+    };
     pub use crate::tensor::asarray::{asarray, asarray_f};
     pub use crate::tensor::creation::{
         arange, arange_f, empty, empty_f, empty_like, empty_like_f, eye, eye_f, full, full_f,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -11,7 +11,9 @@ pub mod rstsr_traits {
         ArangeAPI, EmptyAPI, EmptyLikeAPI, EyeAPI, FullAPI, FullLikeAPI, LinspaceAPI, OnesAPI,
         OnesLikeAPI, TrilAPI, TriuAPI, ZerosAPI, ZerosLikeAPI,
     };
-    pub use crate::tensor::creation_from_tensor::{ConcatAPI, DiagAPI, MeshgridAPI};
+    pub use crate::tensor::creation_from_tensor::{
+        ConcatAPI, DiagAPI, HStackAPI, MeshgridAPI, VStackAPI,
+    };
     pub use crate::tensor::operators::op_binary_common::{
         TensorATan2API, TensorCopySignAPI, TensorEqualAPI, TensorFloorDivideAPI, TensorGreaterAPI,
         TensorGreaterEqualAPI, TensorHypotAPI, TensorLessAPI, TensorLessEqualAPI,
@@ -58,7 +60,8 @@ pub mod rstsr_funcs {
         tril_f, triu, triu_f, zeros, zeros_f, zeros_like, zeros_like_f,
     };
     pub use crate::tensor::creation_from_tensor::{
-        concat, concat_f, concatenate, concatenate_f, diag, diag_f, meshgrid, meshgrid_f,
+        concat, concat_f, concatenate, concatenate_f, diag, diag_f, hstack, hstack_f, meshgrid,
+        meshgrid_f, vstack, vstack_f,
     };
     pub use crate::tensor::indexing::{
         diagonal, diagonal_f, diagonal_mut, diagonal_mut_f, into_diagonal, into_diagonal_f,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -11,7 +11,7 @@ pub mod rstsr_traits {
         ArangeAPI, EmptyAPI, EmptyLikeAPI, EyeAPI, FullAPI, FullLikeAPI, LinspaceAPI, OnesAPI,
         OnesLikeAPI, TrilAPI, TriuAPI, ZerosAPI, ZerosLikeAPI,
     };
-    pub use crate::tensor::creation_from_tensor::DiagAPI;
+    pub use crate::tensor::creation_from_tensor::{DiagAPI, MeshgridAPI};
     pub use crate::tensor::operators::op_binary_common::{
         TensorATan2API, TensorCopySignAPI, TensorEqualAPI, TensorFloorDivideAPI, TensorGreaterAPI,
         TensorGreaterEqualAPI, TensorHypotAPI, TensorLessAPI, TensorLessEqualAPI,
@@ -57,7 +57,7 @@ pub mod rstsr_funcs {
         full_like, full_like_f, linspace, linspace_f, ones, ones_f, ones_like, ones_like_f, tril,
         tril_f, triu, triu_f, zeros, zeros_f, zeros_like, zeros_like_f,
     };
-    pub use crate::tensor::creation_from_tensor::{diag, diag_f};
+    pub use crate::tensor::creation_from_tensor::{diag, diag_f, meshgrid, meshgrid_f};
     pub use crate::tensor::indexing::{
         diagonal, diagonal_f, diagonal_mut, diagonal_mut_f, into_diagonal, into_diagonal_f,
         into_diagonal_mut, into_diagonal_mut_f, into_slice, into_slice_f, slice, slice_f,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -12,7 +12,7 @@ pub mod rstsr_traits {
         OnesLikeAPI, TrilAPI, TriuAPI, ZerosAPI, ZerosLikeAPI,
     };
     pub use crate::tensor::creation_from_tensor::{
-        ConcatAPI, DiagAPI, HStackAPI, MeshgridAPI, VStackAPI,
+        ConcatAPI, DiagAPI, HStackAPI, MeshgridAPI, StackAPI, VStackAPI,
     };
     pub use crate::tensor::operators::op_binary_common::{
         TensorATan2API, TensorCopySignAPI, TensorEqualAPI, TensorFloorDivideAPI, TensorGreaterAPI,
@@ -61,7 +61,7 @@ pub mod rstsr_funcs {
     };
     pub use crate::tensor::creation_from_tensor::{
         concat, concat_f, concatenate, concatenate_f, diag, diag_f, hstack, hstack_f, meshgrid,
-        meshgrid_f, vstack, vstack_f,
+        meshgrid_f, stack, stack_f, vstack, vstack_f,
     };
     pub use crate::tensor::indexing::{
         diagonal, diagonal_f, diagonal_mut, diagonal_mut_f, into_diagonal, into_diagonal_f,

--- a/rstsr-core/src/prelude.rs
+++ b/rstsr-core/src/prelude.rs
@@ -12,7 +12,7 @@ pub mod rstsr_traits {
         OnesLikeAPI, TrilAPI, TriuAPI, ZerosAPI, ZerosLikeAPI,
     };
     pub use crate::tensor::creation_from_tensor::{
-        ConcatAPI, DiagAPI, HStackAPI, MeshgridAPI, StackAPI, VStackAPI,
+        ConcatAPI, DiagAPI, HStackAPI, MeshgridAPI, StackAPI, UnstackAPI, VStackAPI,
     };
     pub use crate::tensor::operators::op_binary_common::{
         TensorATan2API, TensorCopySignAPI, TensorEqualAPI, TensorFloorDivideAPI, TensorGreaterAPI,
@@ -61,7 +61,7 @@ pub mod rstsr_funcs {
     };
     pub use crate::tensor::creation_from_tensor::{
         concat, concat_f, concatenate, concatenate_f, diag, diag_f, hstack, hstack_f, meshgrid,
-        meshgrid_f, stack, stack_f, vstack, vstack_f,
+        meshgrid_f, stack, stack_f, unstack, unstack_f, vstack, vstack_f,
     };
     pub use crate::tensor::indexing::{
         diagonal, diagonal_f, diagonal_mut, diagonal_mut_f, into_diagonal, into_diagonal_f,

--- a/rstsr-core/src/tensor/creation.rs
+++ b/rstsr-core/src/tensor/creation.rs
@@ -12,11 +12,11 @@
 //! - [x] `full`: [`full`]
 //! - [x] `full_like`: [`full_like`]
 //! - [x] `linspace`: [`linspace`]
-//! - [ ] `meshgrid`
+//! - [x] `meshgrid`
 //! - [x] `ones`: [`ones`]
 //! - [x] `ones_like`: [`ones_like`]
-//! - [ ] `tril`
-//! - [ ] `triu`
+//! - [x] `tril`
+//! - [x] `triu`
 //! - [x] `zeros`: [`zeros`]
 //! - [x] `zeros_like`: [`zeros_like`]
 

--- a/rstsr-core/src/tensor/creation_from_tensor.rs
+++ b/rstsr-core/src/tensor/creation_from_tensor.rs
@@ -300,9 +300,9 @@ pub trait ConcatAPI<Inp> {
 }
 
 /// Join a sequence of arrays along an existing axis.
-/// 
+///
 /// # See also
-/// 
+///
 /// - [Python Array Standard `concatnate`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.concat.html)
 pub fn concat<Args, Inp>(args: Args) -> Args::Out
 where
@@ -318,8 +318,8 @@ where
     Args::concat_f(args)
 }
 
-pub use concat_f as concatenate_f;
 pub use concat as concatenate;
+pub use concat_f as concatenate_f;
 
 impl<R, T, B, D> ConcatAPI<()> for (Vec<TensorAny<R, T, B, D>>, isize)
 where
@@ -334,11 +334,7 @@ where
         let (tensors, axis) = self;
 
         // quick error for empty tensors
-        rstsr_assert!(
-            !tensors.is_empty(),
-            InvalidValue,
-            "concat requires at least one tensor."
-        )?;
+        rstsr_assert!(!tensors.is_empty(), InvalidValue, "concat requires at least one tensor.")?;
 
         // check same device and same ndim
         let device = tensors[0].device().clone();
@@ -346,7 +342,12 @@ where
 
         rstsr_assert!(ndim > 0, InvalidLayout, "All tensors must have ndim > 0 in concat.")?;
         tensors.iter().try_for_each(|tensor| -> Result<()> {
-            rstsr_assert_eq!(tensor.ndim(), ndim, InvalidLayout, "All tensors must have the same ndim.")?;
+            rstsr_assert_eq!(
+                tensor.ndim(),
+                ndim,
+                InvalidLayout,
+                "All tensors must have the same ndim."
+            )?;
             rstsr_assert!(
                 tensor.device().same_device(&device),
                 DeviceMismatch,
@@ -356,11 +357,7 @@ where
         })?;
 
         // check and make axis positive
-        let axis = if axis < 0 {
-            ndim as isize + axis
-        } else {
-            axis
-        };
+        let axis = if axis < 0 { ndim as isize + axis } else { axis };
         rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "axis out of bounds")?;
         let axis = axis as usize;
 
@@ -390,16 +387,12 @@ where
         for tensor in tensors {
             let layout = tensor.layout().to_dim::<IxD>()?;
             let axis_size = tensor.shape()[axis];
-            let layout_result = result.layout().dim_narrow(axis as isize, slice!(offset, offset + axis_size))?;
-            device.assign(
-                result.raw_mut(),
-                &layout_result,
-                tensor.raw(),
-                &layout,
-            )?;
+            let layout_result =
+                result.layout().dim_narrow(axis as isize, slice!(offset, offset + axis_size))?;
+            device.assign(result.raw_mut(), &layout_result, tensor.raw(), &layout)?;
             offset += axis_size;
         }
-        
+
         Ok(result)
     }
 }
@@ -414,7 +407,6 @@ where
    [              ] [(Vec<TensorAny<R, T, B, D>>  , i32  )];
    [              ] [(&Vec<TensorAny<R, T, B, D>> , i32  )];
    [const N: usize] [([TensorAny<R, T, B, D>; N]  , i32  )];
-   
    [              ] [(Vec<&TensorAny<R, T, B, D>> , isize)];
    [              ] [(&Vec<&TensorAny<R, T, B, D>>, isize)];
    [const N: usize] [([&TensorAny<R, T, B, D>; N] , isize)];
@@ -448,7 +440,6 @@ where
    [              ] [Vec<TensorAny<R, T, B, D>>  ];
    [              ] [&Vec<TensorAny<R, T, B, D>> ];
    [const N: usize] [[TensorAny<R, T, B, D>; N]  ];
-   
    [              ] [Vec<&TensorAny<R, T, B, D>> ];
    [              ] [&Vec<&TensorAny<R, T, B, D>>];
    [const N: usize] [[&TensorAny<R, T, B, D>; N] ];
@@ -488,9 +479,9 @@ pub trait HStackAPI<Inp> {
 }
 
 /// Stack tensors in sequence horizontally (column-wise).
-/// 
+///
 /// # See also
-/// 
+///
 /// [NumPy `hstack`](https://numpy.org/doc/stable/reference/generated/numpy.hstack.html)
 pub fn hstack<Args, Inp>(args: Args) -> Args::Out
 where
@@ -511,7 +502,6 @@ where
    [              ] [Vec<TensorAny<R, T, B, D>>  ];
    [              ] [&Vec<TensorAny<R, T, B, D>> ];
    [const N: usize] [[TensorAny<R, T, B, D>; N]  ];
-   
    [              ] [Vec<&TensorAny<R, T, B, D>> ];
    [              ] [&Vec<&TensorAny<R, T, B, D>>];
    [const N: usize] [[&TensorAny<R, T, B, D>; N] ];
@@ -527,7 +517,7 @@ where
 
     fn hstack_f(self) -> Result<Self::Out> {
         let tensors = self;
-        
+
         if tensors.is_empty() {
             return rstsr_raise!(InvalidValue, "hstack requires at least one tensor.");
         }
@@ -557,9 +547,9 @@ pub trait VStackAPI<Inp> {
 }
 
 /// Stack tensors in sequence horizontally (row-wise).
-/// 
+///
 /// # See also
-/// 
+///
 /// [NumPy `vstack`](https://numpy.org/doc/stable/reference/generated/numpy.vstack.html)
 pub fn vstack<Args, Inp>(args: Args) -> Args::Out
 where
@@ -580,7 +570,6 @@ where
    [              ] [Vec<TensorAny<R, T, B, D>>  ];
    [              ] [&Vec<TensorAny<R, T, B, D>> ];
    [const N: usize] [[TensorAny<R, T, B, D>; N]  ];
-   
    [              ] [Vec<&TensorAny<R, T, B, D>> ];
    [              ] [&Vec<&TensorAny<R, T, B, D>>];
    [const N: usize] [[&TensorAny<R, T, B, D>; N] ];
@@ -596,7 +585,7 @@ where
 
     fn vstack_f(self) -> Result<Self::Out> {
         let tensors = self;
-        
+
         if tensors.is_empty() {
             return rstsr_raise!(InvalidValue, "vstack requires at least one tensor.");
         }
@@ -622,9 +611,9 @@ pub trait StackAPI<Inp> {
 }
 
 /// Joins a sequence of arrays along a new axis.
-/// 
+///
 /// # See also
-/// 
+///
 /// [Python Array Standard `stack`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.stack.html)
 pub fn stack<Args, Inp>(args: Args) -> Args::Out
 where
@@ -653,11 +642,7 @@ where
         let (tensors, axis) = self;
 
         // quick error for empty tensors
-        rstsr_assert!(
-            !tensors.is_empty(),
-            InvalidValue,
-            "stack requires at least one tensor."
-        )?;
+        rstsr_assert!(!tensors.is_empty(), InvalidValue, "stack requires at least one tensor.")?;
 
         // check same device and same ndim
         let device = tensors[0].device().clone();
@@ -666,7 +651,12 @@ where
 
         rstsr_assert!(ndim > 0, InvalidLayout, "All tensors must have ndim > 0 in stack.")?;
         tensors.iter().try_for_each(|tensor| -> Result<()> {
-            rstsr_assert_eq!(tensor.shape(), shape_orig, InvalidLayout, "All tensors must have the same shape.")?;
+            rstsr_assert_eq!(
+                tensor.shape(),
+                shape_orig,
+                InvalidLayout,
+                "All tensors must have the same shape."
+            )?;
             rstsr_assert!(
                 tensor.device().same_device(&device),
                 DeviceMismatch,
@@ -674,18 +664,17 @@ where
             )?;
             Ok(())
         })?;
-        
+
         // check and make axis positive
-        let axis = if axis < 0 {
-            ndim as isize + axis + 1
-        } else {
-            axis
-        };
+        let axis = if axis < 0 { ndim as isize + axis + 1 } else { axis };
         rstsr_pattern!(axis, 0..=ndim as isize, InvalidLayout, "axis out of bounds")?;
         let axis = axis as usize;
 
         // expand the shape of each tensor
-        let tensors = tensors.into_iter().map(|tensor| tensor.into_expand_dims_f(axis)).collect::<Result<Vec<_>>>()?;
+        let tensors = tensors
+            .into_iter()
+            .map(|tensor| tensor.into_expand_dims_f(axis))
+            .collect::<Result<Vec<_>>>()?;
 
         // use concat function to perform the stacking
         ConcatAPI::concat_f((tensors, axis as isize))
@@ -702,7 +691,6 @@ where
    [              ] [(Vec<TensorAny<R, T, B, D>>  , i32  )];
    [              ] [(&Vec<TensorAny<R, T, B, D>> , i32  )];
    [const N: usize] [([TensorAny<R, T, B, D>; N]  , i32  )];
-   
    [              ] [(Vec<&TensorAny<R, T, B, D>> , isize)];
    [              ] [(&Vec<&TensorAny<R, T, B, D>>, isize)];
    [const N: usize] [([&TensorAny<R, T, B, D>; N] , isize)];
@@ -736,7 +724,6 @@ where
    [              ] [Vec<TensorAny<R, T, B, D>>  ];
    [              ] [&Vec<TensorAny<R, T, B, D>> ];
    [const N: usize] [[TensorAny<R, T, B, D>; N]  ];
-   
    [              ] [Vec<&TensorAny<R, T, B, D>> ];
    [              ] [&Vec<&TensorAny<R, T, B, D>>];
    [const N: usize] [[&TensorAny<R, T, B, D>; N] ];
@@ -776,9 +763,9 @@ pub trait UnstackAPI<Inp> {
 }
 
 /// Splits an array into a sequence of arrays along the given axis.
-/// 
+///
 /// # See also
-/// 
+///
 /// [Python Array Standard `unstack`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.unstack.html)
 pub fn unstack<Args, Inp>(args: Args) -> Args::Out
 where
@@ -807,26 +794,28 @@ where
         let (tensor, axis) = self;
 
         // check tensor ndim
-        rstsr_assert!(tensor.ndim() > 0, InvalidLayout, "unstack requires a tensor with ndim > 0.")?;
+        rstsr_assert!(
+            tensor.ndim() > 0,
+            InvalidLayout,
+            "unstack requires a tensor with ndim > 0."
+        )?;
 
         // check axis
         let ndim = tensor.ndim();
-        let axis = if axis < 0 {
-            ndim as isize + axis
-        } else {
-            axis
-        };
+        let axis = if axis < 0 { ndim as isize + axis } else { axis };
         rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "axis out of bounds")?;
         let axis = axis as usize;
-        
-        (0..tensor.layout().shape()[axis]).map(|i| {
-            let view = tensor.view();
-            let (storage, layout) = view.into_raw_parts();
-            let layout = layout.dim_select(axis as isize, i as isize)?;
-            // safety: transmute for lifetime annotation
-            let storage = unsafe { transmute::<Storage<_, T, B>, Storage<_, T, B>>(storage) };
-            unsafe { Ok(TensorBase::new_unchecked(storage, layout)) }
-        }).collect()
+
+        (0..tensor.layout().shape()[axis])
+            .map(|i| {
+                let view = tensor.view();
+                let (storage, layout) = view.into_raw_parts();
+                let layout = layout.dim_select(axis as isize, i as isize)?;
+                // safety: transmute for lifetime annotation
+                let storage = unsafe { transmute::<Storage<_, T, B>, Storage<_, T, B>>(storage) };
+                unsafe { Ok(TensorBase::new_unchecked(storage, layout)) }
+            })
+            .collect()
     }
 }
 

--- a/rstsr-core/src/tensor/creation_from_tensor.rs
+++ b/rstsr-core/src/tensor/creation_from_tensor.rs
@@ -407,24 +407,24 @@ where
 
 #[duplicate_item(
     ImplType         ImplStruct                            ;
-    [              ] [(&Vec<TensorAny<R, T, B, D>> , isize)];
-    [const N: usize] [([TensorAny<R, T, B, D>; N]  , isize)];
-    [              ] [(Vec<TensorAny<R, T, B, D>>  , usize)];
-    [              ] [(&Vec<TensorAny<R, T, B, D>> , usize)];
-    [const N: usize] [([TensorAny<R, T, B, D>; N]  , usize)];
-    [              ] [(Vec<TensorAny<R, T, B, D>>  , i32  )];
-    [              ] [(&Vec<TensorAny<R, T, B, D>> , i32  )];
-    [const N: usize] [([TensorAny<R, T, B, D>; N]  , i32  )];
-    
-    [              ] [(Vec<&TensorAny<R, T, B, D>> , isize)];
-    [              ] [(&Vec<&TensorAny<R, T, B, D>>, isize)];
-    [const N: usize] [([&TensorAny<R, T, B, D>; N] , isize)];
-    [              ] [(Vec<&TensorAny<R, T, B, D>> , usize)];
-    [              ] [(&Vec<&TensorAny<R, T, B, D>>, usize)];
-    [const N: usize] [([&TensorAny<R, T, B, D>; N] , usize)];
-    [              ] [(Vec<&TensorAny<R, T, B, D>> , i32  )];
-    [              ] [(&Vec<&TensorAny<R, T, B, D>>, i32  )];
-    [const N: usize] [([&TensorAny<R, T, B, D>; N] , i32  )];
+   [              ] [(&Vec<TensorAny<R, T, B, D>> , isize)];
+   [const N: usize] [([TensorAny<R, T, B, D>; N]  , isize)];
+   [              ] [(Vec<TensorAny<R, T, B, D>>  , usize)];
+   [              ] [(&Vec<TensorAny<R, T, B, D>> , usize)];
+   [const N: usize] [([TensorAny<R, T, B, D>; N]  , usize)];
+   [              ] [(Vec<TensorAny<R, T, B, D>>  , i32  )];
+   [              ] [(&Vec<TensorAny<R, T, B, D>> , i32  )];
+   [const N: usize] [([TensorAny<R, T, B, D>; N]  , i32  )];
+   
+   [              ] [(Vec<&TensorAny<R, T, B, D>> , isize)];
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>, isize)];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] , isize)];
+   [              ] [(Vec<&TensorAny<R, T, B, D>> , usize)];
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>, usize)];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] , usize)];
+   [              ] [(Vec<&TensorAny<R, T, B, D>> , i32  )];
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>, i32  )];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] , i32  )];
 )]
 impl<R, T, B, D, ImplType> ConcatAPI<()> for ImplStruct
 where
@@ -439,6 +439,34 @@ where
         let (tensors, axis) = self;
         #[allow(clippy::unnecessary_cast)]
         let axis = axis as isize;
+        let tensors = tensors.iter().map(|t| t.view()).collect::<Vec<_>>();
+        ConcatAPI::concat_f((tensors, axis))
+    }
+}
+
+#[duplicate_item(
+    ImplType         ImplStruct                   ;
+   [              ] [Vec<TensorAny<R, T, B, D>>  ];
+   [              ] [&Vec<TensorAny<R, T, B, D>> ];
+   [const N: usize] [[TensorAny<R, T, B, D>; N]  ];
+   
+   [              ] [Vec<&TensorAny<R, T, B, D>> ];
+   [              ] [&Vec<&TensorAny<R, T, B, D>>];
+   [const N: usize] [[&TensorAny<R, T, B, D>; N] ];
+)]
+impl<R, T, B, D, ImplType> ConcatAPI<()> for ImplStruct
+where
+    R: DataAPI<Data = B::Raw>,
+    T: Clone + Default,
+    D: DimAPI,
+    B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignAPI<T, IxD>,
+{
+    type Out = Tensor<T, B, IxD>;
+
+    fn concat_f(self) -> Result<Self::Out> {
+        let tensors = self;
+        #[allow(clippy::unnecessary_cast)]
+        let axis = 0;
         let tensors = tensors.iter().map(|t| t.view()).collect::<Vec<_>>();
         ConcatAPI::concat_f((tensors, axis))
     }

--- a/rstsr-core/src/tensor/creation_from_tensor.rs
+++ b/rstsr-core/src/tensor/creation_from_tensor.rs
@@ -100,6 +100,153 @@ where
 
 /* #endregion */
 
+/* #region meshgrid */
+
+pub trait MeshgridAPI<Inp> {
+    type Out;
+
+    fn meshgrid_f(self) -> Result<Self::Out>;
+
+    fn meshgrid(self) -> Self::Out
+    where
+        Self: Sized,
+    {
+        Self::meshgrid_f(self).unwrap()
+    }
+}
+
+/// Returns coordinate matrices from coordinate vectors.
+///
+/// # See also
+///
+/// - [Python Array Standard `meshgrid`](https://data-apis.org/array-api/latest/API_specification/generated/array_api.meshgrid.html)
+pub fn meshgrid<Args, Inp>(args: Args) -> Args::Out
+where
+    Args: MeshgridAPI<Inp>,
+{
+    Args::meshgrid(args)
+}
+
+pub fn meshgrid_f<Args, Inp>(args: Args) -> Result<Args::Out>
+where
+    Args: MeshgridAPI<Inp>,
+{
+    Args::meshgrid_f(args)
+}
+
+impl<R, T, B, D> MeshgridAPI<()> for (Vec<&TensorAny<R, T, B, D>>, &str, bool)
+where
+    R: DataAPI<Data = B::Raw> + DataCloneAPI,
+    T: Clone,
+    D: DimAPI,
+    B: DeviceAPI<T>
+        + DeviceCreationAnyAPI<T>
+        + OpAssignAPI<T, IxD>
+        + OpAssignArbitaryAPI<T, IxD, IxD>,
+    B::Raw: Clone,
+{
+    type Out = Vec<Tensor<T, B, IxD>>;
+
+    fn meshgrid_f(self) -> Result<Self::Out> {
+        let (tensors, indexing, copy) = self;
+
+        match indexing {
+            "ij" | "xy" => (),
+            _ => rstsr_raise!(InvalidValue, "indexing must be 'ij' or 'xy'.")?,
+        }
+
+        // fast return for tensors with length 0/1
+        if tensors.is_empty() {
+            return Ok(vec![]);
+        } else if tensors.len() == 1 {
+            let tensor = tensors[0];
+            rstsr_assert_eq!(tensor.ndim(), 1, InvalidLayout, "meshgrid only support 1-D tensor.")?;
+            return Ok(vec![tensor.view().into_dim().into_owned()]);
+        }
+
+        // check
+        // a. all tensors must have the same device
+        // b. all tensors are 1-D
+        let device = tensors[0].device();
+        tensors.iter().try_for_each(|tensor| -> Result<()> {
+            rstsr_assert_eq!(tensor.ndim(), 1, InvalidLayout, "meshgrid only support 1-D tensor.")?;
+            rstsr_assert!(
+                tensor.device().same_device(device),
+                DeviceMismatch,
+                "All tensors must be on the same device."
+            )?;
+            Ok(())
+        })?;
+
+        let ndim = tensors.len();
+        let s0 = vec![1isize; ndim];
+
+        // tensors to be broadcasted
+        let tensors = tensors
+            .iter()
+            .enumerate()
+            .map(|(i, tensor)| {
+                let mut shape_new = s0.clone();
+                if indexing == "xy" && i == 0 {
+                    // special case for indexing="xy"
+                    shape_new[1] = -1;
+                } else if indexing == "xy" && i == 1 {
+                    // special case for indexing="xy"
+                    shape_new[0] = -1;
+                } else {
+                    // s0[:i] + (-1,) + so[i+1:]
+                    shape_new[i] = -1;
+                }
+                tensor.view().into_dim::<IxD>().into_shape_f(shape_new)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // tensors have been broadcasted to the same shape
+        let tensors = broadcast_arrays_f(tensors)?;
+
+        if !copy {
+            Ok(tensors)
+        } else {
+            tensors.into_iter().map(|t| t.into_contig_f(device.default_order())).collect()
+        }
+    }
+}
+
+#[duplicate_item(
+    ImplType         ImplStruct                                           tuple_args                  tuple_internal                             ;
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>, &str, bool)] [(tensors, indexing, copy)] [(tensors.to_vec(), indexing, copy)];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] , &str, bool)] [(tensors, indexing, copy)] [(tensors.to_vec(), indexing, copy)];
+   [              ] [(Vec<&TensorAny<R, T, B, D>> , &str,     )] [(tensors, indexing,     )] [(tensors.to_vec(), indexing, true)];
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>, &str,     )] [(tensors, indexing,     )] [(tensors.to_vec(), indexing, true)];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] , &str,     )] [(tensors, indexing,     )] [(tensors.to_vec(), indexing, true)];
+   [              ] [(Vec<&TensorAny<R, T, B, D>> ,       bool)] [(tensors,           copy)] [(tensors.to_vec(), "xy"    , copy)];
+   [              ] [(&Vec<&TensorAny<R, T, B, D>>,       bool)] [(tensors,           copy)] [(tensors.to_vec(), "xy"    , copy)];
+   [const N: usize] [([&TensorAny<R, T, B, D>; N] ,       bool)] [(tensors,           copy)] [(tensors.to_vec(), "xy"    , copy)];
+   [              ] [ Vec<&TensorAny<R, T, B, D>>              ] [ tensors                 ] [(tensors.to_vec(), "xy"    , true)];
+   [              ] [ &Vec<&TensorAny<R, T, B, D>>             ] [ tensors                 ] [(tensors.to_vec(), "xy"    , true)];
+   [const N: usize] [ [&TensorAny<R, T, B, D>; N]              ] [ tensors                 ] [(tensors.to_vec(), "xy"    , true)];
+)]
+impl<R, T, B, D, ImplType> MeshgridAPI<()> for ImplStruct
+where
+    R: DataAPI<Data = B::Raw> + DataCloneAPI,
+    T: Clone,
+    D: DimAPI,
+    B: DeviceAPI<T>
+        + DeviceCreationAnyAPI<T>
+        + OpAssignAPI<T, IxD>
+        + OpAssignArbitaryAPI<T, IxD, IxD>,
+    B::Raw: Clone,
+{
+    type Out = Vec<Tensor<T, B, IxD>>;
+
+    fn meshgrid_f(self) -> Result<Self::Out> {
+        let tuple_args = self;
+        let (tensors, indexing, copy) = tuple_internal;
+        MeshgridAPI::meshgrid_f((tensors, indexing, copy))
+    }
+}
+
+/* #endregion */
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -114,5 +261,15 @@ mod test {
         let c = arange(3) + 1;
         let d = diag((&c, -1));
         println!("{d:}");
+    }
+
+    #[test]
+    fn test_meshgrid() {
+        let a = arange((3i32, &DeviceFaer::default()));
+        let b = arange((4i32, &DeviceFaer::default()));
+        let c = meshgrid((&vec![&a, &b], "ij", true));
+        println!("{c:?}");
+        let d = meshgrid((&vec![&a, &b], "xy", true));
+        println!("{d:?}");
     }
 }

--- a/rstsr-core/src/tensor/creation_from_tensor.rs
+++ b/rstsr-core/src/tensor/creation_from_tensor.rs
@@ -246,7 +246,7 @@ where
 
 // implementation for non-reference tensors
 #[duplicate_item(
-    ImplType         ImplStruct                                           tuple_args           tuple_internal  ;              
+    ImplType         ImplStruct                                           tuple_args           tuple_internal ;
    [              ] [(Vec<TensorAny<R, T, B, D>> , &str, bool)] [(tensors, indexing, copy)] [(indexing, copy)];
    [              ] [(&Vec<TensorAny<R, T, B, D>>, &str, bool)] [(tensors, indexing, copy)] [(indexing, copy)];
    [const N: usize] [([TensorAny<R, T, B, D>; N] , &str, bool)] [(tensors, indexing, copy)] [(indexing, copy)];

--- a/rstsr-core/src/tensor/indexing.rs
+++ b/rstsr-core/src/tensor/indexing.rs
@@ -9,8 +9,7 @@ use crate::prelude_dev::*;
 pub fn into_slice_f<S, D, I>(tensor: TensorBase<S, D>, index: I) -> Result<TensorBase<S, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
 {
     let (data, layout) = tensor.into_raw_parts();
     let index = index.try_into()?;
@@ -21,8 +20,7 @@ where
 pub fn into_slice<S, D, I>(tensor: TensorBase<S, D>, index: I) -> TensorBase<S, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
 {
     into_slice_f(tensor, index).unwrap()
 }
@@ -33,8 +31,7 @@ pub fn slice_f<R, T, B, D, I>(
 ) -> Result<TensorView<'_, T, B, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -44,8 +41,7 @@ where
 pub fn slice<R, T, B, D, I>(tensor: &TensorAny<R, T, B, D>, index: I) -> TensorView<'_, T, B, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -60,48 +56,42 @@ where
 {
     pub fn into_slice_f<I>(self, index: I) -> Result<TensorAny<R, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         into_slice_f(self, index)
     }
 
     pub fn into_slice<I>(self, index: I) -> TensorAny<R, T, B, IxD>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         into_slice(self, index)
     }
 
     pub fn slice_f<I>(&self, index: I) -> Result<TensorView<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_f(self, index)
     }
 
     pub fn slice<I>(&self, index: I) -> TensorView<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice(self, index)
     }
 
     pub fn i_f<I>(&self, index: I) -> Result<TensorView<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_f(self, index)
     }
 
     pub fn i<I>(&self, index: I) -> TensorView<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice(self, index)
     }
@@ -117,8 +107,7 @@ pub fn slice_mut_f<R, T, B, D, I>(
 ) -> Result<TensorMut<'_, T, B, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
     R: DataMutAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -131,8 +120,7 @@ pub fn slice_mut<R, T, B, D, I>(
 ) -> TensorMut<'_, T, B, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<Indexer>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<Indexer>, Error = Error>,
     R: DataMutAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -147,32 +135,28 @@ where
 {
     pub fn slice_mut_f<I>(&mut self, index: I) -> Result<TensorMut<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_mut_f(self, index)
     }
 
     pub fn slice_mut<I>(&mut self, index: I) -> TensorMut<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_mut(self, index)
     }
 
     pub fn i_mut_f<I>(&mut self, index: I) -> Result<TensorMut<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_mut_f(self, index)
     }
 
     pub fn i_mut<I>(&mut self, index: I) -> TensorMut<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<Indexer>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<Indexer>, Error = Error>,
     {
         slice_mut(self, index)
     }

--- a/rstsr-core/src/tensor/iterator_axes.rs
+++ b/rstsr-core/src/tensor/iterator_axes.rs
@@ -83,8 +83,7 @@ where
         order: TensorIterOrder,
     ) -> Result<IterAxesView<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         // convert axis to negative indexes and sort
         let ndim: isize = TryInto::<isize>::try_into(self.ndim())?;
@@ -144,24 +143,21 @@ where
 
     pub fn axes_iter_f<I>(&self, axes: I) -> Result<IterAxesView<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_with_order_f(axes, TensorIterOrder::default())
     }
 
     pub fn axes_iter_with_order<I>(&self, axes: I, order: TensorIterOrder) -> IterAxesView<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_with_order_f(axes, order).unwrap()
     }
 
     pub fn axes_iter<I>(&self, axes: I) -> IterAxesView<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_f(axes).unwrap()
     }
@@ -249,8 +245,7 @@ where
         order: TensorIterOrder,
     ) -> Result<IterAxesMut<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         // convert axis to negative indexes and sort
         let ndim: isize = TryInto::<isize>::try_into(self.ndim())?;
@@ -310,8 +305,7 @@ where
 
     pub fn axes_iter_mut_f<I>(&'a mut self, axes: I) -> Result<IterAxesMut<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_mut_with_order_f(axes, TensorIterOrder::default())
     }
@@ -322,16 +316,14 @@ where
         order: TensorIterOrder,
     ) -> IterAxesMut<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_mut_with_order_f(axes, order).unwrap()
     }
 
     pub fn axes_iter_mut<I>(&'a mut self, axes: I) -> IterAxesMut<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.axes_iter_mut_f(axes).unwrap()
     }
@@ -427,8 +419,7 @@ where
         order: TensorIterOrder,
     ) -> Result<IndexedIterAxesView<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         use TensorIterOrder::*;
         // this function only accepts c/f iter order currently
@@ -496,8 +487,7 @@ where
 
     pub fn indexed_axes_iter_f<I>(&self, axes: I) -> Result<IndexedIterAxesView<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         let default_order = self.device().default_order();
         let order = match default_order {
@@ -513,16 +503,14 @@ where
         order: TensorIterOrder,
     ) -> IndexedIterAxesView<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.indexed_axes_iter_with_order_f(axes, order).unwrap()
     }
 
     pub fn indexed_axes_iter<I>(&self, axes: I) -> IndexedIterAxesView<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.indexed_axes_iter_f(axes).unwrap()
     }
@@ -618,8 +606,7 @@ where
         order: TensorIterOrder,
     ) -> Result<IndexedIterAxesMut<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         // convert axis to negative indexes and sort
         let ndim: isize = TryInto::<isize>::try_into(self.ndim())?;
@@ -679,8 +666,7 @@ where
 
     pub fn indexed_axes_iter_mut_f<I>(&'a mut self, axes: I) -> Result<IndexedIterAxesMut<'a, T, B>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         let default_order = self.device().default_order();
         let order = match default_order {
@@ -696,16 +682,14 @@ where
         order: TensorIterOrder,
     ) -> IndexedIterAxesMut<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.indexed_axes_iter_mut_with_order_f(axes, order).unwrap()
     }
 
     pub fn indexed_axes_iter_mut<I>(&'a mut self, axes: I) -> IndexedIterAxesMut<'a, T, B>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.indexed_axes_iter_mut_f(axes).unwrap()
     }

--- a/rstsr-core/src/tensor/manuplication.rs
+++ b/rstsr-core/src/tensor/manuplication.rs
@@ -170,8 +170,7 @@ where
 pub fn into_expand_dims_f<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> Result<TensorBase<S, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     // convert axis to negative indexes and sort
     let ndim: isize = TryInto::<isize>::try_into(tensor.ndim())?;
@@ -206,8 +205,7 @@ pub fn expand_dims<I, R, T, B, D>(
 ) -> TensorView<'_, T, B, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -220,8 +218,7 @@ pub fn expand_dims_f<I, R, T, B, D>(
 ) -> Result<TensorView<'_, T, B, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -231,8 +228,7 @@ where
 pub fn into_expand_dims<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> TensorBase<S, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     into_expand_dims_f(tensor, axes).unwrap()
 }
@@ -251,16 +247,14 @@ where
     /// [`expand_dims`]
     pub fn expand_dims<I>(&self, axes: I) -> TensorView<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_expand_dims(self.view(), axes)
     }
 
     pub fn expand_dims_f<I>(&self, axes: I) -> Result<TensorView<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_expand_dims_f(self.view(), axes)
     }
@@ -273,16 +267,14 @@ where
     /// [`expand_dims`]
     pub fn into_expand_dims<I>(self, axes: I) -> TensorAny<R, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_expand_dims(self, axes)
     }
 
     pub fn into_expand_dims_f<I>(self, axes: I) -> Result<TensorAny<R, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_expand_dims_f(self, axes)
     }
@@ -295,8 +287,7 @@ where
 pub fn into_flip_f<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> Result<TensorBase<S, D>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     let (storage, mut layout) = tensor.into_raw_parts();
     let axes = axes.try_into()?;
@@ -326,8 +317,7 @@ where
 pub fn flip<I, R, T, B, D>(tensor: &TensorAny<R, T, B, D>, axes: I) -> TensorView<'_, T, B, D>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -340,8 +330,7 @@ pub fn flip_f<I, R, T, B, D>(
 ) -> Result<TensorView<'_, T, B, D>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -351,8 +340,7 @@ where
 pub fn into_flip<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> TensorBase<S, D>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     into_flip_f(tensor, axes).unwrap()
 }
@@ -370,16 +358,14 @@ where
     /// [`flip`]
     pub fn flip<I>(&self, axis: I) -> TensorView<'_, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         flip(self, axis)
     }
 
     pub fn flip_f<I>(&self, axis: I) -> Result<TensorView<'_, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         flip_f(self, axis)
     }
@@ -391,16 +377,14 @@ where
     /// [`flip`]
     pub fn into_flip<I>(self, axis: I) -> TensorAny<R, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_flip(self, axis)
     }
 
     pub fn into_flip_f<I>(self, axis: I) -> Result<TensorAny<R, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_flip_f(self, axis)
     }
@@ -413,8 +397,7 @@ where
 pub fn into_transpose_f<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> Result<TensorBase<S, D>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     let axes = axes.try_into()?;
     if axes.as_ref().is_empty() {
@@ -433,8 +416,7 @@ where
 pub fn transpose<I, R, T, B, D>(tensor: &TensorAny<R, T, B, D>, axes: I) -> TensorView<'_, T, B, D>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -447,8 +429,7 @@ pub fn transpose_f<I, R, T, B, D>(
 ) -> Result<TensorView<'_, T, B, D>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -458,8 +439,7 @@ where
 pub fn into_transpose<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> TensorBase<S, D>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     into_transpose_f(tensor, axes).unwrap()
 }
@@ -482,16 +462,14 @@ where
     /// [`transpose`]
     pub fn transpose<I>(&self, axes: I) -> TensorView<'_, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         transpose(self, axes)
     }
 
     pub fn transpose_f<I>(&self, axes: I) -> Result<TensorView<'_, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         transpose_f(self, axes)
     }
@@ -503,16 +481,14 @@ where
     /// [`transpose`]
     pub fn into_transpose<I>(self, axes: I) -> TensorAny<R, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_transpose(self, axes)
     }
 
     pub fn into_transpose_f<I>(self, axes: I) -> Result<TensorAny<R, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_transpose_f(self, axes)
     }
@@ -524,16 +500,14 @@ where
     /// [`transpose`]
     pub fn permute_dims<I>(&self, axes: I) -> TensorView<'_, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         transpose(self, axes)
     }
 
     pub fn permute_dims_f<I>(&self, axes: I) -> Result<TensorView<'_, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         transpose_f(self, axes)
     }
@@ -545,16 +519,14 @@ where
     /// [`transpose`]
     pub fn into_permute_dims<I>(self, axes: I) -> TensorAny<R, T, B, D>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_transpose(self, axes)
     }
 
     pub fn into_permute_dims_f<I>(self, axes: I) -> Result<TensorAny<R, T, B, D>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_transpose_f(self, axes)
     }
@@ -730,8 +702,7 @@ where
 pub fn into_squeeze_f<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> Result<TensorBase<S, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     // convert axis to positive indexes and (reversed) sort
     let ndim: isize = TryInto::<isize>::try_into(tensor.ndim())?;
@@ -762,8 +733,7 @@ where
 pub fn squeeze<I, R, T, B, D>(tensor: &TensorAny<R, T, B, D>, axes: I) -> TensorView<'_, T, B, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -776,8 +746,7 @@ pub fn squeeze_f<I, R, T, B, D>(
 ) -> Result<TensorView<'_, T, B, IxD>>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw>,
     B: DeviceAPI<T>,
 {
@@ -787,8 +756,7 @@ where
 pub fn into_squeeze<I, S, D>(tensor: TensorBase<S, D>, axes: I) -> TensorBase<S, IxD>
 where
     D: DimAPI,
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
 {
     into_squeeze_f(tensor, axes).unwrap()
 }
@@ -806,16 +774,14 @@ where
     /// [`squeeze`]
     pub fn squeeze<I>(&self, axis: I) -> TensorView<'_, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         squeeze(self, axis)
     }
 
     pub fn squeeze_f<I>(&self, axis: I) -> Result<TensorView<'_, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         squeeze_f(self, axis)
     }
@@ -827,16 +793,14 @@ where
     /// [`squeeze`]
     pub fn into_squeeze<I>(self, axis: I) -> TensorAny<R, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_squeeze(self, axis)
     }
 
     pub fn into_squeeze_f<I>(self, axis: I) -> Result<TensorAny<R, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         into_squeeze_f(self, axis)
     }
@@ -1118,8 +1082,7 @@ pub fn change_shape_f<'a, I, R, T, B, D>(
     shape: I,
 ) -> Result<TensorCow<'a, T, B, IxD>>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1153,8 +1116,7 @@ pub fn change_shape<'a, I, R, T, B, D>(
     shape: I,
 ) -> TensorCow<'a, T, B, IxD>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1167,8 +1129,7 @@ pub fn into_shape_f<'a, I, R, T, B, D>(
     shape: I,
 ) -> Result<Tensor<T, B, IxD>>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     T: Clone,
@@ -1183,8 +1144,7 @@ where
 
 pub fn into_shape<'a, I, R, T, B, D>(tensor: TensorAny<R, T, B, D>, shape: I) -> Tensor<T, B, IxD>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     T: Clone,
@@ -1202,8 +1162,7 @@ pub fn to_shape_f<'a, I, R, T, B, D>(
     shape: I,
 ) -> Result<TensorCow<'a, T, B, IxD>>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1216,8 +1175,7 @@ pub fn to_shape<'a, I, R, T, B, D>(
     shape: I,
 ) -> TensorCow<'a, T, B, IxD>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1230,8 +1188,7 @@ pub fn reshape_f<'a, I, R, T, B, D>(
     shape: I,
 ) -> Result<TensorCow<'a, T, B, IxD>>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1244,8 +1201,7 @@ pub fn reshape<'a, I, R, T, B, D>(
     shape: I,
 ) -> TensorCow<'a, T, B, IxD>
 where
-    I: TryInto<AxesIndex<isize>>,
-    Error: From<I::Error>,
+    I: TryInto<AxesIndex<isize>, Error = Error>,
     R: DataAPI<Data = B::Raw> + DataIntoCowAPI<'a>,
     D: DimAPI,
     B: DeviceAPI<T> + DeviceCreationAnyAPI<T> + OpAssignArbitaryAPI<T, IxD, D>,
@@ -1265,24 +1221,21 @@ where
 {
     pub fn change_shape_f<I>(self, shape: I) -> Result<TensorCow<'a, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         change_shape_f(self, shape)
     }
 
     pub fn change_shape<I>(self, shape: I) -> TensorCow<'a, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         change_shape(self, shape)
     }
 
     pub fn into_shape_f<I>(self, shape: I) -> Result<Tensor<T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
         B::Raw: Clone + 'a,
     {
         into_shape_f(self, shape)
@@ -1290,8 +1243,7 @@ where
 
     pub fn into_shape<I>(self, shape: I) -> Tensor<T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
         B::Raw: Clone + 'a,
     {
         into_shape(self, shape)
@@ -1299,32 +1251,28 @@ where
 
     pub fn to_shape_f<I>(&'a self, shape: I) -> Result<TensorCow<'a, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.view().change_shape_f(shape)
     }
 
     pub fn to_shape<I>(&'a self, shape: I) -> TensorCow<'a, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.view().change_shape(shape)
     }
 
     pub fn reshape_f<I>(&'a self, shape: I) -> Result<TensorCow<'a, T, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.view().change_shape_f(shape)
     }
 
     pub fn reshape<I>(&'a self, shape: I) -> TensorCow<'a, T, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.view().change_shape(shape)
     }

--- a/rstsr-core/src/tensor/reduction.rs
+++ b/rstsr-core/src/tensor/reduction.rs
@@ -19,8 +19,7 @@ macro_rules! trait_reduction {
             R: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
             D: DimAPI,
             B: $OpReduceAPI<T, D> + DeviceCreationAnyAPI<B::TOut>,
-            I: TryInto<AxesIndex<isize>>,
-            Error: From<I::Error>,
+            I: TryInto<AxesIndex<isize>, Error = Error>,
         {
             let axes = axes.try_into()?;
 
@@ -54,8 +53,7 @@ macro_rules! trait_reduction {
             R: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
             D: DimAPI,
             B: $OpReduceAPI<T, D> + DeviceCreationAnyAPI<B::TOut>,
-            I: TryInto<AxesIndex<isize>>,
-            Error: From<I::Error>,
+            I: TryInto<AxesIndex<isize>, Error = Error>,
         {
             $fn_axes_f(tensor, axes).unwrap()
         }
@@ -95,8 +93,7 @@ macro_rules! trait_reduction {
             pub fn $fn_axes_f<I>(&self, axes: I) -> Result<Tensor<B::TOut, B, IxD>>
             where
                 B: DeviceCreationAnyAPI<B::TOut>,
-                I: TryInto<AxesIndex<isize>>,
-                Error: From<I::Error>,
+                I: TryInto<AxesIndex<isize>, Error = Error>,
             {
                 $fn_axes_f(self, axes)
             }
@@ -104,8 +101,7 @@ macro_rules! trait_reduction {
             pub fn $fn_axes<I>(&self, axes: I) -> Tensor<B::TOut, B, IxD>
             where
                 B: DeviceCreationAnyAPI<B::TOut>,
-                I: TryInto<AxesIndex<isize>>,
-                Error: From<I::Error>,
+                I: TryInto<AxesIndex<isize>, Error = Error>,
             {
                 $fn_axes(self, axes)
             }
@@ -156,8 +152,7 @@ macro_rules! trait_reduction_arg {
             R: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
             D: DimAPI,
             B: $OpReduceAPI<T, D> + DeviceAPI<IxD>,
-            I: TryInto<AxesIndex<isize>>,
-            Error: From<I::Error>,
+            I: TryInto<AxesIndex<isize>, Error = Error>,
         {
             let axes = axes.try_into()?;
 
@@ -183,8 +178,7 @@ macro_rules! trait_reduction_arg {
             R: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
             D: DimAPI,
             B: $OpReduceAPI<T, D> + DeviceAPI<IxD>,
-            I: TryInto<AxesIndex<isize>>,
-            Error: From<I::Error>,
+            I: TryInto<AxesIndex<isize>, Error = Error>,
         {
             $fn_axes_f(tensor, axes).unwrap()
         }
@@ -224,8 +218,7 @@ macro_rules! trait_reduction_arg {
             pub fn $fn_axes_f<I>(&self, axes: I) -> Result<Tensor<IxD, B, IxD>>
             where
                 B: DeviceAPI<IxD>,
-                I: TryInto<AxesIndex<isize>>,
-                Error: From<I::Error>,
+                I: TryInto<AxesIndex<isize>, Error = Error>,
             {
                 $fn_axes_f(self, axes)
             }
@@ -233,8 +226,7 @@ macro_rules! trait_reduction_arg {
             pub fn $fn_axes<I>(&self, axes: I) -> Tensor<IxD, B, IxD>
             where
                 B: DeviceAPI<IxD>,
-                I: TryInto<AxesIndex<isize>>,
-                Error: From<I::Error>,
+                I: TryInto<AxesIndex<isize>, Error = Error>,
             {
                 $fn_axes(self, axes)
             }
@@ -286,12 +278,10 @@ where
     }
     fn sum_axes_f<I>(&self, axes: I) -> Result<Tensor<usize, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>;
+        I: TryInto<AxesIndex<isize>, Error = Error>;
     fn sum_axes<I>(&self, axes: I) -> Tensor<usize, B, IxD>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         self.sum_axes_f(axes).unwrap()
     }
@@ -309,8 +299,7 @@ where
 
     fn sum_axes_f<I>(&self, axes: I) -> Result<Tensor<usize, B, IxD>>
     where
-        I: TryInto<AxesIndex<isize>>,
-        Error: From<I::Error>,
+        I: TryInto<AxesIndex<isize>, Error = Error>,
     {
         let axes = axes.try_into()?;
 

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "faer")]
+
 use rstsr::prelude::*;
 use rstsr_core::prelude_dev::fingerprint;
 use rstsr_test_manifest::get_vec;


### PR DESCRIPTION
This PR will try to implement following methods:

- rstsr-core
  - [x] meshgrid
  - [x] stack, vstack, hstack
  - [x] unstack
  - [x] concate (concatenate)
  - [x] bool_select (custom function in rstsr only)

- rstsr-sci-traits (probably next PR)
  - new crate for similar (?) functionality of scipy, except for linalg (which is rstsr-linalg-traits) and sparse (which is out-of-scope for RSTSR)
  - [ ] distance::cdist
  - [ ] integrate::lebedev_rule

Refactor:
- Eliminate `Error: From<I::Error>` trait bound, and this causes many trait bounds of functions changes. User should not feel that.