### PR TITLE
Fix OpenBLAS device OpenMP `get_num_thread` function

### DIFF
--- a/rstsr-openblas/src/threading.rs
+++ b/rstsr-openblas/src/threading.rs
@@ -13,7 +13,7 @@ use rstsr_openblas_ffi::cblas::{OPENBLAS_OPENMP, OPENBLAS_SEQUENTIAL, OPENBLAS_T
 #[cfg(feature = "openmp")]
 extern "C" {
     pub fn omp_set_num_threads(arg1: c_int);
-    pub fn omp_get_num_threads() -> c_int;
+    pub fn omp_get_max_threads() -> c_int;
 }
 
 /* #endregion */
@@ -73,7 +73,7 @@ impl OpenBLASConfig {
             match self.get_parallel() {
                 OPENBLAS_THREAD => rstsr_openblas_ffi::cblas::openblas_get_num_threads() as usize,
                 #[cfg(feature = "openmp")]
-                OPENBLAS_OPENMP => omp_get_num_threads() as usize,
+                OPENBLAS_OPENMP => omp_get_max_threads() as usize,
                 _ => 1,
             }
         }


### PR DESCRIPTION
Note that for OpenMP, `omp_set_num_threads` often corresponds to `omp_get_max_threads` in non-parallel regions.

Before this fix, though RSTSR still parallels and controls the threading limits well, it will affect other programs due to false getting (use `omp_get_num_threads` in non-parallel region may usually give `1`, and this value will overrides after `with_num_threads` writes that value).