### PR TITLE
Faer enhancements

### DIFF
--- a/rstsr-linalg-traits/src/faer_impl/mod.rs
+++ b/rstsr-linalg-traits/src/faer_impl/mod.rs
@@ -5,5 +5,6 @@ pub mod eigvalsh;
 pub mod inv;
 pub mod pinv;
 pub mod solve_general;
+pub mod solve_triangular;
 pub mod svd;
 pub mod svdvals;

--- a/rstsr-linalg-traits/src/faer_impl/solve_triangular.rs
+++ b/rstsr-linalg-traits/src/faer_impl/solve_triangular.rs
@@ -1,0 +1,185 @@
+use crate::traits_def::SolveTriangularAPI;
+use faer::prelude::*;
+use faer::traits::ComplexField;
+use faer_ext::IntoFaer;
+use rstsr_blas_traits::prelude_dev::*;
+use rstsr_core::prelude_dev::*;
+
+pub fn faer_impl_solve_triangular_f<'b, T>(
+    a: TensorReference<'_, T, DeviceFaer, Ix2>,
+    b: TensorReference<'b, T, DeviceFaer, Ix2>,
+    uplo: Option<FlagUpLo>,
+) -> Result<TensorMutable<'b, T, DeviceFaer, Ix2>>
+where
+    T: ComplexField,
+{
+    // set parallel mode
+    let device = a.device().clone();
+    let pool = device.get_current_pool();
+    let faer_par = pool.map_or(Par::Seq, |pool| Par::rayon(pool.current_num_threads()));
+
+    let uplo = uplo.unwrap_or_else(|| match device.default_order() {
+        RowMajor => Lower,
+        ColMajor => Upper,
+    });
+    let faer_a = a.view().into_faer();
+    let mut b = overwritable_convert(b)?;
+    let faer_b = b.view_mut().into_faer();
+
+    match uplo {
+        Lower => faer::linalg::triangular_solve::solve_lower_triangular_in_place(faer_a, faer_b, faer_par),
+        Upper => faer::linalg::triangular_solve::solve_upper_triangular_in_place(faer_a, faer_b, faer_par),
+    }
+
+    Ok(b.clone_to_mut())
+}
+
+/* #region full-args */
+
+#[duplicate_item(
+    ImplType                                                            TrA                                 TrB                               ;
+   [T, DA, DB, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceFaer, DA>] [&TensorAny<Rb, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceFaer, DA> ] [TensorView<'_, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceFaer, DA>] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                                                       ] [TensorView<'_, T, DeviceFaer, DA>] [TensorView<'_, T, DeviceFaer, DB>];
+)]
+impl<ImplType> SolveTriangularAPI<DeviceFaer> for (TrA, TrB, Option<FlagUpLo>)
+where
+    T: ComplexField,
+    DA: DimAPI,
+    DB: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, DB>;
+    fn solve_triangular_f(self) -> Result<Self::Out> {
+        let (a, b, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
+        let result = faer_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
+    }
+}
+
+#[duplicate_item(
+    ImplType                                   TrA                                 TrB                              ;
+   ['b, T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, DA> ] [TensorMut<'b, T, DeviceFaer, DB>];
+   ['b, T, DA, DB,                          ] [TensorView<'_, T, DeviceFaer, DA>] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceFaer, DA> ] [Tensor<T, DeviceFaer, DB>       ];
+   [    T, DA, DB,                          ] [TensorView<'_, T, DeviceFaer, DA>] [Tensor<T, DeviceFaer, DB>       ];
+)]
+impl<ImplType> SolveTriangularAPI<DeviceFaer> for (TrA, TrB, Option<FlagUpLo>)
+where
+    T: ComplexField,
+    DA: DimAPI,
+    DB: DimAPI,
+{
+    type Out = TrB;
+    fn solve_triangular_f(self) -> Result<Self::Out> {
+        let (a, mut b, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
+        let result = faer_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
+        result.clone_to_mut();
+        Ok(b)
+    }
+}
+
+#[duplicate_item(
+    ImplType                               TrA                                TrB                               ;
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [TensorMut<'_, T, DeviceFaer, DA>] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                          ] [TensorMut<'_, T, DeviceFaer, DA>] [TensorView<'_, T, DeviceFaer, DB>];
+   [T, DA, DB, R: DataAPI<Data = Vec<T>>] [Tensor<T, DeviceFaer, DA>       ] [&TensorAny<R, T, DeviceFaer, DB> ];
+   [T, DA, DB,                          ] [Tensor<T, DeviceFaer, DA>       ] [TensorView<'_, T, DeviceFaer, DB>];
+)]
+impl<ImplType> SolveTriangularAPI<DeviceFaer> for (TrA, TrB, Option<FlagUpLo>)
+where
+    T: ComplexField,
+    DA: DimAPI,
+    DB: DimAPI,
+{
+    type Out = Tensor<T, DeviceFaer, DB>;
+    fn solve_triangular_f(self) -> Result<Self::Out> {
+        let (mut a, b, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i((.., None)).into_dim::<Ix2>(),
+            false => b.view().into_dim::<Ix2>(),
+        };
+        let result = faer_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
+        let result = result.into_owned().into_dim::<IxD>();
+        match is_b_vec {
+            true => Ok(result.into_shape(-1).into_dim::<DB>()),
+            false => Ok(result.into_dim::<DB>()),
+        }
+    }
+}
+
+#[duplicate_item(
+    ImplType        TrA                                TrB                              ;
+   ['b, T, DA, DB] [TensorMut<'_, T, DeviceFaer, DA>] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB] [TensorMut<'_, T, DeviceFaer, DA>] [Tensor<T, DeviceFaer, DB>       ];
+   ['b, T, DA, DB] [Tensor<T, DeviceFaer, DA>       ] [TensorMut<'b, T, DeviceFaer, DB>];
+   [    T, DA, DB] [Tensor<T, DeviceFaer, DA>       ] [Tensor<T, DeviceFaer, DB>       ];
+)]
+impl<ImplType> SolveTriangularAPI<DeviceFaer> for (TrA, TrB, Option<FlagUpLo>)
+where
+    T: ComplexField,
+    DA: DimAPI,
+    DB: DimAPI,
+{
+    type Out = TrB;
+    fn solve_triangular_f(self) -> Result<Self::Out> {
+        let (mut a, mut b, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(b.ndim(), 1..=2, InvalidLayout, "Currently we can only handle 1/2-D matrix.")?;
+        let is_b_vec = b.ndim() == 1;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let b_view = match is_b_vec {
+            true => b.i_mut((.., None)).into_dim::<Ix2>(),
+            false => b.view_mut().into_dim::<Ix2>(),
+        };
+        let result = faer_impl_solve_triangular_f(a_view.into(), b_view.into(), uplo)?;
+        result.clone_to_mut();
+        Ok(b)
+    }
+}
+
+/* #endregion */
+
+/* #region sub-args */
+
+#[duplicate_item(
+    ImplStruct             args_tuple     internal_tuple     ;
+   [(TrA, TrB, FlagUpLo)] [(a, b, uplo)] [(a, b, Some(uplo))];
+   [(TrA, TrB,         )] [(a, b,     )] [(a, b, None      )];
+)]
+impl<TrA, TrB> SolveTriangularAPI<DeviceFaer> for ImplStruct
+where
+    (TrA, TrB, Option<FlagUpLo>): SolveTriangularAPI<DeviceFaer>,
+{
+    type Out = <(TrA, TrB, Option<FlagUpLo>) as SolveTriangularAPI<DeviceFaer>>::Out;
+    fn solve_triangular_f(self) -> Result<Self::Out> {
+        let args_tuple = self;
+        SolveTriangularAPI::<DeviceFaer>::solve_triangular_f(internal_tuple)
+    }
+}
+
+/* #endregion */

--- a/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
+++ b/rstsr-linalg-traits/tests/test_faer_func/func_f64.rs
@@ -137,6 +137,22 @@ mod test {
     }
 
     #[test]
+    fn test_solve_triangular() {
+        let device = DeviceFaer::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let mut a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_triangular((b.view(), a.view()));
+        assert!((fingerprint(&x) - -2.6133848012216587).abs() < 1e-8);
+
+        // upper, mutable changes a
+        rt::linalg::solve_triangular((b.view(), a.view_mut(), Upper));
+        assert!((fingerprint(&a) - 5.112256818100785).abs() < 1e-8);
+    }
+
+    #[test]
     fn test_svd() {
         let device = DeviceFaer::default();
         let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();


### PR DESCRIPTION
This PR will focus on Faer backend:

- [ ] add `solve_triangular`
- [ ] refactor for more proper threading control (try to avoid `set_global_parallelism`)
- [ ] add general eigensolve support (manually implement lu/svd then gemm/trsm)

These enhancements should make Faer to be more similar to current OpenBLAS backend, and open up the possibility to perform elementary HF SCF computation without external BLAS library.