### PR TITLE
Support dynamic loading for OpenBLAS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, vers
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies
-rstsr-lapack-ffi = { version = "0.2.0" }
-rstsr-openblas-ffi = { version = "0.3.1" }
+rstsr-lapack-ffi = { version = "0.4.0", default-features = false, features = ["blas", "cblas", "lapack"] }
+rstsr-openblas-ffi = { version = "0.4.0", default-features = false, features = ["blas", "cblas", "lapack"] }
 # basic dependencies
 num = { version = "0.4" }
 itertools = { version = "0.13" }
@@ -62,3 +62,10 @@ opt-level = 0
 
 [profile.dev]
 opt-level = 2
+
+[profile.dev.package.rstsr-lapack-ffi]
+debug = false
+
+[profile.dev.package.rstsr-openblas-ffi]
+debug = false
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,10 @@ opt-level = 0
 opt-level = 2
 
 [profile.dev.package.rstsr-lapack-ffi]
+opt-level = 0
 debug = false
 
 [profile.dev.package.rstsr-openblas-ffi]
+opt-level = 0
 debug = false
 

--- a/rstsr-blas-traits/driver_impl/cblas/blas3/gemm.rs
+++ b/rstsr-blas-traits/driver_impl/cblas/blas3/gemm.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -26,7 +27,7 @@ impl GEMMDriverAPI<T> for DeviceBLAS {
         c: *mut T,
         ldc: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             transa.into(),
             transb.into(),
@@ -67,7 +68,7 @@ impl GEMMDriverAPI<T> for DeviceBLAS {
         c: *mut T,
         ldc: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             transa.into(),
             transb.into(),

--- a/rstsr-blas-traits/driver_impl/cblas/blas3/syhemm.rs
+++ b/rstsr-blas-traits/driver_impl/cblas/blas3/syhemm.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -25,7 +26,7 @@ impl<const HERMI: bool> SYHEMMDriverAPI<T, HERMI> for DeviceBLAS {
         c: *mut T,
         ldc: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             side.into(),
             uplo.into(),
@@ -66,7 +67,7 @@ impl SYHEMMDriverAPI<T, HERMI> for DeviceBLAS {
         c: *mut T,
         ldc: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             side.into(),
             uplo.into(),

--- a/rstsr-blas-traits/driver_impl/cblas/blas3/trsm.rs
+++ b/rstsr-blas-traits/driver_impl/cblas/blas3/trsm.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -24,7 +25,7 @@ impl TRSMDriverAPI<T> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             side.into(),
             uplo.into(),
@@ -61,7 +62,7 @@ impl TRSMDriverAPI<T> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) {
-        rstsr_lapack_ffi::cblas::cblas_func(
+        lapack_ffi::cblas::cblas_func(
             order.into(),
             side.into(),
             uplo.into(),

--- a/rstsr-blas-traits/driver_impl/lapack/eigh/syevd.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/eigh/syevd.rs
@@ -1,10 +1,9 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use num::complex::ComplexFloat;
 use num::Complex;
 use rstsr_blas_traits::prelude::*;
 use rstsr_common::prelude_dev::*;
-use rstsr_lapack_ffi::blas::xerbla_;
-use rstsr_lapack_ffi::lapacke::{LAPACK_TRANSPOSE_MEMORY_ERROR, LAPACK_WORK_MEMORY_ERROR};
 use rstsr_native_impl::prelude_dev::*;
 use std::slice::from_raw_parts_mut;
 
@@ -23,12 +22,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut T,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"syevd".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -50,7 +44,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
             &mut info,
         );
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query as usize;
         let liwork = iwork_query as usize;
@@ -58,11 +52,11 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         // Allocate memory for temporary array(s)
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
         let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
             Ok(iwork) => iwork,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
@@ -81,14 +75,14 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let la = Layout::new_unchecked([n, n], [lda as isize, 1], 0);
@@ -109,7 +103,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();
@@ -133,12 +127,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"syevd".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -164,7 +153,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
             &mut info,
         );
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query as usize;
         let lrwork = rwork_query as usize;
@@ -173,15 +162,15 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         // Allocate memory for temporary array(s)
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
         let mut rwork: Vec<<T as ComplexFloat>::Real> = match uninitialized_vec(lrwork) {
             Ok(rwork) => rwork,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
         let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
             Ok(iwork) => iwork,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
@@ -202,14 +191,14 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let la = Layout::new_unchecked([n, n], [lda as isize, 1], 0);
@@ -232,7 +221,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();

--- a/rstsr-blas-traits/driver_impl/lapack/solve/getrf.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/solve/getrf.rs
@@ -1,9 +1,8 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use num::Complex;
 use rstsr_blas_traits::prelude::*;
 use rstsr_common::prelude_dev::*;
-use rstsr_lapack_ffi::blas::xerbla_;
-use rstsr_lapack_ffi::lapacke::LAPACK_TRANSPOSE_MEMORY_ERROR;
 use rstsr_native_impl::prelude_dev::*;
 use std::slice::from_raw_parts_mut;
 
@@ -21,12 +20,7 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
         lda: usize,
         ipiv: *mut blas_int,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"getrf".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         let mut info = 0;
 
@@ -34,14 +28,14 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
             // Call LAPACK function and adjust info
             func_(&(m as _), &(n as _), a, &(lda as _), ipiv, &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = m.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(m * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, m * lda);
             let la = Layout::new_unchecked([m, n], [lda as isize, 1], 0);
@@ -50,7 +44,7 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
             // Call LAPACK function and adjust info
             func_(&(m as _), &(n as _), a_t.as_mut_ptr(), &(lda_t as _), ipiv, &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();
@@ -73,12 +67,7 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
         lda: usize,
         ipiv: *mut blas_int,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"getrf".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         let mut info = 0;
 
@@ -86,14 +75,14 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
             // Call LAPACK function and adjust info
             func_(&(m as _), &(n as _), a as *mut _, &(lda as _), ipiv, &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = m.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(m * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, m * lda);
             let la = Layout::new_unchecked([m, n], [lda as isize, 1], 0);
@@ -102,7 +91,7 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
             // Call LAPACK function and adjust info
             func_(&(m as _), &(n as _), a_t.as_mut_ptr() as *mut _, &(lda_t as _), ipiv, &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();

--- a/rstsr-blas-traits/driver_impl/lapack/solve/getri.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/solve/getri.rs
@@ -1,9 +1,9 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use num::Complex;
 use rstsr_blas_traits::prelude::*;
 use rstsr_common::prelude_dev::*;
-use rstsr_lapack_ffi::blas::xerbla_;
-use rstsr_lapack_ffi::lapacke::{LAPACK_TRANSPOSE_MEMORY_ERROR, LAPACK_WORK_MEMORY_ERROR};
+
 use rstsr_native_impl::prelude_dev::*;
 use std::slice::from_raw_parts_mut;
 
@@ -14,12 +14,7 @@ use std::slice::from_raw_parts_mut;
 )]
 impl GETRIDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_getri(order: FlagOrder, n: usize, a: *mut T, lda: usize, ipiv: *mut blas_int) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"getri".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -27,28 +22,28 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
         let mut work_query = 0.0;
         func_(&(n as _), a, &(lda as _), ipiv, &mut work_query, &lwork, &mut info);
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query as usize;
 
         // Allocate memory for work arrays
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
             // Call LAPACK function and adjust info
             func_(&(n as _), a, &(lda as _), ipiv, work.as_mut_ptr(), &(lwork as _), &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let la = Layout::new_unchecked([n, n], [lda as isize, 1], 0);
@@ -57,7 +52,7 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
             // Call LAPACK function and adjust info
             func_(&(n as _), a_t.as_mut_ptr(), &(lda_t as _), ipiv, work.as_mut_ptr(), &(lwork as _), &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();
@@ -73,12 +68,7 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
 )]
 impl GETRIDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_getri(order: FlagOrder, n: usize, a: *mut T, lda: usize, ipiv: *mut blas_int) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"getri".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -86,28 +76,28 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
         let mut work_query: T = num::zero();
         func_(&(n as _), a as *mut _, &(lda as _), ipiv, &mut work_query as *mut _ as *mut _, &lwork, &mut info);
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query.re as usize;
 
         // Allocate memory for work arrays
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
             // Call LAPACK function and adjust info
             func_(&(n as _), a as *mut _, &(lda as _), ipiv, work.as_mut_ptr() as *mut _, &(lwork as _), &mut info);
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let la = Layout::new_unchecked([n, n], [lda as isize, 1], 0);
@@ -124,7 +114,7 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();

--- a/rstsr-blas-traits/driver_impl/lapack/solve/sysv.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/solve/sysv.rs
@@ -1,9 +1,9 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use num::Complex;
 use rstsr_blas_traits::prelude::*;
 use rstsr_common::prelude_dev::*;
-use rstsr_lapack_ffi::blas::xerbla_;
-use rstsr_lapack_ffi::lapacke::{LAPACK_TRANSPOSE_MEMORY_ERROR, LAPACK_WORK_MEMORY_ERROR};
+
 use rstsr_native_impl::prelude_dev::*;
 use std::slice::from_raw_parts_mut;
 
@@ -24,12 +24,7 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"sysv".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -49,14 +44,14 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
             &mut info,
         );
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query as usize;
 
         // Allocate memory for work arrays
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
@@ -75,7 +70,7 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
@@ -83,11 +78,11 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let mut b_t: Vec<T> = match uninitialized_vec(n * nrhs) {
                 Ok(b_t) => b_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let b_slice = from_raw_parts_mut(b, n * ldb);
@@ -112,7 +107,7 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();
@@ -141,12 +136,7 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        use rstsr_lapack_ffi::lapack::func_;
-
-        unsafe fn raise_info(mut info: blas_int) -> blas_int {
-            xerbla_(c"sysv".as_ptr() as _, &mut info as *mut _ as *mut _);
-            return if info < 0 { info - 1 } else { info };
-        }
+        use lapack_ffi::lapack::func_;
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -166,14 +156,14 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
             &mut info,
         );
         if info != 0 {
-            return raise_info(info);
+            return info;
         }
         let lwork = work_query as usize;
 
         // Allocate memory for work arrays
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return LAPACK_WORK_MEMORY_ERROR,
+            Err(_) => return -1010,
         };
 
         if order == ColMajor {
@@ -192,7 +182,7 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
         } else {
             let lda_t = n.max(1);
@@ -200,11 +190,11 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
             // Transpose input matrices
             let mut a_t: Vec<T> = match uninitialized_vec(n * n) {
                 Ok(a_t) => a_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let mut b_t: Vec<T> = match uninitialized_vec(n * nrhs) {
                 Ok(b_t) => b_t,
-                Err(_) => return LAPACK_TRANSPOSE_MEMORY_ERROR,
+                Err(_) => return -1011,
             };
             let a_slice = from_raw_parts_mut(a, n * lda);
             let b_slice = from_raw_parts_mut(b, n * ldb);
@@ -229,7 +219,7 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
                 &mut info,
             );
             if info != 0 {
-                return raise_info(info);
+                return info;
             }
             // Transpose output matrices
             orderchange_out_c2r_ix2_cpu_serial(a_slice, &la, &a_t, &la_t).unwrap();

--- a/rstsr-blas-traits/driver_impl/lapacke/eigh/syev.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/eigh/syev.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -20,7 +21,7 @@ impl SYEVDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut T,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a, lda as _, w)
+        lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a, lda as _, w)
     }
 }
 
@@ -39,6 +40,6 @@ impl SYEVDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a as *mut _, lda as _, w)
+        lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a as *mut _, lda as _, w)
     }
 }

--- a/rstsr-blas-traits/driver_impl/lapacke/eigh/syevd.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/eigh/syevd.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -20,7 +21,7 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut T,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a, lda as _, w)
+        lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a, lda as _, w)
     }
 }
 
@@ -39,6 +40,6 @@ impl SYEVDDriverAPI<T> for DeviceBLAS {
         lda: usize,
         w: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a as *mut _, lda as _, w)
+        lapack_ffi::lapacke::lapacke_func(order as _, jobz as _, uplo.into(), n as _, a as *mut _, lda as _, w)
     }
 }

--- a/rstsr-blas-traits/driver_impl/lapacke/eigh/sygv.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/eigh/sygv.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -23,7 +24,7 @@ impl SYGVDriverAPI<T> for DeviceBLAS {
         ldb: usize,
         w: *mut T,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             itype as _,
             jobz as _,
@@ -56,7 +57,7 @@ impl SYGVDriverAPI<T> for DeviceBLAS {
         ldb: usize,
         w: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             itype as _,
             jobz as _,

--- a/rstsr-blas-traits/driver_impl/lapacke/eigh/sygvd.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/eigh/sygvd.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -23,7 +24,7 @@ impl SYGVDDriverAPI<T> for DeviceBLAS {
         ldb: usize,
         w: *mut T,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             itype as _,
             jobz as _,
@@ -56,7 +57,7 @@ impl SYGVDDriverAPI<T> for DeviceBLAS {
         ldb: usize,
         w: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             itype as _,
             jobz as _,

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/gesv.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/gesv.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -20,7 +21,7 @@ impl GESVDriverAPI<T> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, n as _, nrhs as _, a, lda as _, ipiv, b, ldb as _)
+        lapack_ffi::lapacke::lapacke_func(order as _, n as _, nrhs as _, a, lda as _, ipiv, b, ldb as _)
     }
 }
 
@@ -40,7 +41,7 @@ impl GESVDriverAPI<T> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             n as _,
             nrhs as _,

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/getrf.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/getrf.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -18,7 +19,7 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
         lda: usize,
         ipiv: *mut blas_int,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, m as _, n as _, a, lda as _, ipiv)
+        lapack_ffi::lapacke::lapacke_func(order as _, m as _, n as _, a, lda as _, ipiv)
     }
 }
 
@@ -36,6 +37,6 @@ impl GETRFDriverAPI<T> for DeviceBLAS {
         lda: usize,
         ipiv: *mut blas_int,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, m as _, n as _, a as *mut _, lda as _, ipiv)
+        lapack_ffi::lapacke::lapacke_func(order as _, m as _, n as _, a as *mut _, lda as _, ipiv)
     }
 }

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/getri.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/getri.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -11,7 +12,7 @@ use rstsr_common::prelude::*;
 )]
 impl GETRIDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_getri(order: FlagOrder, n: usize, a: *mut T, lda: usize, ipiv: *mut blas_int) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, n as _, a, lda as _, ipiv)
+        lapack_ffi::lapacke::lapacke_func(order as _, n as _, a, lda as _, ipiv)
     }
 }
 
@@ -22,6 +23,6 @@ impl GETRIDriverAPI<T> for DeviceBLAS {
 )]
 impl GETRIDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_getri(order: FlagOrder, n: usize, a: *mut T, lda: usize, ipiv: *mut blas_int) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, n as _, a as *mut _, lda as _, ipiv)
+        lapack_ffi::lapacke::lapacke_func(order as _, n as _, a as *mut _, lda as _, ipiv)
     }
 }

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/potrf.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/potrf.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -11,7 +12,7 @@ use rstsr_common::prelude::*;
 )]
 impl POTRFDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_potrf(order: FlagOrder, uplo: FlagUpLo, n: usize, a: *mut T, lda: usize) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, uplo.into(), n as _, a, lda as _)
+        lapack_ffi::lapacke::lapacke_func(order as _, uplo.into(), n as _, a, lda as _)
     }
 }
 
@@ -22,6 +23,6 @@ impl POTRFDriverAPI<T> for DeviceBLAS {
 )]
 impl POTRFDriverAPI<T> for DeviceBLAS {
     unsafe fn driver_potrf(order: FlagOrder, uplo: FlagUpLo, n: usize, a: *mut T, lda: usize) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(order as _, uplo.into(), n as _, a as *mut _, lda as _)
+        lapack_ffi::lapacke::lapacke_func(order as _, uplo.into(), n as _, a as *mut _, lda as _)
     }
 }

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/sysv.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/sysv.rs
@@ -22,17 +22,7 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        lapack_ffi::lapacke::lapacke_func(
-            order as _,
-            uplo.into(),
-            n as _,
-            nrhs as _,
-            a,
-            lda as _,
-            ipiv,
-            b,
-            ldb as _,
-        )
+        lapack_ffi::lapacke::lapacke_func(order as _, uplo.into(), n as _, nrhs as _, a, lda as _, ipiv, b, ldb as _)
     }
 }
 

--- a/rstsr-blas-traits/driver_impl/lapacke/solve/sysv.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/solve/sysv.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::Complex;
@@ -21,7 +22,7 @@ impl<const HERMI: bool> SYSVDriverAPI<T, HERMI> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             uplo.into(),
             n as _,
@@ -54,7 +55,7 @@ impl SYSVDriverAPI<T, HERMI> for DeviceBLAS {
         b: *mut T,
         ldb: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             uplo.into(),
             n as _,

--- a/rstsr-blas-traits/driver_impl/lapacke/svd/gesdd.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/svd/gesdd.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -24,7 +25,7 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
         vt: *mut T,
         ldvt: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _, jobz as _, m as _, n as _, a, lda as _, s, u, ldu as _, vt, ldvt as _,
         )
     }
@@ -49,7 +50,7 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
         vt: *mut T,
         ldvt: usize,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             jobz as _,
             m as _,

--- a/rstsr-blas-traits/driver_impl/lapacke/svd/gesvd.rs
+++ b/rstsr-blas-traits/driver_impl/lapacke/svd/gesvd.rs
@@ -1,3 +1,4 @@
+use crate::lapack_ffi;
 use crate::DeviceBLAS;
 use duplicate::duplicate_item;
 use num::complex::ComplexFloat;
@@ -26,7 +27,7 @@ impl GESVDDriverAPI<T> for DeviceBLAS {
         ldvt: usize,
         superb: *mut T,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _, jobu as _, jobvt as _, m as _, n as _, a, lda as _, s, u, ldu as _, vt, ldvt as _, superb,
         )
     }
@@ -53,7 +54,7 @@ impl GESVDDriverAPI<T> for DeviceBLAS {
         ldvt: usize,
         superb: *mut <T as ComplexFloat>::Real,
     ) -> blas_int {
-        rstsr_lapack_ffi::lapacke::lapacke_func(
+        lapack_ffi::lapacke::lapacke_func(
             order as _,
             jobu as _,
             jobvt as _,

--- a/rstsr-common/Cargo.toml
+++ b/rstsr-common/Cargo.toml
@@ -14,7 +14,7 @@ itertools = { workspace = true }
 num = { workspace = true }
 derive_builder = { workspace = true }
 rayon = { workspace = true, optional = true }
-rstsr-lapack-ffi = { workspace = true }
+rstsr-lapack-ffi = { workspace = true, default-features = false, features = ["cblas"] }
 
 [dev-dependencies]
 rstsr-core = { path = "../rstsr-core", default-features = false }

--- a/rstsr-openblas/Cargo.toml
+++ b/rstsr-openblas/Cargo.toml
@@ -14,7 +14,6 @@ rayon = { workspace = true }
 num = { workspace = true }
 duplicate = { workspace = true }
 rstsr-openblas-ffi = { workspace = true }
-rstsr-lapack-ffi = { workspace = true }
 rstsr-native-impl = { workspace = true, features = ["rayon"] }
 rstsr-core = { workspace = true, features = ["rayon"] }
 rstsr-common = { workspace = true, features = ["rayon"] }
@@ -28,13 +27,14 @@ rstsr = { path = "../rstsr", default-features = false, features = ["openblas", "
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg"]
+default = ["linalg", "dynamic_loading", "openmp"]
+dynamic_loading = ["rstsr-openblas-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
-ilp64 = ["rstsr-openblas-ffi/ilp64", "rstsr-lapack-ffi/ilp64", "rstsr-blas-traits/ilp64"]
+ilp64 = ["rstsr-openblas-ffi/ilp64", "rstsr-blas-traits/ilp64"]
 linalg = ["dep:rstsr-linalg-traits"]
 sci = ["dep:rstsr-sci-traits"]
 
 # use openmp for linking
 openmp = []
 # use lapacke instead of lapack for linalg functions
-lapacke = []
+lapacke = ["rstsr-openblas-ffi/lapacke"]

--- a/rstsr-openblas/Cargo.toml
+++ b/rstsr-openblas/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["openblas", "
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading", "openmp"]
+default = ["linalg", "dynamic_loading"]
 dynamic_loading = ["rstsr-openblas-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-openblas-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr-openblas/src/lib.rs
+++ b/rstsr-openblas/src/lib.rs
@@ -25,5 +25,6 @@ pub struct DeviceOpenBLAS {
     base: DeviceCpuRayon,
 }
 
+pub(crate) use rstsr_openblas_ffi as lapack_ffi;
 pub(crate) use DeviceOpenBLAS as DeviceBLAS;
 pub(crate) use DeviceOpenBLAS as DeviceRayonAutoImpl;

--- a/rstsr-openblas/src/matmul_impl.rs
+++ b/rstsr-openblas/src/matmul_impl.rs
@@ -5,7 +5,7 @@ use num::complex::Complex;
 use num::traits::ConstZero;
 use rayon::prelude::*;
 use rstsr_core::prelude_dev::uninitialized_vec;
-use rstsr_lapack_ffi::cblas;
+use lapack_ffi::cblas;
 use std::ffi::c_void;
 
 type c32 = Complex<f32>;

--- a/rstsr-openblas/src/matmul_impl.rs
+++ b/rstsr-openblas/src/matmul_impl.rs
@@ -1,11 +1,11 @@
 #![allow(non_camel_case_types)]
 
 use crate::prelude_dev::*;
+use lapack_ffi::cblas;
 use num::complex::Complex;
 use num::traits::ConstZero;
 use rayon::prelude::*;
 use rstsr_core::prelude_dev::uninitialized_vec;
-use lapack_ffi::cblas;
 use std::ffi::c_void;
 
 type c32 = Complex<f32>;

--- a/rstsr-openblas/src/prelude_dev.rs
+++ b/rstsr-openblas/src/prelude_dev.rs
@@ -1,3 +1,4 @@
 pub(crate) use crate::DeviceBLAS;
 pub(crate) use crate::DeviceRayonAutoImpl;
 pub use rstsr_core::prelude_dev::*;
+pub(crate) use rstsr_openblas_ffi as lapack_ffi;

--- a/rstsr-openblas/src/threading.rs
+++ b/rstsr-openblas/src/threading.rs
@@ -10,12 +10,6 @@ use rstsr_openblas_ffi::cblas::{OPENBLAS_OPENMP, OPENBLAS_SEQUENTIAL, OPENBLAS_T
 
 /* #region required openmp ffi */
 
-#[cfg(feature = "openmp")]
-extern "C" {
-    pub fn omp_set_num_threads(arg1: c_int);
-    pub fn omp_get_max_threads() -> c_int;
-}
-
 /* #endregion */
 
 /* #region parallel scheme */
@@ -62,7 +56,7 @@ impl OpenBLASConfig {
             match self.get_parallel() {
                 OPENBLAS_THREAD => rstsr_openblas_ffi::cblas::openblas_set_num_threads(n as i32),
                 #[cfg(feature = "openmp")]
-                OPENBLAS_OPENMP => omp_set_num_threads(n as c_int),
+                OPENBLAS_OPENMP => rstsr_openblas_ffi::cblas::omp_set_num_threads(n as c_int),
                 _ => (),
             }
         }
@@ -73,7 +67,7 @@ impl OpenBLASConfig {
             match self.get_parallel() {
                 OPENBLAS_THREAD => rstsr_openblas_ffi::cblas::openblas_get_num_threads() as usize,
                 #[cfg(feature = "openmp")]
-                OPENBLAS_OPENMP => omp_get_max_threads() as usize,
+                OPENBLAS_OPENMP => rstsr_openblas_ffi::cblas::omp_get_max_threads() as usize,
                 _ => 1,
             }
         }

--- a/rstsr/Cargo.toml
+++ b/rstsr/Cargo.toml
@@ -16,7 +16,7 @@ rstsr-sci-traits = { workspace = true, optional = true }
 rstsr-openblas = { workspace = true, optional = true }
 
 [features]
-default = ["rstsr-core/default", "faer"]
+default = ["rstsr-core/default", "faer", "dynamic_loading"]
 
 # rstsr-core features
 std = ["rstsr-core/std"]
@@ -34,3 +34,7 @@ openblas = ["dep:rstsr-openblas"]
 # dependencies specification
 linalg = ["dep:rstsr-linalg-traits", "rstsr-openblas?/linalg"]
 sci = ["dep:rstsr-sci-traits", "rstsr-openblas?/sci"]
+
+# BLAS configurations
+dynamic_loading = ["rstsr-openblas?/dynamic_loading"]
+ilp64 = ["rstsr-openblas?/ilp64"]


### PR DESCRIPTION
API breaking change: Supporting dynamic loading for OpenBLAS

- Update `rstsr-lapack-ffi` and `rstsr-openblas-ffi` version to v0.4.
- Default to `dynamic_loading` for using OpenBLAS.
- Changes internal ways to call BLAS and LAPACK functions.

If compile time and disk usage becomes very large for `rstsr-openblas-ffi`, you may wish to set those options in Cargo.toml:

```toml
[profile.dev.package.rstsr-lapack-ffi]
opt-level = 0
debug = false

[profile.dev.package.rstsr-openblas-ffi]
opt-level = 0
debug = false
```

---

## Backgrounds to dynamic loading

See also [RESTGroup/rstsr-ffi#1](https://github.com/RESTGroup/rstsr-ffi/issues/1)

Dynamic-loading FFI has been successfully implemented in rust crate [cudarc](https://github.com/coreylowman/cudarc/) (CUDA) and [ort](https://github.com/pykeio/ort) (ONNX), in the domain of numerical libraries.

The binary compiled by dynamic loading does not explicitly link to external library (like libopenblas.so), and the library will be loaded at runtime, lazily.

Dynamic-loading can be very useful, in that
- partially resolves [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell);
- you don't really need to require `build.rs` to manually link some libraries, less possibility for build errors and symbols not found;

But anyway, it has some drawbacks, though benefits should overweights drawbacks a lot:
- not fully zero-cost (but the cost is extremely small, compared to GEMM tasks);
- decreases flexibility a bit;
- should use single-dynamic library, otherwise runtime error may occur (for MKL use [SDL option or libmkl_rt.so](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2025-0/using-the-single-dynamic-library.html) instead of advanced configuration options, for libflame you need to embed lapack symbols by `--enable-lapack2flame`)