### PR TITLE
linalg: Solve-related functions supports vector (Ix1) RHS

### DIFF
--- a/.github/workflows/rstsr-core-test.yml
+++ b/.github/workflows/rstsr-core-test.yml
@@ -12,20 +12,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: unittest
-        run: cargo test -p rstsr-core --lib
+        run: cargo test -p rstsr-core --lib --release
       - name: unittest (common)
-        run: cargo test -p rstsr-common --lib
+        run: cargo test -p rstsr-common --lib --release
 
   unittests-col-major:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: unittest
-        run: cargo test -p rstsr-core --lib --no-default-features --features="std faer rayon col_major faer_as_default"
+        run: cargo test -p rstsr-core --lib --release --no-default-features --features="std faer rayon col_major faer_as_default"
   
   integration-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: integrationtest
-        run: cargo test -p rstsr-core --test "*"
+        run: cargo test -p rstsr-core --test "*" --release

--- a/.github/workflows/rstsr-linalg-traits.yml
+++ b/.github/workflows/rstsr-linalg-traits.yml
@@ -27,4 +27,4 @@ jobs:
         cd rstsr-openblas/tests/test_linalg_func
         python func_validation_f64.py
     - name: test faer implementation
-      run: cargo test -p rstsr-linalg-traits --test "*" --features="faer"
+      run: cargo test -p rstsr-linalg-traits --test "*" --release --features="faer"

--- a/.github/workflows/rstsr-openblas-test.yml
+++ b/.github/workflows/rstsr-openblas-test.yml
@@ -34,4 +34,4 @@ jobs:
         cd rstsr-openblas/tests/test_linalg_func
         python func_validation_f64.py
     - name: test
-      run: RSTSR_DEV=1 cargo test -p rstsr-openblas --features="openmp linalg"
+      run: RSTSR_DEV=1 cargo test -p rstsr-openblas --release --features="openmp linalg"

--- a/rstsr-linalg-traits/src/faer_impl/solve_general.rs
+++ b/rstsr-linalg-traits/src/faer_impl/solve_general.rs
@@ -38,48 +38,62 @@ where
 }
 
 #[duplicate_item(
-    ImplType                                                       TrA                                TrB                              ;
-   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceFaer, D>] [&TensorAny<Rb, T, DeviceFaer, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceFaer, D> ] [TensorView<'_, T, DeviceFaer, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceFaer, D>] [&TensorAny<R, T, DeviceFaer, D> ];
-   [T, D,                                                       ] [TensorView<'_, T, DeviceFaer, D>] [TensorView<'_, T, DeviceFaer, D>];
+    ImplType                                                            TrA                                 TrB                              ;
+   [T, DA, DB, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceFaer, DA>] [&TensorAny<Rb, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceFaer, DA> ] [TensorView<'_, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceFaer, DA>] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                                                       ] [TensorView<'_, T, DeviceFaer, DA>] [TensorView<'_, T, DeviceFaer, DB>];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
 where
     T: ComplexField,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
 {
-    type Out = Tensor<T, DeviceFaer, D>;
+    type Out = Tensor<T, DeviceFaer, DB>;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (a, b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                                TrB                             ;
-   ['b, T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ] [TensorMut<'b, T, DeviceFaer, D>];
-   ['b, T, D,                          ] [TensorView<'_, T, DeviceFaer, D>] [TensorMut<'b, T, DeviceFaer, D>];
-   [    T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, D> ] [Tensor<T, DeviceFaer, D>       ];
-   [    T, D,                          ] [TensorView<'_, T, DeviceFaer, D>] [Tensor<T, DeviceFaer, D>       ];
+    ImplType                                   TrA                                 TrB                              ;
+   ['b, T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, DA> ] [TensorMut<'b, T, DeviceFaer, DB>];
+   ['b, T, DA, DB,                          ] [TensorView<'_, T, DeviceFaer, DA>] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, DA> ] [Tensor<T, DeviceFaer, DB>       ];
+   [    T, DA, DB,                          ] [TensorView<'_, T, DeviceFaer, DA>] [Tensor<T, DeviceFaer, DB>       ];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
 where
     T: ComplexField,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
 {
     type Out = TrB;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (a, mut b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
         result.clone_to_mut();
         Ok(b)
@@ -87,48 +101,62 @@ where
 }
 
 #[duplicate_item(
-    ImplType                          TrA                               TrB                              ;
-   [T, D, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceFaer, D>] [&TensorAny<R, T, DeviceFaer, D> ];
-   [T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [TensorView<'_, T, DeviceFaer, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceFaer, D>       ] [&TensorAny<R, T, DeviceFaer, D> ];
-   [T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [TensorView<'_, T, DeviceFaer, D>];
+    ImplType                               TrA                                TrB                               ;
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceFaer, DA>] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                          ] [TensorMut<'_, T, DeviceFaer, DA>] [TensorView<'_, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceFaer, DA>       ] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                          ] [Tensor<T, DeviceFaer, DA>       ] [TensorView<'_, T, DeviceFaer, DB>];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
 where
     T: ComplexField,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
 {
-    type Out = Tensor<T, DeviceFaer, D>;
+    type Out = Tensor<T, DeviceFaer, DB>;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (mut a, b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                               TrB                             ;
-   ['b, T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [TensorMut<'b, T, DeviceFaer, D>];
-   [    T, D,                          ] [TensorMut<'_, T, DeviceFaer, D>] [Tensor<T, DeviceFaer, D>       ];
-   ['b, T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [TensorMut<'b, T, DeviceFaer, D>];
-   [    T, D,                          ] [Tensor<T, DeviceFaer, D>       ] [Tensor<T, DeviceFaer, D>       ];
+    ImplType        TrA                               TrB                              ;
+   ['b, T, DA, DB] [TensorMut<'_, T, DeviceFaer, DA>] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB] [TensorMut<'_, T, DeviceFaer, DA>] [Tensor<T, DeviceFaer, DB>       ];
+   ['b, T, DA, DB] [Tensor<T, DeviceFaer, DA>       ] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB] [Tensor<T, DeviceFaer, DA>       ] [Tensor<T, DeviceFaer, DB>       ];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceFaer> for (TrA, TrB)
 where
     T: ComplexField,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
 {
     type Out = TrB;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (mut a, mut b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = faer_impl_solve_general_f(a_view.into(), b_view.into())?;
         result.clone_to_mut();
         Ok(b)

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -121,6 +121,22 @@ mod test {
     }
 
     #[test]
+    fn test_solve_general_for_vec() {
+        let device = DeviceFaer::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024].to_vec();
+        let mut b = rt::asarray((b_vec, [1024].c(), &device)).into_dim::<Ix1>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - -9.120066438800688).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - -9.120066438800688).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_svd() {
         let device = DeviceFaer::default();
         let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();

--- a/rstsr-openblas/src/linalg_traits_impl/solve_general.rs
+++ b/rstsr-openblas/src/linalg_traits_impl/solve_general.rs
@@ -4,50 +4,64 @@ use rstsr_core::prelude_dev::*;
 use rstsr_linalg_traits::prelude_dev::*;
 
 #[duplicate_item(
-    ImplType                                                       TrA                                TrB                              ;
-   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                                                            TrA                                 TrB                               ;
+   [T, DA, DB, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, DA>] [&TensorAny<Rb, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                                                       ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceBLAS> for (TrA, TrB)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (a, b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
         rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_general_f(a_view.into(), b_view.into())?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                                TrB                             ;
-   ['b, T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorMut<'b, T, DeviceBLAS, D>];
-   ['b, T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [Tensor<T, DeviceBLAS, D>       ];
-   [    T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType                                   TrA                                 TrB                              ;
+   ['b, T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   ['b, T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [Tensor<T, DeviceBLAS, DB>       ];
+   [    T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceBLAS> for (TrA, TrB)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (a, mut b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_general_f(a_view.into(), b_view.into())?;
         result.clone_to_mut();
         Ok(b)
@@ -55,50 +69,64 @@ where
 }
 
 #[duplicate_item(
-    ImplType                          TrA                               TrB                              ;
-   [T, D, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, D>       ] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                               TrA                                TrB                               ;
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, DA>       ] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [Tensor<T, DeviceBLAS, DA>       ] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceBLAS> for (TrA, TrB)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (mut a, b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_general_f(a_view.into(), b_view.into())?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                               TrB                             ;
-   ['b, T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
-   ['b, T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType        TrA                                TrB                              ;
+   ['b, T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
+   ['b, T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveGeneralAPI<DeviceBLAS> for (TrA, TrB)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_general_f(self) -> Result<Self::Out> {
         let (mut a, mut b) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_general_f(a_view.into(), b_view.into())?;
         result.clone_to_mut();
         Ok(b)

--- a/rstsr-openblas/src/linalg_traits_impl/solve_symmetric.rs
+++ b/rstsr-openblas/src/linalg_traits_impl/solve_symmetric.rs
@@ -6,50 +6,64 @@ use rstsr_linalg_traits::prelude_dev::*;
 /* #region full-args */
 
 #[duplicate_item(
-    ImplType                                                       TrA                                TrB                              ;
-   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                                                            TrA                                 TrB                               ;
+   [T, DA, DB, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, DA>] [&TensorAny<Rb, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                                                       ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveSymmetricAPI<DeviceBLAS> for (TrA, TrB, bool, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_symmetric_f(self) -> Result<Self::Out> {
         let (a, b, hermi, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_symmetric_f(a_view.into(), b_view.into(), hermi, uplo)?;
-        return Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>());
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                                TrB                             ;
-   ['b, T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorMut<'b, T, DeviceBLAS, D>];
-   ['b, T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [Tensor<T, DeviceBLAS, D>       ];
-   [    T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType                                   TrA                                 TrB                              ;
+   ['b, T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   ['b, T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [Tensor<T, DeviceBLAS, DB>       ];
+   [    T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveSymmetricAPI<DeviceBLAS> for (TrA, TrB, bool, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_symmetric_f(self) -> Result<Self::Out> {
         let (a, mut b, hermi, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_symmetric_f(a_view.into(), b_view.into(), hermi, uplo)?;
         result.clone_to_mut();
         Ok(b)
@@ -57,50 +71,64 @@ where
 }
 
 #[duplicate_item(
-    ImplType                          TrA                               TrB                              ;
-   [T, D, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, D>       ] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                               TrA                                TrB                               ;
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, DA>       ] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [Tensor<T, DeviceBLAS, DA>       ] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveSymmetricAPI<DeviceBLAS> for (TrA, TrB, bool, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_symmetric_f(self) -> Result<Self::Out> {
         let (mut a, b, hermi, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_symmetric_f(a_view.into(), b_view.into(), hermi, uplo)?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                               TrB                             ;
-   ['b, T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
-   ['b, T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType        TrA                                TrB                              ;
+   ['b, T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
+   ['b, T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveSymmetricAPI<DeviceBLAS> for (TrA, TrB, bool, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_symmetric_f(self) -> Result<Self::Out> {
         let (mut a, mut b, hermi, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_symmetric_f(a_view.into(), b_view.into(), hermi, uplo)?;
         result.clone_to_mut();
         Ok(b)

--- a/rstsr-openblas/src/linalg_traits_impl/solve_triangular.rs
+++ b/rstsr-openblas/src/linalg_traits_impl/solve_triangular.rs
@@ -6,50 +6,64 @@ use rstsr_linalg_traits::prelude_dev::*;
 /* #region full-args */
 
 #[duplicate_item(
-    ImplType                                                       TrA                                TrB                              ;
-   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                                                            TrA                                 TrB                               ;
+   [T, DA, DB, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, DA>] [&TensorAny<Rb, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                                                       ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveTriangularAPI<DeviceBLAS> for (TrA, TrB, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_triangular_f(self) -> Result<Self::Out> {
         let (a, b, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
-        return Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>());
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                                TrB                             ;
-   ['b, T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorMut<'b, T, DeviceBLAS, D>];
-   ['b, T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ] [Tensor<T, DeviceBLAS, D>       ];
-   [    T, D,                          ] [TensorView<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType                                   TrA                                 TrB                              ;
+   ['b, T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   ['b, T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, DA> ] [Tensor<T, DeviceBLAS, DB>       ];
+   [    T, DA, DB,                          ] [TensorView<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveTriangularAPI<DeviceBLAS> for (TrA, TrB, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_triangular_f(self) -> Result<Self::Out> {
         let (a, mut b, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
         result.clone_to_mut();
         Ok(b)
@@ -57,50 +71,64 @@ where
 }
 
 #[duplicate_item(
-    ImplType                          TrA                               TrB                              ;
-   [T, D, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
-   [T, D, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, D>       ] [&TensorAny<R, T, DeviceBLAS, D> ];
-   [T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorView<'_, T, DeviceBLAS, D>];
+    ImplType                               TrA                                TrB                               ;
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceBLAS, DA>] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorView<'_, T, DeviceBLAS, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceBLAS, DA>       ] [&TensorAny<R, T, DeviceBLAS, DB> ];
+   [T, DA, DB,                          ] [Tensor<T, DeviceBLAS, DA>       ] [TensorView<'_, T, DeviceBLAS, DB>];
 )]
 impl<ImplType> SolveTriangularAPI<DeviceBLAS> for (TrA, TrB, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
-    type Out = Tensor<T, DeviceBLAS, D>;
+    type Out = Tensor<T, DeviceBLAS, DB>;
     fn solve_triangular_f(self) -> Result<Self::Out> {
         let (mut a, b, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
-        Ok(result.into_owned().into_dim::<IxD>().into_dim::<D>())
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
     }
 }
 
 #[duplicate_item(
-    ImplType                              TrA                               TrB                             ;
-   ['b, T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [TensorMut<'_, T, DeviceBLAS, D>] [Tensor<T, DeviceBLAS, D>       ];
-   ['b, T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [TensorMut<'b, T, DeviceBLAS, D>];
-   [    T, D,                          ] [Tensor<T, DeviceBLAS, D>       ] [Tensor<T, DeviceBLAS, D>       ];
+    ImplType        TrA                                TrB                              ;
+   ['b, T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [TensorMut<'_, T, DeviceBLAS, DA>] [Tensor<T, DeviceBLAS, DB>       ];
+   ['b, T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [TensorMut<'b, T, DeviceBLAS, DB>];
+   [    T, DA, DB] [Tensor<T, DeviceBLAS, DA>       ] [Tensor<T, DeviceBLAS, DB>       ];
 )]
 impl<ImplType> SolveTriangularAPI<DeviceBLAS> for (TrA, TrB, Option<FlagUpLo>)
 where
     T: BlasFloat,
-    D: DimAPI,
+    DA: DimAPI,
+    DB: DimAPI,
     DeviceBLAS: LapackDriverAPI<T>,
 {
     type Out = TrB;
     fn solve_triangular_f(self) -> Result<Self::Out> {
         let (mut a, mut b, uplo) = self;
         rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
-        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
         let a_view = a.view_mut().into_dim::<Ix2>();
-        let b_view = b.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
         let result = ref_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
         result.clone_to_mut();
         Ok(b)

--- a/rstsr-openblas/tests/test_linalg_func/func_f64.rs
+++ b/rstsr-openblas/tests/test_linalg_func/func_f64.rs
@@ -166,6 +166,22 @@ mod test {
     }
 
     #[test]
+    fn test_solve_general_for_vec() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024].to_vec();
+        let mut b = rt::asarray((b_vec, [1024].c(), &device)).into_dim::<Ix1>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - -9.120066438800688).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - -9.120066438800688).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_solve_symmetric() {
         let device = DeviceBLAS::default();
         let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();

--- a/rstsr-openblas/tests/test_linalg_func/func_validation_f64.py
+++ b/rstsr-openblas/tests/test_linalg_func/func_validation_f64.py
@@ -78,6 +78,11 @@ b = b_raw[:1024*512].copy().reshape(1024, 512)
 x = np.linalg.solve(a, b)
 fingerprint(x)
 
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024].copy().reshape(1024)
+x = np.linalg.solve(a, b)
+fingerprint(x)
+
 # ### sovle_symmetric
 
 a = a_raw.copy().reshape(1024, 1024)


### PR DESCRIPTION
This enhancement will support case $A x = b$, where $x$ and $b$ are vector (1-D tensor). This enhancement affects DeviceFaer and DeviceOpenBLAS.

Previously, $x$ and $b$ must be 2-D matrix, which can be inconvenient ([code in showcase_rust_pcm](https://github.com/ajz34/showcase_rust_pcm/blob/a7d6fa2bec91214de58a9e6955b00c8cf9f46be5/src/lib.rs#L440), for example).