### PR TITLE
Update v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.3.6 -- 2025-06-05
+
+Bug Fix:
+- OpenBLAS device OpenMP `get_num_thread` function ([#40](https://github.com/RESTGroup/rstsr/pull/40))
+    - Note that threading control is not stablized. There may be an incoming API breaking change on this feature for v0.4+.
+
+Enhancements:
+- Feature addition (meshgrid, concat, stack, bool_select) ([#38](https://github.com/RESTGroup/rstsr/pull/38))
+- Feature addition (cdist, lebedev_rule) ([#39](https://github.com/RESTGroup/rstsr/pull/39))
+
+Refactor:
+- Eliminate `Error: From<I::Error>` trait bound ([#38](https://github.com/RESTGroup/rstsr/pull/38))
+
 ## v0.3.5 -- 2025-05-22
 
 Bug Fix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -22,16 +22,16 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.5" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.3.6" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.5" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.5" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.5" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.3.6" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.3.6" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.3.6" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.5" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.5" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.5" }
-rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, version = "0.3.5" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.3.6" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.3.6" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.3.6" }
+rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, version = "0.3.6" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies


### PR DESCRIPTION
## v0.3.6 -- 2025-06-05

Bug Fix:
- OpenBLAS device OpenMP `get_num_thread` function ([#40](https://github.com/RESTGroup/rstsr/pull/40))
    - Note that threading control is not stablized. There may be an incoming API breaking change on this feature for v0.4+.

Enhancements:
- Feature addition (meshgrid, concat, stack, bool_select) ([#38](https://github.com/RESTGroup/rstsr/pull/38))
- Feature addition (cdist, lebedev_rule) ([#39](https://github.com/RESTGroup/rstsr/pull/39))

Refactor:
- Eliminate `Error: From<I::Error>` trait bound ([#38](https://github.com/RESTGroup/rstsr/pull/38))