### PR TITLE
Enhancement: DeviceKML initialization 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version 
 rstsr-mkl = { path = "./rstsr-mkl", default-features = false, version = "0.4.0" }
 rstsr-blis = { path = "./rstsr-blis", default-features = false, version = "0.4.0" }
 rstsr-aocl = { path = "./rstsr-aocl", default-features = false, version = "0.4.0" }
+rstsr-kml = { path = "./rstsr-kml", default-features = false, version = "0.4.0" }
 rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.4.0" }
 rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.4.0" }
 rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, version = "0.4.0" }
@@ -46,6 +47,7 @@ rstsr-openblas-ffi = { version = "0.4", default-features = false, features = ["b
 rstsr-mkl-ffi = { version = "0.1", default-features = false, features = ["blas", "cblas", "lapack"] }
 rstsr-blis-ffi = { version = "0.1", default-features = false, features = ["lapack"] }
 rstsr-aocl-ffi = { version = "0.1", default-features = false, features = ["blis", "lapack"] }
+rstsr-kml-ffi = { version = "0.0.2", default-features = false, features = ["kblas", "lapack"] }
 # basic dependencies
 num = { version = "0.4" }
 itertools = { version = "0.13" }
@@ -85,6 +87,10 @@ opt-level = 0
 debug = false
 
 [profile.dev.package.rstsr-aocl-ffi]
+opt-level = 0
+debug = false
+
+[profile.dev.package.rstsr-kml-ffi]
 opt-level = 0
 debug = false
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ For users comes from NumPy, the [NumPy-RSTSR Cheatsheet](https://restgroup.githu
 | oneAPI MKL | `DeviceMKL` | rstsr-mkl | `rstsr/mkl` |
 | BLIS/FLAME | `DeviceBLIS` | rstsr-blis | `rstsr/blis` |
 | AOCL | `DeviceAOCL` | rstsr-aocl | `rstsr/aocl` |
+| KML | `DeviceKML` | rstsr-kml | `rstsr/kml` |
 
 ## Illustrative Example
 

--- a/rstsr-blas-traits/driver_impl/lapack/svd/gesdd.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/svd/gesdd.rs
@@ -28,6 +28,13 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
         ldvt: usize,
     ) -> blas_int {
         use lapack_ffi::lapack::func_;
+        
+        // Allocate memory for temporary array(s)
+        let liwork = 8 * m.min(n);
+        let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
+            Ok(iwork) => iwork,
+            Err(_) => return -1010,
+        };
 
         // Query optimal working array(s) size
         let mut info = 0;
@@ -46,22 +53,17 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
             &(m.max(n) as _),
             &mut work_query,
             &lwork,
-            std::ptr::null_mut(),
+            iwork.as_mut_ptr(),
             &mut info,
         );
         if info != 0 {
             return info;
         }
         let lwork = work_query as usize;
-        let liwork = 8 * m.min(n);
 
         // Allocate memory for temporary array(s)
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
             Ok(work) => work,
-            Err(_) => return -1010,
-        };
-        let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
-            Ok(iwork) => iwork,
             Err(_) => return -1010,
         };
 
@@ -197,6 +199,13 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
     ) -> blas_int {
         use lapack_ffi::lapack::func_;
 
+        // Allocate memory for temporary array(s)
+        let liwork = 8 * m.min(n);
+        let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
+            Ok(iwork) => iwork,
+            Err(_) => return -1010,
+        };
+
         // Query optimal working array(s) size
         let mut info = 0;
         let lwork = -1;
@@ -218,14 +227,13 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
             &mut work_query as *mut _ as *mut _,
             &lwork,
             &mut rwork_query as *mut _ as *mut _,
-            std::ptr::null_mut(),
+            iwork.as_mut_ptr(),
             &mut info,
         );
         if info != 0 {
             return info;
         }
         let lwork = work_query.re as usize;
-        let liwork = 8 * m.min(n);
 
         // Allocate memory for temporary array(s)
         let mut work: Vec<T> = match uninitialized_vec(lwork) {
@@ -234,10 +242,6 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
         };
         let mut rwork: Vec<<T as ComplexFloat>::Real> = match uninitialized_vec(lrwork) {
             Ok(rwork) => rwork,
-            Err(_) => return -1010,
-        };
-        let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {
-            Ok(iwork) => iwork,
             Err(_) => return -1010,
         };
 

--- a/rstsr-blas-traits/driver_impl/lapack/svd/gesdd.rs
+++ b/rstsr-blas-traits/driver_impl/lapack/svd/gesdd.rs
@@ -28,7 +28,7 @@ impl GESDDDriverAPI<T> for DeviceBLAS {
         ldvt: usize,
     ) -> blas_int {
         use lapack_ffi::lapack::func_;
-        
+
         // Allocate memory for temporary array(s)
         let liwork = 8 * m.min(n);
         let mut iwork: Vec<blas_int> = match uninitialized_vec(liwork) {

--- a/rstsr-kml/Cargo.toml
+++ b/rstsr-kml/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "rstsr-kml"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+readme = "readme.md"
+
+[dependencies]
+rayon = { workspace = true }
+num = { workspace = true }
+duplicate = { workspace = true }
+rstsr-kml-ffi = { workspace = true }
+rstsr-native-impl = { workspace = true, features = ["rayon"] }
+rstsr-core = { workspace = true, features = ["rayon"] }
+rstsr-common = { workspace = true, features = ["rayon"] }
+rstsr-dtype-traits = { workspace = true, features = ["half"] }
+rstsr-blas-traits = { workspace = true }
+rstsr-linalg-traits = { workspace = true, optional = true }
+rstsr-sci-traits = { workspace = true, optional = true }
+
+[dev-dependencies]
+rstsr = { path = "../rstsr", default-features = false, features = ["kml", "linalg"] }
+rstsr-test-manifest = { workspace = true }
+
+[features]
+default = ["linalg", "dynamic_loading"]
+dynamic_loading = ["rstsr-kml-ffi/dynamic_loading"]
+faer = ["rstsr-core/faer"]
+ilp64 = ["rstsr-kml-ffi/ilp64", "rstsr-blas-traits/ilp64"]
+linalg = ["dep:rstsr-linalg-traits"]
+sci = ["dep:rstsr-sci-traits"]

--- a/rstsr-kml/readme.md
+++ b/rstsr-kml/readme.md
@@ -1,0 +1,3 @@
+# RSTSR KML device
+
+This crate enables KML device.

--- a/rstsr-kml/src/conversion.rs
+++ b/rstsr-kml/src/conversion.rs
@@ -1,0 +1,79 @@
+use crate::prelude_dev::*;
+
+macro_rules! impl_change_device {
+    ($DevA: ty, $DevB: ty) => {
+        impl<'a, R, T, D> DeviceChangeAPI<'a, $DevB, R, T, D> for $DevA
+        where
+            T: Clone + Send + Sync + 'a,
+            D: DimAPI,
+            R: DataCloneAPI<Data = Vec<T>>,
+        {
+            type Repr = R;
+            type ReprTo = DataRef<'a, Vec<T>>;
+
+            fn change_device(
+                tensor: TensorAny<R, T, $DevA, D>,
+                device: &$DevB,
+            ) -> Result<TensorAny<Self::Repr, T, $DevB, D>> {
+                let (storage, layout) = tensor.into_raw_parts();
+                let (data, _) = storage.into_raw_parts();
+                let storage = Storage::new(data, device.clone());
+                let tensor = TensorAny::new(storage, layout);
+                Ok(tensor)
+            }
+
+            fn into_device(
+                tensor: TensorAny<R, T, $DevA, D>,
+                device: &$DevB,
+            ) -> Result<TensorAny<DataOwned<Vec<T>>, T, $DevB, D>> {
+                let tensor = tensor.into_owned();
+                DeviceChangeAPI::change_device(tensor, device)
+            }
+
+            fn to_device(tensor: &'a TensorAny<R, T, $DevA, D>, device: &$DevB) -> Result<TensorView<'a, T, $DevB, D>> {
+                let view = tensor.view();
+                DeviceChangeAPI::change_device(view, device)
+            }
+        }
+    };
+}
+
+impl_change_device!(DeviceCpuSerial, DeviceBLAS);
+impl_change_device!(DeviceBLAS, DeviceCpuSerial);
+impl_change_device!(DeviceBLAS, DeviceBLAS);
+#[cfg(feature = "faer")]
+impl_change_device!(DeviceFaer, DeviceBLAS);
+#[cfg(feature = "faer")]
+impl_change_device!(DeviceBLAS, DeviceFaer);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_device_conversion_cpu_serial() {
+        let device_serial = DeviceCpuSerial::default();
+        let device = DeviceBLAS::new(0);
+        let a = linspace((1.0, 5.0, 5, &device));
+        let b = a.to_device(&device_serial);
+        println!("{b:?}");
+        let a = linspace((1.0, 5.0, 5, &device_serial));
+        let a_view = a.view();
+        let b = a_view.to_device(&device);
+        println!("{b:?}");
+    }
+
+    #[test]
+    #[cfg(feature = "faer")]
+    fn test_device_conversion_faer() {
+        let device_faer = DeviceFaer::new(0);
+        let device = DeviceBLAS::new(0);
+        let a = linspace((1.0, 5.0, 5, &device));
+        let b = a.to_device(&device_faer);
+        println!("{b:?}");
+        let a = linspace((1.0, 5.0, 5, &device_faer));
+        let a_view = a.view();
+        let b = a_view.to_device(&device);
+        println!("{b:?}");
+    }
+}

--- a/rstsr-kml/src/creation.rs
+++ b/rstsr-kml/src/creation.rs
@@ -1,0 +1,115 @@
+use crate::prelude_dev::*;
+use num::{complex::ComplexFloat, Num};
+
+// for creation, we use most of the functions from DeviceCpuSerial
+impl<T> DeviceCreationAnyAPI<T> for DeviceBLAS
+where
+    Self: DeviceRawAPI<T, Raw = Vec<T>>,
+{
+    unsafe fn empty_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().empty_impl(len)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+
+    fn full_impl(&self, len: usize, fill: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
+        let storage = DeviceCpuSerial::default().full_impl(len, fill)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+
+    fn outof_cpu_vec(&self, vec: Vec<T>) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        Ok(Storage::new(DataOwned::from(vec), self.clone()))
+    }
+
+    fn from_cpu_vec(&self, vec: &[T]) -> Result<Storage<DataOwned<Vec<T>>, T, Self>>
+    where
+        T: Clone,
+    {
+        let raw = vec.to_vec();
+        Ok(Storage::new(DataOwned::from(raw), self.clone()))
+    }
+}
+
+impl<T> DeviceCreationNumAPI<T> for DeviceBLAS
+where
+    T: Num + Clone,
+    Self: DeviceRawAPI<T, Raw = Vec<T>>,
+{
+    fn zeros_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().zeros_impl(len)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+
+    fn ones_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().ones_impl(len)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+
+    fn arange_int_impl(&self, len: usize) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().arange_int_impl(len)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+}
+
+impl<T> DeviceCreationPartialOrdNumAPI<T> for DeviceBLAS
+where
+    T: Num + PartialOrd + Clone,
+    Self: DeviceRawAPI<T, Raw = Vec<T>>,
+{
+    fn arange_impl(&self, start: T, end: T, step: T) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().arange_impl(start, end, step)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+}
+
+impl<T> DeviceCreationComplexFloatAPI<T> for DeviceBLAS
+where
+    T: ComplexFloat + Clone + Send + Sync,
+    Self: DeviceRawAPI<T, Raw = Vec<T>>,
+{
+    fn linspace_impl(&self, start: T, end: T, n: usize, endpoint: bool) -> Result<Storage<DataOwned<Vec<T>>, T, Self>> {
+        let storage = DeviceCpuSerial::default().linspace_impl(start, end, n, endpoint)?;
+        let (data, _) = storage.into_raw_parts();
+        Ok(Storage::new(data, self.clone()))
+    }
+}
+
+impl<T> DeviceCreationTriAPI<T> for DeviceBLAS
+where
+    T: Num + Clone,
+    Self: DeviceRawAPI<T, Raw = Vec<T>>,
+{
+    fn tril_impl<D>(&self, raw: &mut Self::Raw, layout: &Layout<D>, k: isize) -> Result<()>
+    where
+        D: DimAPI,
+    {
+        DeviceCpuSerial::default().tril_impl(raw, layout, k)
+    }
+
+    fn triu_impl<D>(&self, raw: &mut Self::Raw, layout: &Layout<D>, k: isize) -> Result<()>
+    where
+        D: DimAPI,
+    {
+        DeviceCpuSerial::default().triu_impl(raw, layout, k)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_linspace() {
+        let device = DeviceBLAS::default();
+        let a = linspace((1.0, 5.0, 5, &device));
+        assert_eq!(a.raw(), &vec![1., 2., 3., 4., 5.]);
+    }
+}

--- a/rstsr-kml/src/device.rs
+++ b/rstsr-kml/src/device.rs
@@ -1,0 +1,132 @@
+use crate::prelude_dev::*;
+use num::{complex::ComplexFloat, Num};
+
+impl DeviceBLAS {
+    pub fn new(num_threads: usize) -> Self {
+        DeviceBLAS { base: DeviceCpuRayon::new(num_threads) }
+    }
+}
+
+impl DeviceRayonAPI for DeviceBLAS {
+    #[inline]
+    fn set_num_threads(&mut self, num_threads: usize) {
+        self.base.set_num_threads(num_threads);
+    }
+
+    #[inline]
+    fn get_num_threads(&self) -> usize {
+        self.base.get_num_threads()
+    }
+
+    #[inline]
+    fn get_pool(&self) -> &ThreadPool {
+        self.base.get_pool()
+    }
+
+    #[inline]
+    fn get_current_pool(&self) -> Option<&ThreadPool> {
+        self.base.get_current_pool()
+    }
+}
+
+impl Default for DeviceBLAS {
+    fn default() -> Self {
+        DeviceBLAS::new(0)
+    }
+}
+
+impl DeviceBaseAPI for DeviceBLAS {
+    fn same_device(&self, other: &Self) -> bool {
+        let same_num_threads = self.get_num_threads() == other.get_num_threads();
+        let same_default_order = self.default_order() == other.default_order();
+        same_num_threads && same_default_order
+    }
+
+    fn default_order(&self) -> FlagOrder {
+        self.base.default_order()
+    }
+
+    fn set_default_order(&mut self, order: FlagOrder) {
+        self.base.set_default_order(order);
+    }
+}
+
+impl<T> DeviceRawAPI<T> for DeviceBLAS {
+    type Raw = Vec<T>;
+}
+
+impl<T> DeviceStorageAPI<T> for DeviceBLAS {
+    fn len<R>(storage: &Storage<R, T, Self>) -> usize
+    where
+        R: DataAPI<Data = Self::Raw>,
+    {
+        storage.raw().len()
+    }
+
+    fn to_cpu_vec<R>(storage: &Storage<R, T, Self>) -> Result<Vec<T>>
+    where
+        Self::Raw: Clone,
+        R: DataAPI<Data = Self::Raw>,
+    {
+        Ok(storage.raw().clone())
+    }
+
+    fn into_cpu_vec<R>(storage: Storage<R, T, Self>) -> Result<Vec<T>>
+    where
+        Self::Raw: Clone,
+        R: DataCloneAPI<Data = Self::Raw>,
+    {
+        let (raw, _) = storage.into_raw_parts();
+        Ok(raw.into_owned().into_raw())
+    }
+
+    #[inline]
+    fn get_index<R>(storage: &Storage<R, T, Self>, index: usize) -> T
+    where
+        T: Clone,
+        R: DataAPI<Data = Self::Raw>,
+    {
+        storage.raw()[index].clone()
+    }
+
+    #[inline]
+    fn get_index_ptr<R>(storage: &Storage<R, T, Self>, index: usize) -> *const T
+    where
+        R: DataAPI<Data = Self::Raw>,
+    {
+        &storage.raw()[index] as *const T
+    }
+
+    #[inline]
+    fn get_index_mut_ptr<R>(storage: &mut Storage<R, T, Self>, index: usize) -> *mut T
+    where
+        R: DataMutAPI<Data = Self::Raw>,
+    {
+        storage.raw_mut().get_mut(index).unwrap() as *mut T
+    }
+
+    #[inline]
+    fn set_index<R>(storage: &mut Storage<R, T, Self>, index: usize, value: T)
+    where
+        R: DataMutAPI<Data = Self::Raw>,
+    {
+        storage.raw_mut()[index] = value;
+    }
+}
+
+impl<T> DeviceAPI<T> for DeviceBLAS {}
+
+impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
+where
+    T: ComplexFloat + Send + Sync,
+    T::Real: Send + Sync,
+    D: DimAPI,
+{
+}
+
+impl<T, D> DeviceNumAPI<T, D> for DeviceBLAS
+where
+    T: Clone + Num + Send + Sync,
+    D: DimAPI,
+{
+}

--- a/rstsr-kml/src/driver_impl/cblas
+++ b/rstsr-kml/src/driver_impl/cblas
@@ -1,0 +1,1 @@
+../../../rstsr-blas-traits/driver_impl/cblas/

--- a/rstsr-kml/src/driver_impl/lapack
+++ b/rstsr-kml/src/driver_impl/lapack
@@ -1,0 +1,1 @@
+../../../rstsr-blas-traits/driver_impl/lapack/

--- a/rstsr-kml/src/driver_impl/mod.rs
+++ b/rstsr-kml/src/driver_impl/mod.rs
@@ -1,0 +1,20 @@
+pub mod cblas;
+pub mod lapack;
+
+use crate::DeviceBLAS;
+use duplicate::duplicate_item;
+use num::Complex;
+use rstsr_blas_traits::prelude::*;
+
+impl<T> BlasDriverBaseAPI<T> for DeviceBLAS
+where
+    T: BlasFloat,
+    T::Real: BlasFloat + rstsr_dtype_traits::MinMaxAPI + num::Bounded,
+{
+}
+
+#[duplicate_item(T; [f32]; [f64]; [Complex<f32>]; [Complex<f64>])]
+impl BlasDriverAPI<T> for DeviceBLAS {}
+
+#[duplicate_item(T; [f32]; [f64]; [Complex<f32>]; [Complex<f64>])]
+impl LapackDriverAPI<T> for DeviceBLAS {}

--- a/rstsr-kml/src/lib.rs
+++ b/rstsr-kml/src/lib.rs
@@ -1,0 +1,30 @@
+#![allow(clippy::needless_return)]
+#![allow(non_camel_case_types)]
+#![doc = include_str!("../readme.md")]
+
+pub mod conversion;
+pub mod creation;
+pub mod device;
+pub mod matmul;
+pub mod matmul_impl;
+pub mod prelude_dev;
+pub mod rayon_auto_impl;
+pub mod threading;
+
+pub mod driver_impl;
+#[cfg(feature = "linalg")]
+pub mod linalg_auto_impl;
+
+#[cfg(feature = "sci")]
+pub mod sci_auto_impl;
+
+use rstsr_core::prelude_dev::DeviceCpuRayon;
+
+#[derive(Clone, Debug)]
+pub struct DeviceKML {
+    base: DeviceCpuRayon,
+}
+
+pub(crate) use rstsr_kml_ffi as lapack_ffi;
+pub(crate) use DeviceKML as DeviceBLAS;
+pub(crate) use DeviceKML as DeviceRayonAutoImpl;

--- a/rstsr-kml/src/linalg_auto_impl/cholesky.rs
+++ b/rstsr-kml/src/linalg_auto_impl/cholesky.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/cholesky.rs

--- a/rstsr-kml/src/linalg_auto_impl/det.rs
+++ b/rstsr-kml/src/linalg_auto_impl/det.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/det.rs

--- a/rstsr-kml/src/linalg_auto_impl/eigh.rs
+++ b/rstsr-kml/src/linalg_auto_impl/eigh.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/eigh.rs

--- a/rstsr-kml/src/linalg_auto_impl/eigvalsh.rs
+++ b/rstsr-kml/src/linalg_auto_impl/eigvalsh.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/eigvalsh.rs

--- a/rstsr-kml/src/linalg_auto_impl/inv.rs
+++ b/rstsr-kml/src/linalg_auto_impl/inv.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/inv.rs

--- a/rstsr-kml/src/linalg_auto_impl/mod.rs
+++ b/rstsr-kml/src/linalg_auto_impl/mod.rs
@@ -1,0 +1,12 @@
+pub mod cholesky;
+pub mod det;
+pub mod eigh;
+pub mod eigvalsh;
+pub mod inv;
+pub mod pinv;
+pub mod slogdet;
+pub mod solve_general;
+pub mod solve_symmetric;
+pub mod solve_triangular;
+pub mod svd;
+pub mod svdvals;

--- a/rstsr-kml/src/linalg_auto_impl/pinv.rs
+++ b/rstsr-kml/src/linalg_auto_impl/pinv.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/pinv.rs

--- a/rstsr-kml/src/linalg_auto_impl/slogdet.rs
+++ b/rstsr-kml/src/linalg_auto_impl/slogdet.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/slogdet.rs

--- a/rstsr-kml/src/linalg_auto_impl/solve_general.rs
+++ b/rstsr-kml/src/linalg_auto_impl/solve_general.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/solve_general.rs

--- a/rstsr-kml/src/linalg_auto_impl/solve_symmetric.rs
+++ b/rstsr-kml/src/linalg_auto_impl/solve_symmetric.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/solve_symmetric.rs

--- a/rstsr-kml/src/linalg_auto_impl/solve_triangular.rs
+++ b/rstsr-kml/src/linalg_auto_impl/solve_triangular.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/solve_triangular.rs

--- a/rstsr-kml/src/linalg_auto_impl/svd.rs
+++ b/rstsr-kml/src/linalg_auto_impl/svd.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/svd.rs

--- a/rstsr-kml/src/linalg_auto_impl/svdvals.rs
+++ b/rstsr-kml/src/linalg_auto_impl/svdvals.rs
@@ -1,0 +1,1 @@
+../../../rstsr-linalg-traits/src/blas_impl/svdvals.rs

--- a/rstsr-kml/src/matmul.rs
+++ b/rstsr-kml/src/matmul.rs
@@ -1,0 +1,479 @@
+use crate::matmul_impl::*;
+use crate::prelude_dev::*;
+use crate::threading::with_num_threads;
+use core::any::TypeId;
+use core::ops::{Add, Mul};
+use core::slice::{from_raw_parts, from_raw_parts_mut};
+use num::{Complex, Zero};
+use rayon::prelude::*;
+
+// code from ndarray
+fn same_type<A: 'static, B: 'static>() -> bool {
+    TypeId::of::<A>() == TypeId::of::<B>()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gemm_blas_ix2_no_conj_dispatch<TA, TB, TC>(
+    c: &mut [TC],
+    lc: &Layout<Ix2>,
+    a: &[TA],
+    la: &Layout<Ix2>,
+    b: &[TB],
+    lb: &Layout<Ix2>,
+    alpha: TC,
+    beta: TC,
+    pool: Option<&ThreadPool>,
+) -> Result<()>
+where
+    TA: Clone + Send + Sync + 'static,
+    TB: Clone + Send + Sync + 'static,
+    TC: Clone + Send + Sync + 'static,
+    TA: Mul<TB, Output = TC>,
+    TC: Mul<TC, Output = TC> + Add<TC, Output = TC> + Zero + PartialEq,
+{
+    // check if syrk could be applicable
+    let able_syrk = beta == TC::zero()
+        && same_type::<TB, TC>()
+        && same_type::<TA, TC>()
+        && unsafe {
+            let a_ptr = a.as_ptr().add(la.offset()) as *const TC;
+            let b_ptr = b.as_ptr().add(lb.offset()) as *const TC;
+            let equal_ptr = core::ptr::eq(a_ptr, b_ptr);
+            let equal_shape = la.shape() == lb.reverse_axes().shape();
+            let equal_stride = la.stride() == lb.reverse_axes().stride();
+            equal_ptr && equal_shape && equal_stride
+        };
+
+    // type check and dispatch
+    macro_rules! impl_gemm_dispatch {
+        ($ty: ty, $fn_gemm_name: ident, $fn_syrk_name: ident) => {
+            if (same_type::<TA, $ty>() && same_type::<TB, $ty>() && same_type::<TC, $ty>()) {
+                let a_slice = unsafe { from_raw_parts(a.as_ptr() as *const $ty, a.len()) };
+                let b_slice = unsafe { from_raw_parts(b.as_ptr() as *const $ty, b.len()) };
+                let c_slice = unsafe { from_raw_parts_mut(c.as_mut_ptr() as *mut $ty, c.len()) };
+                let alpha = unsafe { *(&alpha as *const TC as *const $ty) };
+                let beta = unsafe { *(&beta as *const TC as *const $ty) };
+                if able_syrk {
+                    $fn_syrk_name(c_slice, lc, a_slice, la, alpha, pool)?;
+                } else {
+                    $fn_gemm_name(c_slice, lc, a_slice, la, b_slice, lb, alpha, beta, pool)?;
+                }
+                return Ok(());
+            }
+        };
+    }
+
+    impl_gemm_dispatch!(f32, gemm_blas_no_conj_f32, syrk_blas_no_conj_f32);
+    impl_gemm_dispatch!(f64, gemm_blas_no_conj_f64, syrk_blas_no_conj_f64);
+    impl_gemm_dispatch!(Complex<f32>, gemm_blas_no_conj_c32, syrk_blas_no_conj_c32);
+    impl_gemm_dispatch!(Complex<f64>, gemm_blas_no_conj_c64, syrk_blas_no_conj_c64);
+
+    // not able to be accelarated by blas_no_conj
+    // fallback to naive implementation
+    let c_slice = c;
+    let a_slice = a;
+    let b_slice = b;
+    return gemm_ix2_naive_cpu_rayon(c_slice, lc, a_slice, la, b_slice, lb, alpha, beta, pool);
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn matmul_row_major_blas<TA, TB, TC, DA, DB, DC>(
+    c: &mut [TC],
+    lc: &Layout<DC>,
+    a: &[TA],
+    la: &Layout<DA>,
+    b: &[TB],
+    lb: &Layout<DB>,
+    alpha: TC,
+    beta: TC,
+    pool: Option<&ThreadPool>,
+) -> Result<()>
+where
+    TA: Clone + Send + Sync + 'static,
+    TB: Clone + Send + Sync + 'static,
+    TC: Clone + Send + Sync + 'static,
+    DA: DimAPI,
+    DB: DimAPI,
+    DC: DimAPI,
+    TA: Mul<TB, Output = TC>,
+    TC: Mul<TC, Output = TC> + Add<TC, Output = TC> + Zero + PartialEq,
+{
+    // NOTE: this only works for row-major layout
+    // for column-major layout, we need to transpose the input:
+    // C = A * B  =>  C^T = B^T * A^T
+
+    // quick return for empty matrix
+    // in this case, we do not check the shape of a, b, c
+    if lc.size() == 0 {
+        return Ok(());
+    }
+
+    let nthreads = match pool {
+        Some(pool) => pool.current_num_threads(),
+        None => 1,
+    };
+
+    // handle special cases
+    match (la.ndim(), lb.ndim(), lc.ndim()) {
+        (1, 1, 0) => {
+            // rule 1: vector inner dot
+            let la = &la.clone().into_dim::<Ix1>().unwrap();
+            let lb = &lb.clone().into_dim::<Ix1>().unwrap();
+            let lc = &lc.clone().into_dim::<Ix0>().unwrap();
+            let c_num = &mut c[lc.offset()];
+            return with_num_threads(nthreads, || inner_dot_naive_cpu_rayon(c_num, a, la, b, lb, alpha, beta, pool));
+        },
+        (2, 2, 2) => {
+            // rule 2: matrix multiplication
+            let la = &la.clone().into_dim::<Ix2>().unwrap();
+            let lb = &lb.clone().into_dim::<Ix2>().unwrap();
+            let lc = &lc.clone().into_dim::<Ix2>().unwrap();
+            return with_num_threads(nthreads, || {
+                gemm_blas_ix2_no_conj_dispatch(c, lc, a, la, b, lb, alpha, beta, pool)
+            });
+        },
+        _ => (),
+    };
+
+    // handle broadcasted cases
+    // temporary variables
+    let la_matmul;
+    let lb_matmul;
+    let lc_matmul;
+    let la_rest;
+    let lb_rest;
+    let lc_rest;
+
+    match (la.ndim(), lb.ndim(), lc.ndim()) {
+        // we have already handled these cases
+        (1, 1, 0) | (2, 2, 2) => unreachable!(),
+        (1, 2.., _) => {
+            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
+            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-1)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
+            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
+            lb_rest = lb_r;
+            lc_rest = lc_r;
+            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
+            lb_matmul = lb_m.into_dim::<Ix2>()?;
+            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
+        },
+        (2.., 1, _) => {
+            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
+            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
+            la_rest = la_r;
+            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
+            lc_rest = lc_r;
+            la_matmul = la_m.into_dim::<Ix2>()?;
+            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
+            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
+        },
+        (2, 3.., _) => {
+            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
+            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
+            lb_rest = lb_r;
+            lc_rest = lc_r;
+            la_matmul = la_m.into_dim::<Ix2>()?;
+            lb_matmul = lb_m.into_dim::<Ix2>()?;
+            lc_matmul = lc_m.into_dim::<Ix2>()?;
+        },
+        (3.., 2, _) => {
+            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
+            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            la_rest = la_r;
+            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
+            lc_rest = lc_r;
+            la_matmul = la_m.into_dim::<Ix2>()?;
+            lb_matmul = lb_m.into_dim::<Ix2>()?;
+            lc_matmul = lc_m.into_dim::<Ix2>()?;
+        },
+        (3.., 3.., _) => {
+            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
+            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
+            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            la_rest = la_r;
+            lb_rest = lb_r;
+            lc_rest = lc_r;
+            la_matmul = la_m.into_dim::<Ix2>()?;
+            lb_matmul = lb_m.into_dim::<Ix2>()?;
+            lc_matmul = lc_m.into_dim::<Ix2>()?;
+        },
+        _ => {
+            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
+            unreachable!()
+        },
+    }
+    // now, lx_rest should have the same shape, while lx_matmul
+    // should be matmulable
+    // only parallel matmul when lx_rest is small (larger than
+    // 2*nthreads), otherwise parallel matmul anyway
+    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
+    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
+    let n_task = la_rest.size();
+    let ita_rest = IterLayoutColMajor::new(&la_rest)?;
+    let itb_rest = IterLayoutColMajor::new(&lb_rest)?;
+    let itc_rest = IterLayoutColMajor::new(&lc_rest)?;
+    if n_task >= 4 * nthreads {
+        // parallel outer, sequential matmul
+        with_num_threads(1, || {
+            let task = || {
+                ita_rest.into_par_iter().zip(itb_rest).zip(itc_rest).try_for_each(
+                    |((ia_rest, ib_rest), ic_rest)| -> Result<()> {
+                        // prepare layout
+                        let mut la_m = la_matmul.clone();
+                        let mut lb_m = lb_matmul.clone();
+                        let mut lc_m = lc_matmul.clone();
+                        unsafe {
+                            la_m.set_offset(ia_rest);
+                            lb_m.set_offset(ib_rest);
+                            lc_m.set_offset(ic_rest);
+                        }
+                        // move mutable reference into parallel closure
+                        let c = unsafe {
+                            let c_ptr = c.as_ptr() as *mut TC;
+                            let c_len = c.len();
+                            from_raw_parts_mut(c_ptr, c_len)
+                        };
+                        // clone alpha and beta
+                        let alpha = alpha.clone();
+                        let beta = beta.clone();
+                        gemm_blas_ix2_no_conj_dispatch(c, &lc_m, a, &la_m, b, &lb_m, alpha, beta, None)
+                    },
+                )
+            };
+            match pool {
+                Some(pool) => pool.install(task),
+                None => task(),
+            }
+        })
+    } else {
+        // sequential outer, parallel matmul
+        with_num_threads(nthreads, || -> Result<()> {
+            izip!(ita_rest, itb_rest, itc_rest).try_for_each(|(ia_rest, ib_rest, ic_rest)| {
+                // prepare layout
+                let mut la_m = la_matmul.clone();
+                let mut lb_m = lb_matmul.clone();
+                let mut lc_m = lc_matmul.clone();
+                unsafe {
+                    la_m.set_offset(ia_rest);
+                    lb_m.set_offset(ib_rest);
+                    lc_m.set_offset(ic_rest);
+                }
+                // clone alpha and beta
+                let alpha = alpha.clone();
+                let beta = beta.clone();
+                gemm_blas_ix2_no_conj_dispatch(c, &lc_m, a, &la_m, b, &lb_m, alpha, beta, pool)
+            })
+        })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+impl<TA, TB, TC, DA, DB, DC> DeviceMatMulAPI<TA, TB, TC, DA, DB, DC> for DeviceBLAS
+where
+    TA: Clone + Send + Sync + 'static,
+    TB: Clone + Send + Sync + 'static,
+    TC: Clone + Send + Sync + 'static,
+    DA: DimAPI,
+    DB: DimAPI,
+    DC: DimAPI,
+    TA: Mul<TB, Output = TC>,
+    TB: Mul<TA, Output = TC>,
+    TC: Mul<TC, Output = TC> + Add<TC, Output = TC> + Zero + PartialEq,
+{
+    fn matmul(
+        &self,
+        c: &mut Vec<TC>,
+        lc: &Layout<DC>,
+        a: &Vec<TA>,
+        la: &Layout<DA>,
+        b: &Vec<TB>,
+        lb: &Layout<DB>,
+        alpha: TC,
+        beta: TC,
+    ) -> Result<()> {
+        let default_order = self.default_order();
+        let pool = self.get_current_pool();
+        match default_order {
+            RowMajor => matmul_row_major_blas(c, lc, a, la, b, lb, alpha, beta, pool),
+            ColMajor => {
+                let la = la.reverse_axes();
+                let lb = lb.reverse_axes();
+                let lc = lc.reverse_axes();
+                matmul_row_major_blas(c, &lc, b, &lb, a, &la, alpha, beta, pool)
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_matmul() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 14.0, 15, &device)).into_shape([3, 5]);
+        let b = linspace((0.0, 14.0, 15, &device)).into_shape([5, 3]);
+        println!("{:}", &a % &b);
+
+        let a = linspace((0.0, 14.0, 15, &device));
+        let b = linspace((0.0, 14.0, 15, &device));
+        println!("{:}", &a % &b);
+
+        let a = linspace((0.0, 2.0, 3, &device));
+        let b = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        println!("{:}", &a % &b);
+
+        let a = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        let b = linspace((0.0, 4.0, 5, &device));
+        println!("{:}", &a % &b);
+
+        let a = linspace((0.0, 14.0, 15, &device)).into_shape([5, 3]);
+        let b = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        println!("{:}", &a % &b);
+
+        let a = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        let b = linspace((0.0, 14.0, 15, &device)).into_shape([5, 3]);
+        println!("{:}", &a % &b);
+    }
+
+    #[test]
+    #[ignore]
+    fn parallel_test_full() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([8192, 8192]);
+        let b = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([8192, 8192]);
+        for _ in 0..10 {
+            let start = std::time::Instant::now();
+            let _ = &a % &b;
+            println!("time: {:?}", start.elapsed());
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn parallel_test_full_512() {
+        let device = DeviceBLAS::new(1);
+        let a = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        let b = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        for _ in 0..1000 {
+            let start = std::time::Instant::now();
+            let c = &a % &b;
+            println!("{:?}", c.device());
+            println!("time: {:?}", start.elapsed());
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn parallel_test_par_rule7() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([256, 512, 512]);
+        let b = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([256, 512, 512]);
+        for i in 0..10 {
+            let start = std::time::Instant::now();
+            let c = &a % &b;
+            println!("{:?}", c.layout());
+            println!("time: {:?}", start.elapsed());
+            if i == 0 {
+                println!("{c:?}");
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn parallel_test_par_rule6() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([256, 512, 512]);
+        let b = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        for i in 0..10 {
+            let start = std::time::Instant::now();
+            let c = &a % &b;
+            println!("{:?}", c.layout());
+            println!("time: {:?}", start.elapsed());
+            if i == 0 {
+                println!("{c:?}");
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn parallel_test_par_rule6_fprefer() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([512, 512, 256]).into_reverse_axes();
+        let b = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        for i in 0..10 {
+            let start = std::time::Instant::now();
+            let c = &a % &b;
+            println!("{:?}", c.layout());
+            println!("time: {:?}", start.elapsed());
+            if i == 0 {
+                println!("{c:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn syrk_correctness() {
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        let b = linspace((0.0, 1.0, 512 * 512, &device)).into_shape([512, 512]);
+        let c = &a % &a.t();
+        let d = &a % &b.t();
+        assert!(allclose_f64(&c, &d));
+
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 1024 * 1024, &device)).into_shape([4, 512, 512]);
+        let b = linspace((0.0, 1.0, 1024 * 1024, &device)).into_shape([4, 512, 512]);
+        let c = &a % &a.swapaxes(-1, -2);
+        let d = &a % &b.swapaxes(-1, -2);
+        assert!(allclose_f64(&c, &d));
+    }
+
+    #[test]
+    #[ignore]
+    fn syrk_efficiency() {
+        use std::hint::black_box;
+        let device = DeviceBLAS::default();
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([256, 512, 512]);
+        let b = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([256, 512, 512]);
+        for _ in 0..10 {
+            let start = std::time::Instant::now();
+            black_box(&a % &a.swapaxes(-1, -2));
+            println!("syrk time: {:?}", start.elapsed());
+            let start = std::time::Instant::now();
+            black_box(&a % &b.swapaxes(-1, -2));
+            println!("gemm time: {:?}", start.elapsed());
+        }
+
+        println!("---------------------");
+        let a = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([8192, 8192]);
+        let b = linspace((0.0, 1.0, 8192 * 8192, &device)).into_shape([8192, 8192]);
+        for _ in 0..10 {
+            let start = std::time::Instant::now();
+            black_box(&a % &a.swapaxes(-1, -2));
+            println!("syrk time: {:?}", start.elapsed());
+            let start = std::time::Instant::now();
+            black_box(&a % &b.swapaxes(-1, -2));
+            println!("gemm time: {:?}", start.elapsed());
+        }
+    }
+}

--- a/rstsr-kml/src/matmul_impl.rs
+++ b/rstsr-kml/src/matmul_impl.rs
@@ -1,0 +1,583 @@
+#![allow(non_camel_case_types)]
+
+use crate::prelude_dev::*;
+use lapack_ffi::cblas;
+use num::complex::Complex;
+use num::traits::ConstZero;
+use rayon::prelude::*;
+use rstsr_core::prelude_dev::uninitialized_vec;
+use std::ffi::c_void;
+
+type c32 = Complex<f32>;
+type c64 = Complex<f64>;
+
+use cblas::CBLAS_LAYOUT::CblasColMajor as ColMajor;
+use cblas::CBLAS_TRANSPOSE::CblasNoTrans as NoTrans;
+use cblas::CBLAS_TRANSPOSE::CblasTrans as Trans;
+use cblas::CBLAS_UPLO::CblasUpper as Upper;
+
+/* #region gemm */
+
+#[duplicate_item(
+     ty    fn_name                 cblas_wrap       ;
+    [f32] [gemm_blas_no_conj_f32] [cblas_sgemm_wrap];
+    [f64] [gemm_blas_no_conj_f64] [cblas_dgemm_wrap];
+    [c32] [gemm_blas_no_conj_c32] [cblas_cgemm_wrap];
+    [c64] [gemm_blas_no_conj_c64] [cblas_zgemm_wrap];
+)]
+#[allow(clippy::too_many_arguments)]
+pub fn fn_name(
+    c: &mut [ty],
+    lc: &Layout<Ix2>,
+    a: &[ty],
+    la: &Layout<Ix2>,
+    b: &[ty],
+    lb: &Layout<Ix2>,
+    alpha: ty,
+    beta: ty,
+    pool: Option<&ThreadPool>,
+) -> Result<()> {
+    // nthreads is only used for `assign_cpu_rayon`.
+    // the threading should be handled outside this function.
+
+    // check layout of output
+    if !lc.f_prefer() {
+        // change to f-contig anyway
+        // we do not handle conj, so this can be done easily
+        if lc.c_prefer() {
+            // c-prefer, transpose and run
+            return fn_name(c, &lc.reverse_axes(), b, &lb.reverse_axes(), a, &la.reverse_axes(), alpha, beta, pool);
+        } else {
+            // not c-prefer, allocate new buffer and copy back
+            let lc_new = lc.shape().new_f_contig(None);
+            let mut c_new = unsafe { uninitialized_vec(lc_new.size())? };
+            if beta == <ty>::ZERO {
+                fill_cpu_rayon(&mut c_new, &lc_new, <ty>::ZERO, pool)?;
+            } else {
+                assign_cpu_rayon(&mut c_new, &lc_new, c, lc, pool)?;
+            }
+            fn_name(&mut c_new, &lc_new, a, la, b, lb, alpha, <ty>::ZERO, pool)?;
+            assign_cpu_rayon(c, lc, &c_new, &lc_new, pool)?;
+            return Ok(());
+        }
+    }
+
+    // we assume that the layout is correct
+    let sc = lc.shape();
+    let sa = la.shape();
+    let sb = lb.shape();
+    rstsr_assert_eq!(sc[0], sa[0], InvalidLayout)?;
+    rstsr_assert_eq!(sa[1], sb[0], InvalidLayout)?;
+    rstsr_assert_eq!(sc[1], sb[1], InvalidLayout)?;
+
+    let m = sc[0];
+    let n = sc[1];
+    let k = sa[1];
+
+    // handle the special case that k is zero-dimensional
+    if k == 0 {
+        // if k is zero, the result is a zero matrix
+        return fill_cpu_rayon(c, lc, <ty>::ZERO, pool);
+    }
+
+    // handle the special case that n/m is zero-dimensional
+    if n == 0 || m == 0 {
+        // if n or m is zero, the result matrix size is zero, and nothing to do
+        return Ok(());
+    }
+
+    // determine trans/layout and clone data if necessary
+    let mut a_data: Option<Vec<ty>> = None;
+    let mut b_data: Option<Vec<ty>> = None;
+    let (a_trans, la) = if la.f_prefer() {
+        (NoTrans, la.clone())
+    } else if la.c_prefer() {
+        (Trans, la.reverse_axes())
+    } else {
+        let len = la.size();
+        a_data = unsafe { Some(uninitialized_vec(len)?) };
+        let la_data = la.shape().new_f_contig(None);
+        assign_cpu_rayon(a_data.as_mut().unwrap(), &la_data, a, la, pool)?;
+        (NoTrans, la_data)
+    };
+    let (b_trans, lb) = if lb.f_prefer() {
+        (NoTrans, lb.clone())
+    } else if lb.c_prefer() {
+        (Trans, lb.reverse_axes())
+    } else {
+        let len = lb.size();
+        b_data = unsafe { Some(uninitialized_vec(len)?) };
+        let lb_data = lb.shape().new_f_contig(None);
+        assign_cpu_rayon(b_data.as_mut().unwrap(), &lb_data, b, lb, pool)?;
+        (NoTrans, lb_data)
+    };
+
+    // final configuration
+    // shape may be broadcasted for one-dimension case, so make this check
+    let lda = if la.shape()[1] != 1 { la.stride()[1] } else { la.shape()[0] as isize };
+    let ldb = if lb.shape()[1] != 1 { lb.stride()[1] } else { lb.shape()[0] as isize };
+    let ldc = if lc.shape()[1] != 1 { lc.stride()[1] } else { lc.shape()[0] as isize };
+
+    let ptr_c = unsafe { c.as_mut_ptr().add(lc.offset()) };
+    let ptr_a =
+        if let Some(a_data) = a_data.as_ref() { a_data.as_ptr() } else { unsafe { a.as_ptr().add(la.offset()) } };
+    let ptr_b =
+        if let Some(b_data) = b_data.as_ref() { b_data.as_ptr() } else { unsafe { b.as_ptr().add(lb.offset()) } };
+
+    // actual computation
+    unsafe {
+        cblas_wrap(ColMajor, a_trans, b_trans, m, n, k, alpha, ptr_a, lda, ptr_b, ldb, beta, ptr_c, ldc);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_sgemm_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    b_trans: cblas::CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+    k: usize,
+    alpha: f32,
+    ptr_a: *const f32,
+    lda: isize,
+    ptr_b: *const f32,
+    ldb: isize,
+    beta: f32,
+    ptr_c: *mut f32,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_sgemm(
+            order as cblas::CBLAS_LAYOUT,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            b_trans as cblas::CBLAS_TRANSPOSE,
+            m as cblas::blas_int,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            alpha,
+            ptr_a,
+            lda as cblas::blas_int,
+            ptr_b,
+            ldb as cblas::blas_int,
+            beta,
+            ptr_c,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_dgemm_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    b_trans: cblas::CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+    k: usize,
+    alpha: f64,
+    ptr_a: *const f64,
+    lda: isize,
+    ptr_b: *const f64,
+    ldb: isize,
+    beta: f64,
+    ptr_c: *mut f64,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_dgemm(
+            order as cblas::CBLAS_LAYOUT,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            b_trans as cblas::CBLAS_TRANSPOSE,
+            m as cblas::blas_int,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            alpha,
+            ptr_a,
+            lda as cblas::blas_int,
+            ptr_b,
+            ldb as cblas::blas_int,
+            beta,
+            ptr_c,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_cgemm_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    b_trans: cblas::CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+    k: usize,
+    alpha: c32,
+    ptr_a: *const c32,
+    lda: isize,
+    ptr_b: *const c32,
+    ldb: isize,
+    beta: c32,
+    ptr_c: *mut c32,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_cgemm(
+            order as cblas::CBLAS_LAYOUT,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            b_trans as cblas::CBLAS_TRANSPOSE,
+            m as cblas::blas_int,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            &alpha as *const _ as *const c_void,
+            ptr_a as *const c_void,
+            lda as cblas::blas_int,
+            ptr_b as *const c_void,
+            ldb as cblas::blas_int,
+            &beta as *const _ as *const c_void,
+            ptr_c as *mut c_void,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_zgemm_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    b_trans: cblas::CBLAS_TRANSPOSE,
+    m: usize,
+    n: usize,
+    k: usize,
+    alpha: c64,
+    ptr_a: *const c64,
+    lda: isize,
+    ptr_b: *const c64,
+    ldb: isize,
+    beta: c64,
+    ptr_c: *mut c64,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_zgemm(
+            order as cblas::CBLAS_LAYOUT,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            b_trans as cblas::CBLAS_TRANSPOSE,
+            m as cblas::blas_int,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            &alpha as *const _ as *const c_void,
+            ptr_a as *const c_void,
+            lda as cblas::blas_int,
+            ptr_b as *const c_void,
+            ldb as cblas::blas_int,
+            &beta as *const _ as *const c_void,
+            ptr_c as *mut c_void,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+/* #endregion */
+
+/* #region syrk */
+
+#[duplicate_item(
+     ty    fn_name                 cblas_wrap       ;
+    [f32] [syrk_blas_no_conj_f32] [cblas_ssyrk_wrap];
+    [f64] [syrk_blas_no_conj_f64] [cblas_dsyrk_wrap];
+    [c32] [syrk_blas_no_conj_c32] [cblas_csyrk_wrap];
+    [c64] [syrk_blas_no_conj_c64] [cblas_zsyrk_wrap];
+)]
+pub fn fn_name(
+    c: &mut [ty],
+    lc: &Layout<Ix2>,
+    a: &[ty],
+    la: &Layout<Ix2>,
+    alpha: ty,
+    pool: Option<&ThreadPool>,
+) -> Result<()> {
+    // beta is assumed to be zero, and not passed as argument.
+
+    // check layout of output
+    if !lc.f_prefer() {
+        // change to f-contig anyway
+        // we do not handle conj, so this can be done easily
+        if lc.c_prefer() {
+            // c-prefer, transpose and run
+            return fn_name(c, &lc.reverse_axes(), a, la, alpha, pool);
+        } else {
+            // not c-prefer, allocate new buffer and copy back
+            let lc_new = lc.shape().new_f_contig(None);
+            let mut c_new = unsafe { uninitialized_vec(lc_new.size())? };
+            fill_cpu_rayon(&mut c_new, &lc_new, <ty>::ZERO, pool)?;
+            fn_name(&mut c_new, &lc_new, a, la, alpha, pool)?;
+            assign_cpu_rayon(c, lc, &c_new, &lc_new, pool)?;
+            return Ok(());
+        }
+    }
+
+    // we assume that the layout is correct
+    let sc = lc.shape();
+    let sa = la.shape();
+    rstsr_assert_eq!(sc[0], sa[0], InvalidLayout)?;
+    rstsr_assert_eq!(sc[1], sc[0], InvalidLayout)?;
+
+    let n = sc[0];
+    let k = sa[1];
+
+    // handle the special case that k is zero-dimensional
+    if k == 0 {
+        // if k is zero, the result is a zero matrix
+        return fill_cpu_rayon(c, lc, <ty>::ZERO, pool);
+    }
+
+    // handle the special case that n is zero-dimensional
+    if n == 0 {
+        // if n is zero, the result matrix size is zero, and nothing to do
+        return Ok(());
+    }
+
+    // determine trans/layout and clone data if necessary
+    let mut a_data: Option<Vec<ty>> = None;
+    let (a_trans, la) = if la.f_prefer() {
+        (NoTrans, la.clone())
+    } else if la.c_prefer() {
+        (Trans, la.reverse_axes())
+    } else {
+        let len = la.size();
+        a_data = unsafe { Some(uninitialized_vec(len)?) };
+        let la_data = la.shape().new_f_contig(None);
+        assign_cpu_rayon(a_data.as_mut().unwrap(), &la_data, a, la, pool)?;
+        (NoTrans, la_data)
+    };
+
+    // final configuration
+    // shape may be broadcasted for one-dimension case, so make this check
+    let lda = if la.shape()[1] != 1 { la.stride()[1] } else { la.shape()[0] as isize };
+    let ldc = if lc.shape()[1] != 1 { lc.stride()[1] } else { lc.shape()[0] as isize };
+
+    let ptr_c = unsafe { c.as_mut_ptr().add(lc.offset()) };
+    let ptr_a =
+        if let Some(a_data) = a_data.as_ref() { a_data.as_ptr() } else { unsafe { a.as_ptr().add(la.offset()) } };
+
+    // actual computation
+    unsafe {
+        cblas_wrap(ColMajor, Upper, a_trans, n, k, alpha, ptr_a, lda, <ty>::ZERO, ptr_c, ldc);
+    }
+
+    // write back to lower triangle
+    let n = sc[0];
+    let ldc = lc.stride()[1];
+    let offset = lc.offset() as isize;
+    let task = || {
+        (0..(n as isize)).into_par_iter().for_each(|j| {
+            ((j + 1)..(n as isize)).for_each(|i| unsafe {
+                let idx_ij = (offset + j * ldc + i) as usize;
+                let idx_ji = (offset + i * ldc + j) as usize;
+                let c_ptr_ij = c.as_ptr().add(idx_ij) as *mut ty;
+                *c_ptr_ij = c[idx_ji];
+            });
+        });
+    };
+    pool.map_or_else(task, |pool| pool.install(task));
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_ssyrk_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    uplo: cblas::CBLAS_UPLO,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    n: usize,
+    k: usize,
+    alpha: f32,
+    ptr_a: *const f32,
+    lda: isize,
+    beta: f32,
+    ptr_c: *mut f32,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_ssyrk(
+            order as cblas::CBLAS_LAYOUT,
+            uplo as cblas::CBLAS_UPLO,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            alpha,
+            ptr_a,
+            lda as cblas::blas_int,
+            beta,
+            ptr_c,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_dsyrk_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    uplo: cblas::CBLAS_UPLO,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    n: usize,
+    k: usize,
+    alpha: f64,
+    ptr_a: *const f64,
+    lda: isize,
+    beta: f64,
+    ptr_c: *mut f64,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_dsyrk(
+            order as cblas::CBLAS_LAYOUT,
+            uplo as cblas::CBLAS_UPLO,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            alpha,
+            ptr_a,
+            lda as cblas::blas_int,
+            beta,
+            ptr_c,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_csyrk_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    uplo: cblas::CBLAS_UPLO,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    n: usize,
+    k: usize,
+    alpha: c32,
+    ptr_a: *const c32,
+    lda: isize,
+    beta: c32,
+    ptr_c: *mut c32,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_csyrk(
+            order as cblas::CBLAS_LAYOUT,
+            uplo as cblas::CBLAS_UPLO,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            &alpha as *const _ as *const c_void,
+            ptr_a as *const c_void,
+            lda as cblas::blas_int,
+            &beta as *const _ as *const c_void,
+            ptr_c as *mut c_void,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+unsafe fn cblas_zsyrk_wrap(
+    order: cblas::CBLAS_LAYOUT,
+    uplo: cblas::CBLAS_UPLO,
+    a_trans: cblas::CBLAS_TRANSPOSE,
+    n: usize,
+    k: usize,
+    alpha: c64,
+    ptr_a: *const c64,
+    lda: isize,
+    beta: c64,
+    ptr_c: *mut c64,
+    ldc: isize,
+) {
+    unsafe {
+        cblas::cblas_zsyrk(
+            order as cblas::CBLAS_LAYOUT,
+            uplo as cblas::CBLAS_UPLO,
+            a_trans as cblas::CBLAS_TRANSPOSE,
+            n as cblas::blas_int,
+            k as cblas::blas_int,
+            &alpha as *const _ as *const c_void,
+            ptr_a as *const c_void,
+            lda as cblas::blas_int,
+            &beta as *const _ as *const c_void,
+            ptr_c as *mut c_void,
+            ldc as cblas::blas_int,
+        );
+    }
+}
+
+/* #endregion */
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_f32() {
+        let a = vec![1., 2., 3., 4., 5., 6.];
+        let b = vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.];
+        let mut c = vec![0.0; 16];
+
+        let la = [2, 3].c();
+        let lb = [3, 4].c();
+        let lc = [2, 4].c();
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(16).build().unwrap();
+        let pool = Some(&pool);
+        gemm_blas_no_conj_f32(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        let c_tsr = TensorView::new(asarray(&c).into_raw_parts().0, lc);
+        println!("{c_tsr:}");
+        println!("{:}", c_tsr.reshape([8]));
+        let c_ref = asarray(vec![38., 44., 50., 56., 83., 98., 113., 128.]);
+        assert!(allclose_f64(&c_tsr.map(|v| *v as f64), &c_ref));
+
+        let la = [2, 3].c();
+        let lb = [3, 4].c();
+        let lc = [2, 4].f();
+        gemm_blas_no_conj_f32(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        let c_tsr = TensorView::new(asarray(&c).into_raw_parts().0, lc);
+        println!("{c_tsr:}");
+        println!("{:}", c_tsr.reshape([8]));
+        let c_ref = asarray(vec![38., 44., 50., 56., 83., 98., 113., 128.]);
+        assert!(allclose_f64(&c_tsr.map(|v| *v as f64), &c_ref));
+
+        let la = [2, 3].f();
+        let lb = [3, 4].c();
+        let lc = [2, 4].c();
+        gemm_blas_no_conj_f32(&mut c, &lc, &a, &la, &b, &lb, 1.0, 0.0, pool).unwrap();
+        let c_tsr = TensorView::new(asarray(&c).into_raw_parts().0, lc);
+        println!("{c_tsr:}");
+        println!("{:}", c_tsr.reshape([8]));
+        let c_ref = asarray(vec![61., 70., 79., 88., 76., 88., 100., 112.]);
+        assert!(allclose_f64(&c_tsr.map(|v| *v as f64), &c_ref));
+
+        let la = [2, 3].f();
+        let lb = [3, 4].c();
+        let lc = [2, 4].f();
+        gemm_blas_no_conj_f32(&mut c, &lc, &a, &la, &b, &lb, 2.0, 0.0, pool).unwrap();
+        let c_tsr = TensorView::new(asarray(&c).into_raw_parts().0, lc);
+        println!("{c_tsr:}");
+        println!("{:}", c_tsr.reshape([8]));
+        let c_ref = 2 * asarray(vec![61., 70., 79., 88., 76., 88., 100., 112.]);
+        assert!(allclose_f64(&c_tsr.map(|v| *v as f64), &c_ref));
+    }
+
+    #[test]
+    fn test_c32() {
+        let a = linspace((c32::new(1., 1.), c32::new(6., 6.), 6)).into_vec();
+        let b = linspace((c32::new(1., 1.), c32::new(12., 12.), 12)).into_vec();
+        let mut c = vec![c32::ZERO; 16];
+
+        let la = [2, 3].c();
+        let lb = [3, 4].c();
+        let lc = [2, 4].c();
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(16).build().unwrap();
+        let pool = Some(&pool);
+        gemm_blas_no_conj_c32(&mut c, &lc, &a, &la, &b, &lb, c32::ONE, c32::ZERO, pool).unwrap();
+        let c_tsr = TensorView::new(asarray(&c).into_raw_parts().0, lc);
+        println!("{c_tsr:}");
+        println!("{:}", c_tsr.reshape([8]));
+    }
+}

--- a/rstsr-kml/src/prelude_dev.rs
+++ b/rstsr-kml/src/prelude_dev.rs
@@ -1,0 +1,4 @@
+pub(crate) use crate::DeviceBLAS;
+pub(crate) use crate::DeviceRayonAutoImpl;
+pub use rstsr_core::prelude_dev::*;
+pub(crate) use rstsr_kml_ffi as lapack_ffi;

--- a/rstsr-kml/src/rayon_auto_impl/adv_indexing.rs
+++ b/rstsr-kml/src/rayon_auto_impl/adv_indexing.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/adv_indexing.rs

--- a/rstsr-kml/src/rayon_auto_impl/assignment.rs
+++ b/rstsr-kml/src/rayon_auto_impl/assignment.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/assignment.rs

--- a/rstsr-kml/src/rayon_auto_impl/mod.rs
+++ b/rstsr-kml/src/rayon_auto_impl/mod.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/mod.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_binary_arithmetic.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_binary_arithmetic.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_binary_arithmetic.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_binary_common.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_binary_common.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_binary_common.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_ternary_arithmetic.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_ternary_arithmetic.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_ternary_arithmetic.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_ternary_common.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_ternary_common.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_ternary_common.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_tri.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_tri.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_tri.rs

--- a/rstsr-kml/src/rayon_auto_impl/op_with_func.rs
+++ b/rstsr-kml/src/rayon_auto_impl/op_with_func.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/op_with_func.rs

--- a/rstsr-kml/src/rayon_auto_impl/reduction.rs
+++ b/rstsr-kml/src/rayon_auto_impl/reduction.rs
@@ -1,0 +1,1 @@
+../../../rstsr-core/src/feature_rayon/auto_impl/reduction.rs

--- a/rstsr-kml/src/sci_auto_impl/distance_auto_impl.rs
+++ b/rstsr-kml/src/sci_auto_impl/distance_auto_impl.rs
@@ -1,0 +1,1 @@
+../../../rstsr-sci-traits/src/distance/auto_impl_rayon.rs

--- a/rstsr-kml/src/sci_auto_impl/integrate_auto_impl.rs
+++ b/rstsr-kml/src/sci_auto_impl/integrate_auto_impl.rs
@@ -1,0 +1,1 @@
+../../../rstsr-sci-traits/src/integrate/auto_impl_rayon.rs

--- a/rstsr-kml/src/sci_auto_impl/mod.rs
+++ b/rstsr-kml/src/sci_auto_impl/mod.rs
@@ -1,0 +1,2 @@
+pub mod distance_auto_impl;
+pub mod integrate_auto_impl;

--- a/rstsr-kml/src/threading.rs
+++ b/rstsr-kml/src/threading.rs
@@ -10,15 +10,11 @@ struct KMLConfig;
 impl KMLConfig {
     fn set_num_threads(&mut self, n: usize) {
         unsafe { rstsr_kml_ffi::kblas::BlasSetNumThreadsLocal(n as _) };
-        unsafe { rstsr_kml_ffi::service::KmlSetNumThreads(n as _) };
+        unsafe { rstsr_kml_ffi::service::KmlSetNumThreads(1) };
     }
 
     fn get_num_threads(&mut self) -> usize {
         let n_blas = unsafe { rstsr_kml_ffi::kblas::BlasGetNumThreadsLocal() as usize };
-        let n_kml = unsafe { rstsr_kml_ffi::service::KmlGetMaxThreads() as usize };
-        if n_blas != n_kml {
-            eprintln!("KML thread counts are inconsistent: {n_blas} (kblas) vs {n_kml} (service)");
-        }
         n_blas
     }
 }

--- a/rstsr-kml/src/threading.rs
+++ b/rstsr-kml/src/threading.rs
@@ -14,8 +14,7 @@ impl KMLConfig {
     }
 
     fn get_num_threads(&mut self) -> usize {
-        let n_blas = unsafe { rstsr_kml_ffi::kblas::BlasGetNumThreadsLocal() as usize };
-        n_blas
+        unsafe { rstsr_kml_ffi::kblas::BlasGetNumThreadsLocal() as usize }
     }
 }
 

--- a/rstsr-kml/src/threading.rs
+++ b/rstsr-kml/src/threading.rs
@@ -1,0 +1,69 @@
+//! KML threading
+
+use crate::prelude_dev::*;
+use rstsr_blas_traits::prelude_dev::*;
+
+/* #region threading number control */
+
+struct KMLConfig;
+
+impl KMLConfig {
+    fn set_num_threads(&mut self, n: usize) {
+        unsafe { rstsr_kml_ffi::kblas::BlasSetNumThreadsLocal(n as _) };
+        unsafe { rstsr_kml_ffi::service::KmlSetNumThreads(n as _) };
+    }
+
+    fn get_num_threads(&mut self) -> usize {
+        let n_blas = unsafe { rstsr_kml_ffi::kblas::BlasGetNumThreadsLocal() as usize };
+        let n_kml = unsafe { rstsr_kml_ffi::service::KmlGetMaxThreads() as usize };
+        if n_blas != n_kml {
+            eprintln!("KML thread counts are inconsistent: {n_blas} (kblas) vs {n_kml} (service)");
+        }
+        n_blas
+    }
+}
+
+/// Set number of threads for KML.
+///
+/// This function should be safe to call from multiple threads.
+pub fn set_num_threads(n: usize) {
+    KMLConfig.set_num_threads(n);
+}
+
+/// Get the number of threads currently set for KML.
+///
+/// This function should be safe to call from multiple threads.
+pub fn get_num_threads() -> usize {
+    KMLConfig.get_num_threads()
+}
+
+pub fn with_num_threads<F, R>(nthreads: usize, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let n = get_num_threads();
+    set_num_threads(nthreads);
+    let r = f();
+    set_num_threads(n);
+    return r;
+}
+
+/* #endregion */
+
+/* #region trait impl */
+
+impl BlasThreadAPI for DeviceBLAS {
+    fn get_blas_num_threads(&self) -> usize {
+        crate::threading::get_num_threads()
+    }
+
+    fn set_blas_num_threads(&self, nthreads: usize) {
+        crate::threading::set_num_threads(nthreads);
+    }
+
+    fn with_blas_num_threads<T>(&self, nthreads: usize, f: impl FnOnce() -> T) -> T {
+        crate::threading::with_num_threads(nthreads, f)
+    }
+}
+
+/* #endregion */

--- a/rstsr-kml/tests/mod.rs
+++ b/rstsr-kml/tests/mod.rs
@@ -1,0 +1,3 @@
+mod test_driver_impl;
+#[cfg(feature = "linalg")]
+mod test_linalg_func;

--- a/rstsr-kml/tests/test_driver_impl/driver_validation_f64.py
+++ b/rstsr-kml/tests/test_driver_impl/driver_validation_f64.py
@@ -1,0 +1,141 @@
+# # Driver tests in Python
+
+import numpy as np
+import scipy
+
+
+def fingerprint(a):
+    return np.dot(np.cos(np.arange(a.size)), np.asarray(a, order="C").ravel())
+
+
+# Path of npy files in rstsr-test-manifest
+
+root = "../../../rstsr-test-manifest/resources/"
+
+# ## make sure of random generation
+
+a_raw = np.load(f"{root}/a-f64.npy")
+b_raw = np.load(f"{root}/b-f64.npy")
+
+assert np.isclose(fingerprint(a_raw), 191.28900005103065)
+assert np.isclose(fingerprint(b_raw), -51.11100342180723)
+
+# ## eigh driver tests
+
+# ### dsyev*
+
+a = a_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsyevd(a, lower=True)
+assert np.isclose(fingerprint(w), -71.4747209499407)
+assert np.isclose(fingerprint(np.abs(v)), -9.903934930318247)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsyevd(a, lower=False)
+assert np.isclose(fingerprint(w), -71.4902453763506)
+assert np.isclose(fingerprint(np.abs(v)), 6.973792268793419)
+fingerprint(w), fingerprint(np.abs(v))
+
+# ### dsygv*
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsygvd(a, b, uplo='L')
+assert np.isclose(fingerprint(w), -89.60433120129908)
+assert np.isclose(fingerprint(np.abs(v)), -5.243112559130817)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsygvd(a, b, uplo='U')
+assert np.isclose(fingerprint(w), -65.27252612342873)
+assert np.isclose(fingerprint(np.abs(v)), -7.0849504857534535)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsygvd(a, b, uplo='L', itype=2)
+assert np.isclose(fingerprint(w), -2437.094304861363)
+assert np.isclose(fingerprint(np.abs(v)), -4.108281604767547)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v, _ = scipy.linalg.lapack.dsygvd(a, b, uplo='L', itype=3)
+assert np.isclose(fingerprint(w), -2437.094304861363)
+assert np.isclose(fingerprint(np.abs(v)), 30.756098926747757)
+fingerprint(w), fingerprint(np.abs(v))
+
+# ## solve driver tests
+
+# ### gesv
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy()[:1024*512].reshape(1024, 512)
+lu, piv, x, _ = scipy.linalg.lapack.dgesv(a, b)
+assert np.isclose(fingerprint(lu), 5397.198541468395)
+assert np.isclose(fingerprint(piv), -14.694714160751573)
+assert np.isclose(fingerprint(x), -1951.253447757597)
+fingerprint(lu), fingerprint(piv), fingerprint(x)
+
+# ### getrf, getri
+
+a = a_raw.copy().reshape(1024, 1024)
+lu, piv, _ = scipy.linalg.lapack.dgetrf(a)
+assert np.isclose(fingerprint(lu), 5397.198541468395)
+assert np.isclose(fingerprint(piv), -14.694714160751573)
+fingerprint(lu), fingerprint(piv)
+
+inv_a, _ = scipy.linalg.lapack.dgetri(lu, piv)
+assert np.isclose(fingerprint(inv_a), 143.3900557703788)
+fingerprint(inv_a)
+
+# ### potrf
+
+# Please note that driver implementation in rust does not clean upper/lower triangular.
+
+b = b_raw.copy().reshape(1024, 1024)
+c, _ = scipy.linalg.lapack.dpotrf(b, lower=True, clean=0)
+assert np.isclose(fingerprint(c), 35.17266259472725)
+fingerprint(c)
+
+b = b_raw.copy().reshape(1024, 1024)
+c, _ = scipy.linalg.lapack.dpotrf(b, lower=False, clean=0)
+assert np.isclose(fingerprint(c), -53.53353704132017)
+fingerprint(c)
+
+# ### sysv
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy()[:1024*512].reshape(1024, 512)
+udut, piv, x, _ = scipy.linalg.lapack.dsysv(a, b, lower=True)
+assert np.isclose(fingerprint(udut), -1201.6472395568974)
+assert np.isclose(fingerprint(piv), -16668.7094872639)
+assert np.isclose(fingerprint(x), -397.12032355166446)
+fingerprint(udut), fingerprint(piv), fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy()[:1024*512].reshape(1024, 512)
+udut, piv, x, _ = scipy.linalg.lapack.dsysv(a, b, lower=False)
+assert np.isclose(fingerprint(udut), 1182.7836118324408)
+assert np.isclose(fingerprint(piv), 11905.503011559245)
+assert np.isclose(fingerprint(x), -314.4502289190444)
+fingerprint(udut), fingerprint(piv), fingerprint(x)
+
+# ## svd driver tests
+
+a = a_raw.copy()[:1024*512].reshape(1024, 512)
+u, s, vt, _ = scipy.linalg.lapack.dgesvd(a)
+assert np.isclose(fingerprint(np.abs(u)), -1.9368850983570982)
+assert np.isclose(fingerprint(s), 33.969339071043095)
+assert np.isclose(fingerprint(np.abs(vt)), 13.465522484136157)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+a = a_raw.copy()[:1024*512].reshape(1024, 512)
+u, s, vt, _ = scipy.linalg.lapack.dgesvd(a, full_matrices=False)
+assert np.isclose(fingerprint(np.abs(u)), -9.144981428076894)
+assert np.isclose(fingerprint(s), 33.969339071043095)
+assert np.isclose(fingerprint(np.abs(vt)), 13.465522484136157)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+

--- a/rstsr-kml/tests/test_driver_impl/lapack_eigh_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_eigh_f64.rs
@@ -1,0 +1,148 @@
+use rstsr_blas_traits::lapack_eigh::*;
+use rstsr_core::prelude::*;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_kml::DeviceKML as DeviceBLAS;
+use rstsr_test_manifest::get_vec;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_dsyevd() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DSYEVD::default().a(a.view()).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+
+        // upper for c-contiguous
+        let driver = DSYEVD::default().a(a.view()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 6.973792268793419).abs() < 1e-8);
+
+        // transpose upper for c-contiguous
+        let driver = DSYEVD::default().a(a.t()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dsyev() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DSYEV::default().a(a.view()).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+
+        // upper for c-contiguous
+        let driver = DSYEV::default().a(a.view()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 6.973792268793419).abs() < 1e-8);
+
+        // transpose upper for c-contiguous
+        let driver = DSYEV::default().a(a.t()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dsygvd() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DSYGVD::default().a(a.view()).b(b.view()).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -5.243112559130817).abs() < 1e-8);
+
+        // upper for c-contiguous
+        let driver = DSYGVD::default().a(a.view()).b(b.view()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -65.27252612342873).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -7.0849504857534535).abs() < 1e-8);
+
+        // transpose upper for c-contiguous
+        let driver = DSYGVD::default().a(a.t()).b(b.t()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -5.243112559130817).abs() < 1e-8);
+
+        // itype 2
+        let driver = DSYGVD::default().a(a.view()).b(b.view()).itype(2).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -2437.094304861363).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -4.108281604767547).abs() < 1e-8);
+
+        // itype 3
+        let driver = DSYGVD::default().a(a.view()).b(b.view()).itype(3).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -2437.094304861363).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 30.756098926747757).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dsygv() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DSYGV::default().a(a.view()).b(b.view()).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -5.243112559130817).abs() < 1e-8);
+
+        // upper for c-contiguous
+        let driver = DSYGV::default().a(a.view()).b(b.view()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -65.27252612342873).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -7.0849504857534535).abs() < 1e-8);
+
+        // transpose upper for c-contiguous
+        let driver = DSYGV::default().a(a.t()).b(b.t()).uplo(Upper).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -5.243112559130817).abs() < 1e-8);
+
+        // itype 2
+        let driver = DSYGV::default().a(a.view()).b(b.view()).itype(2).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -2437.094304861363).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -4.108281604767547).abs() < 1e-8);
+
+        // itype 3
+        let driver = DSYGV::default().a(a.view()).b(b.view()).itype(3).build().unwrap();
+        let (w, v) = driver.run().unwrap();
+        let v = v.into_owned();
+        assert!((fingerprint(&w) - -2437.094304861363).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 30.756098926747757).abs() < 1e-8);
+    }
+}

--- a/rstsr-kml/tests/test_driver_impl/lapack_solve_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_solve_f64.rs
@@ -1,0 +1,95 @@
+use rstsr_blas_traits::lapack_solve::*;
+use rstsr_core::prelude::*;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_kml::DeviceKML as DeviceBLAS;
+use rstsr_test_manifest::get_vec;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_dgesv() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = &get_vec::<f64>('b')[..1024 * 512];
+        let b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DGESV::default().a(a.view()).b(b.view()).build().unwrap();
+        let (lu, piv, x) = driver.run().unwrap();
+        let lu = lu.into_owned();
+        let x = x.into_owned();
+        let fpiv = piv.map(|&v| v as f64);
+        assert!((fingerprint(&lu) - 5397.198541468395).abs() < 1e-8);
+        assert!((fingerprint(&fpiv) - -14.694714160751573).abs() < 1e-8);
+        assert!((fingerprint(&x) - -1951.253447757597).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dgetrf_dgetri() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DGETRF::default().a(a.view()).build().unwrap();
+        let (lu, piv) = driver.run().unwrap();
+        let lu = lu.into_owned();
+        let fpiv = piv.map(|&v| v as f64);
+        assert!((fingerprint(&lu) - 5397.198541468395).abs() < 1e-8);
+        assert!((fingerprint(&fpiv) - -14.694714160751573).abs() < 1e-8);
+
+        let driver = DGETRI::default().a(lu.view()).ipiv(piv.view()).build().unwrap();
+        let inv_a = driver.run().unwrap();
+        let inv_a = inv_a.into_owned();
+        assert!((fingerprint(&inv_a) - 143.3900557703788).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dpotrf() {
+        let device = DeviceBLAS::default();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DPOTRF::default().a(b.view()).build().unwrap();
+        let c = driver.run().unwrap();
+        let c = c.into_owned();
+        println!("fingerprint {:?}", fingerprint(&c));
+        assert!((fingerprint(&c) - 35.17266259472725).abs() < 1e-8);
+
+        // upper
+        let driver = DPOTRF::default().a(b.view()).uplo(Upper).build().unwrap();
+        let c = driver.run().unwrap();
+        let c = c.into_owned();
+        println!("fingerprint {:?}", fingerprint(&c));
+        assert!((fingerprint(&c) - -53.53353704132017).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_dsysv() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = &get_vec::<f64>('b')[..1024 * 512];
+        let b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DSYSV::default().a(a.view()).b(b.view()).build().unwrap();
+        let (udut, piv, x) = driver.run().unwrap();
+        let udut = udut.into_owned();
+        let x = x.into_owned();
+        let fpiv = piv.map(|&v| v as f64);
+        assert!((fingerprint(&udut) - -1201.6472395568974).abs() < 1e-8);
+        assert!((fingerprint(&fpiv) - -16668.7094872639).abs() < 1e-8);
+        assert!((fingerprint(&x) - -397.12032355166446).abs() < 1e-8);
+
+        // upper
+        let driver = DSYSV::default().a(a.view()).b(b.view()).uplo(Upper).build().unwrap();
+        let (udut, piv, x) = driver.run().unwrap();
+        let udut = udut.into_owned();
+        let x = x.into_owned();
+        let fpiv = piv.map(|&v| v as f64);
+        assert!((fingerprint(&udut) - 1182.7836118324408).abs() < 1e-8);
+        assert!((fingerprint(&fpiv) - 11905.503011559245).abs() < 1e-8);
+        assert!((fingerprint(&x) - -314.4502289190444).abs() < 1e-8);
+    }
+}

--- a/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
@@ -18,6 +18,7 @@ mod test {
         let driver = DGESVD::default().a(a.view()).build().unwrap();
         if let (s, Some(u), Some(vt), _) = driver.run().unwrap() {
             assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+            println!("fingerprint(u) = {}", fingerprint(&(&u).abs())); // 8.932956543614006
             assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
             assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
         } else {

--- a/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
@@ -1,0 +1,80 @@
+use rstsr_blas_traits::lapack_svd::*;
+use rstsr_core::prelude::*;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_kml::DeviceKML as DeviceBLAS;
+use rstsr_test_manifest::get_vec;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_dgesvd() {
+        let device = DeviceBLAS::default();
+        let a_vec = &get_vec::<f64>('a')[..1024 * 512];
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DGESVD::default().a(a.view()).build().unwrap();
+        if let (s, Some(u), Some(vt), _) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+            assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
+            assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+        } else {
+            panic!("DGESVD did not return expected output");
+        }
+
+        // full_matrices = false
+        let driver = DGESVD::default().a(a.view()).full_matrices(false).build().unwrap();
+        if let (s, Some(u), Some(vt), _) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+            assert!((fingerprint(&u.abs()) - -9.144981428076894).abs() < 1e-8);
+            assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+        } else {
+            panic!("DGESVD did not return expected output");
+        }
+
+        // full_matrices = false, compute_uv = false
+        let driver = DGESVD::default().a(a.view()).full_matrices(false).compute_uv(false).build().unwrap();
+        if let (s, None, None, _) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        } else {
+            panic!("DGESVD did not return expected output");
+        }
+    }
+
+    #[test]
+    fn test_dgesdd() {
+        let device = DeviceBLAS::default();
+        let a_vec = &get_vec::<f64>('a')[..1024 * 512];
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let driver = DGESDD::default().a(a.view()).build().unwrap();
+        if let (s, Some(u), Some(vt)) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+            assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
+            assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+        } else {
+            panic!("DGESDD did not return expected output");
+        }
+
+        // full_matrices = false
+        let driver = DGESDD::default().a(a.view()).full_matrices(false).build().unwrap();
+        if let (s, Some(u), Some(vt)) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+            assert!((fingerprint(&u.abs()) - -9.144981428076894).abs() < 1e-8);
+            assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+        } else {
+            panic!("DGESDD did not return expected output");
+        }
+
+        // full_matrices = false, compute_uv = false
+        let driver = DGESDD::default().a(a.view()).full_matrices(false).compute_uv(false).build().unwrap();
+        if let (s, None, None) = driver.run().unwrap() {
+            assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        } else {
+            panic!("DGESDD did not return expected output");
+        }
+    }
+}

--- a/rstsr-kml/tests/test_driver_impl/mod.rs
+++ b/rstsr-kml/tests/test_driver_impl/mod.rs
@@ -1,0 +1,3 @@
+mod lapack_eigh_f64;
+mod lapack_solve_f64;
+mod lapack_svd_f64;

--- a/rstsr-kml/tests/test_linalg_func/func_c64.rs
+++ b/rstsr-kml/tests/test_linalg_func/func_c64.rs
@@ -1,0 +1,319 @@
+use rstsr::prelude::*;
+use rstsr_kml::DeviceKML as DeviceBLAS;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_test_manifest::get_vec;
+
+#[allow(non_camel_case_types)]
+type c64 = num::Complex<f64>;
+
+macro_rules! c64 {
+    ($real:expr, $imag:expr) => {
+        c64::new($real, $imag)
+    };
+    ($real:expr) => {
+        c64::new($real, 0.0)
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cholesky() {
+        let device = DeviceBLAS::default();
+        let mut b = rt::asarray((get_vec::<c64>('b'), [1024, 1024].c(), &device));
+
+        // default
+        let c = rt::linalg::cholesky(b.view());
+        assert!((fingerprint(&c) - c64!(62.89494065393874, -73.47055443374522)).norm() < 1e-8);
+
+        // upper
+        let c = rt::linalg::cholesky((b.view(), Upper));
+        assert!((fingerprint(&c) - c64!(13.720509103165073, -1.8066465348490963)).norm() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::cholesky((b.view_mut(), Upper));
+        assert!((fingerprint(&b) - c64!(13.720509103165073, -1.8066465348490963)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_det() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<c64>('a')[..5 * 5].to_vec();
+        let mut a = rt::asarray((a_vec, [5, 5].c(), &device));
+
+        let det = rt::linalg::det(a.view_mut());
+        assert!((det - c64!(-24.808965756481086, 11.800248863799464)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_eigh() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device));
+        let b = rt::asarray((get_vec::<c64>('b'), [1024, 1024].c(), &device));
+
+        // default, a
+        let (w, v) = rt::linalg::eigh(a.view()).into();
+        assert!((fingerprint(&w) - -100.79793355894122).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -7.450761195788254).abs() < 1e-8);
+
+        // upper, a
+        let (w, v) = rt::linalg::eigh((a.view(), Upper)).into();
+        assert!((fingerprint(&w) - -103.99103522434956).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -12.184946930165328).abs() < 1e-8);
+
+        // default, a b
+        let (w, v) = rt::linalg::eigh((a.view(), b.view())).into();
+        assert!((fingerprint(&w) - -97.43376763322635).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -4.3181177983574255).abs() < 1e-8);
+
+        // upper, a b, itype=3
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Upper, 3)).into();
+        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -0.15861903557045487).abs() < 1e-8);
+
+        // mutable changes a
+        let (w, _) = rt::linalg::eigh(a.view_mut()).into();
+        assert!((fingerprint(&w) - -100.79793355894122).abs() < 1e-8);
+        assert!((fingerprint(&a.abs()) - -7.450761195788254).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_eigvalsh() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device));
+        let b = rt::asarray((get_vec::<c64>('b'), [1024, 1024].c(), &device));
+
+        // default, a
+        let w = rt::linalg::eigvalsh(a.view());
+        assert!((fingerprint(&w) - -100.79793355894122).abs() < 1e-8);
+
+        // upper, a
+        let w = rt::linalg::eigvalsh((a.view(), Upper));
+        assert!((fingerprint(&w) - -103.99103522434956).abs() < 1e-8);
+
+        // default, a b
+        let w = rt::linalg::eigvalsh((a.view(), b.view()));
+        assert!((fingerprint(&w) - -97.43376763322635).abs() < 1e-8);
+
+        // upper, a b, itype=3
+        let w = rt::linalg::eigvalsh((a.view(), b.view(), Upper, 3));
+        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8);
+
+        // mutable changes a
+        let w = rt::linalg::eigvalsh(a.view_mut());
+        assert!((fingerprint(&w) - -100.79793355894122).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_inv() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device));
+
+        // immutable
+        let a_inv = rt::linalg::inv(a.view());
+        assert!((fingerprint(&a_inv) - c64!(-11.836382515156183, 8.250167298349842)).norm() < 1e-8);
+
+        // mutable
+        rt::linalg::inv(a.view_mut());
+        assert!((fingerprint(&a) - c64!(-11.836382515156183, 8.250167298349842)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_pinv() {
+        let device = DeviceBLAS::default();
+
+        // 1024 x 512
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - c64!(-0.03454885412959018, -0.023651876085623254)).norm() < 1e-8);
+        assert_eq!(rank, 240);
+
+        // 512 x 1024
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - c64!(-0.2814806469687325, -0.15198888300458474)).norm() < 1e-8);
+        assert_eq!(rank, 240);
+    }
+
+    #[test]
+    fn test_slogdet() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device));
+
+        let (sign, logabsdet) = rt::linalg::slogdet(a.view_mut()).into();
+        assert!((sign - c64!(-0.44606842323663365, 0.8949988613351316)).norm() < 1e-8);
+        assert!(logabsdet - 3393.6720579594585 < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_general() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<c64>('b')[..1024 * 512].to_vec();
+        let mut b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - c64!(404.1900761036138, -258.5602505551204)).norm() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - c64!(404.1900761036138, -258.5602505551204)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_general_for_vec() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<c64>('b')[..1024].to_vec();
+        let mut b = rt::asarray((b_vec, [1024].c(), &device)).into_dim::<Ix1>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - c64!(-15.070310793269726, -1.987917054716041)).norm() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - c64!(-15.070310793269726, -1.987917054716041)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_symmetric() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<c64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<c64>('b')[..1024 * 512].to_vec();
+        let mut b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default (hermi)
+        let x = rt::linalg::solve_symmetric((a.view(), b.view()));
+        assert!((fingerprint(&x) - c64!(-1053.7242100144504, -559.2846004618166)).norm() < 1e-8);
+
+        // upper (hermi)
+        let x = rt::linalg::solve_symmetric((a.view(), b.view(), Upper));
+        assert!((fingerprint(&x) - c64!(674.2725854112028, -68.55236080351166)).norm() < 1e-8);
+
+        // default (symm)
+        let x = rt::linalg::solve_symmetric((a.view(), b.view(), false));
+        assert!((fingerprint(&x) - c64!(401.05642312535775, -805.8028453625365)).norm() < 1e-8);
+
+        // upper, mutable changes b (symm)
+        rt::linalg::solve_symmetric((a.view(), b.view_mut(), false, Upper));
+        assert!((fingerprint(&b) - c64!(141.70122084637046, -829.609691493499)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_triangular() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let mut a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((get_vec::<c64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_triangular((b.view(), a.view()));
+        assert!((fingerprint(&x) - c64!(-8.433708003916948, 20.578272827017052)).norm() < 1e-8);
+
+        // upper, mutable changes a
+        rt::linalg::solve_triangular((b.view(), a.view_mut(), Upper));
+        assert!((fingerprint(&a) - c64!(0.1778922244846507, 11.42463765128442)).norm() < 1e-8);
+    }
+
+    #[test]
+    fn test_svd() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let (u, s, vt) = rt::linalg::svd(a.view()).into();
+        assert!((fingerprint(&s) - 46.60343405921802).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -15.44133470545584).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 2.1605324161714172).abs() < 1e-8);
+
+        // full_matrices = false
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 46.60343405921802).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -1.9516528722381659).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 2.1605324161714172).abs() < 1e-8);
+
+        // m < n, full_matrices = false
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 47.599274835886646).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - 4.636614351700778).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 1.4497879458575658).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_svdvals() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 46.60343405921802).abs() < 1e-8);
+
+        // m < n, full_matrices = false
+        let a_vec = get_vec::<c64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 47.599274835886646).abs() < 1e-8);
+    }
+}
+
+#[cfg(test)]
+mod test_generalized_eigh {
+    use super::*;
+
+    #[test]
+    fn test_generalized_eigh() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<c64>('a')[..1024 * 1024].to_vec();
+        let b_vec = get_vec::<c64>('b')[..1024 * 1024].to_vec();
+        let a = rt::asarray((a_vec, [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((b_vec, [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // 1, lower
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Lower, 1)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -97.43376763322635).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -4.3181177983574255).abs() < 1e-8);
+
+        // 1, upper
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Upper, 1)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -54.81859256480441).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -1.4841788446757156).abs() < 1e-8);
+
+        // 2, lower
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Lower, 2)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -4967.627482507203).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 5.541034627252399).abs() < 1e-8);
+
+        // 2, upper
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Upper, 2)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 1.0609263552377188).abs() < 1e-8);
+
+        // 3, lower
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Lower, 3)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -4967.627482507203).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 118.76501084045631).abs() < 1e-8);
+
+        // 3, upper
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Upper, 3)).into();
+        println!("w: {:?}, v: {:?}", fingerprint(&w), fingerprint(&v.abs()));
+        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -0.15861903557045487).abs() < 1e-8);
+    }
+}

--- a/rstsr-kml/tests/test_linalg_func/func_c64.rs
+++ b/rstsr-kml/tests/test_linalg_func/func_c64.rs
@@ -1,6 +1,6 @@
 use rstsr::prelude::*;
-use rstsr_kml::DeviceKML as DeviceBLAS;
 use rstsr_core::prelude_dev::fingerprint;
+use rstsr_kml::DeviceKML as DeviceBLAS;
 use rstsr_test_manifest::get_vec;
 
 #[allow(non_camel_case_types)]

--- a/rstsr-kml/tests/test_linalg_func/func_c64.rs
+++ b/rstsr-kml/tests/test_linalg_func/func_c64.rs
@@ -87,19 +87,22 @@ mod test {
 
         // default, a
         let w = rt::linalg::eigvalsh(a.view());
+        // println!("fingerprint(w) = {}", fingerprint(&w)); // -101.47224104162413
         assert!((fingerprint(&w) - -100.79793355894122).abs() < 1e-8);
 
         // upper, a
         let w = rt::linalg::eigvalsh((a.view(), Upper));
+        // println!("fingerprint(w) = {}", fingerprint(&w)); // -99.33417238136008
         assert!((fingerprint(&w) - -103.99103522434956).abs() < 1e-8);
 
         // default, a b
         let w = rt::linalg::eigvalsh((a.view(), b.view()));
-        assert!((fingerprint(&w) - -97.43376763322635).abs() < 1e-8);
+        println!("fingerprint(w) = {}", fingerprint(&w));
+        assert!((fingerprint(&w) - -97.43376763322635).abs() < 1e-8); // correct
 
         // upper, a b, itype=3
         let w = rt::linalg::eigvalsh((a.view(), b.view(), Upper, 3));
-        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8);
+        assert!((fingerprint(&w) - -4656.824753078057).abs() < 1e-8); // correct
 
         // mutable changes a
         let w = rt::linalg::eigvalsh(a.view_mut());

--- a/rstsr-kml/tests/test_linalg_func/func_f64.rs
+++ b/rstsr-kml/tests/test_linalg_func/func_f64.rs
@@ -1,0 +1,260 @@
+use rstsr::prelude::*;
+use rstsr_kml::DeviceKML as DeviceBLAS;
+use rstsr_core::prelude_dev::fingerprint;
+use rstsr_test_manifest::get_vec;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cholesky() {
+        let device = DeviceBLAS::default();
+        let mut b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device));
+
+        // default
+        let c = rt::linalg::cholesky(b.view());
+        assert!((fingerprint(&c) - 43.21904478556176).abs() < 1e-8);
+
+        // upper
+        let c = rt::linalg::cholesky((b.view(), Upper));
+        assert!((fingerprint(&c) - -25.925655124816647).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::cholesky((b.view_mut(), Upper));
+        assert!((fingerprint(&b) - -25.925655124816647).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_cholesky_submatrix() {
+        let device = DeviceBLAS::default();
+        let vec_b: Vec<f64> = vec![0.0, 1.0, 2.0, 1.0, 5.0, 1.5, 2.0, 1.5, 8.0];
+        let b = rt::asarray((vec_b, [3, 3].c(), &device));
+
+        let b_view = b.i((1..3, 1..3));
+        let c = rt::linalg::cholesky(b_view);
+        assert!((fingerprint(&c) - -0.7633202592326889).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_det() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<f64>('a')[..5 * 5].to_vec();
+        let mut a = rt::asarray((a_vec, [5, 5].c(), &device));
+
+        let det = rt::linalg::det(a.view_mut());
+        assert!((det - 3.9699917597338046).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_eigh() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device));
+
+        // default, a
+        let (w, v) = rt::linalg::eigh(a.view()).into();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -9.903934930318247).abs() < 1e-8);
+
+        // upper, a
+        let (w, v) = rt::linalg::eigh((a.view(), Upper)).into();
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 6.973792268793419).abs() < 1e-8);
+
+        // default, a b
+        let (w, v) = rt::linalg::eigh((a.view(), b.view())).into();
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - -5.243112559130817).abs() < 1e-8);
+
+        // upper, a b, itype=3
+        let (w, v) = rt::linalg::eigh((a.view(), b.view(), Upper, 3)).into();
+        assert!((fingerprint(&w) - -2503.84161931662).abs() < 1e-8);
+        assert!((fingerprint(&v.abs()) - 152.17700520642055).abs() < 1e-8);
+
+        // mutable changes a
+        let (w, _) = rt::linalg::eigh(a.view_mut()).into();
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+        assert!((fingerprint(&a.abs()) - -9.903934930318247).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_eigvalsh() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device));
+
+        // default, a
+        let w = rt::linalg::eigvalsh(a.view());
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+
+        // upper, a
+        let w = rt::linalg::eigvalsh((a.view(), Upper));
+        assert!((fingerprint(&w) - -71.4902453763506).abs() < 1e-8);
+
+        // default, a b
+        let w = rt::linalg::eigvalsh((a.view(), b.view()));
+        assert!((fingerprint(&w) - -89.60433120129908).abs() < 1e-8);
+
+        // upper, a b, itype=3
+        let w = rt::linalg::eigvalsh((a.view(), b.view(), Upper, 3));
+        assert!((fingerprint(&w) - -2503.84161931662).abs() < 1e-8);
+
+        // mutable changes a
+        let w = rt::linalg::eigvalsh(a.view_mut());
+        assert!((fingerprint(&w) - -71.4747209499407).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_inv() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+
+        // immutable
+        let a_inv = rt::linalg::inv(a.view());
+        assert!((fingerprint(&a_inv) - 143.39005577037764).abs() < 1e-8);
+
+        // mutable
+        rt::linalg::inv(a.view_mut());
+        assert!((fingerprint(&a) - 143.39005577037764).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_pinv() {
+        let device = DeviceBLAS::default();
+
+        // 1024 x 512
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - 0.0878262837784408).abs() < 1e-8);
+        assert_eq!(rank, 163);
+
+        // 512 x 1024
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+
+        let (a_pinv, rank) = rt::linalg::pinv((a.view(), 20.0, 0.3)).into();
+        assert!((fingerprint(&a_pinv) - -0.3244041253699862).abs() < 1e-8);
+        assert_eq!(rank, 161);
+    }
+
+    #[test]
+    fn test_slogdet() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device));
+
+        let (sign, logabsdet) = rt::linalg::slogdet(a.view_mut()).into();
+        assert!(sign - -1.0 < 1e-8);
+        assert!(logabsdet - 3031.1259211802403 < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_general() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024 * 512].to_vec();
+        let mut b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - -1951.253447757597).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - -1951.253447757597).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_general_for_vec() {
+        let device = DeviceBLAS::default();
+        let mut a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024].to_vec();
+        let mut b = rt::asarray((b_vec, [1024].c(), &device)).into_dim::<Ix1>();
+
+        // default
+        let x = rt::linalg::solve_general((a.view(), b.view()));
+        assert!((fingerprint(&x) - -9.120066438800688).abs() < 1e-8);
+
+        // mutable changes itself
+        rt::linalg::solve_general((a.view_mut(), b.view_mut()));
+        assert!((fingerprint(&b) - -9.120066438800688).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_symmetric() {
+        let device = DeviceBLAS::default();
+        let a = rt::asarray((get_vec::<f64>('a'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+        let b_vec = get_vec::<f64>('b')[..1024 * 512].to_vec();
+        let mut b = rt::asarray((b_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_symmetric((a.view(), b.view()));
+        assert!((fingerprint(&x) - -397.1203235513806).abs() < 1e-8);
+
+        // upper, mutable changes b
+        rt::linalg::solve_symmetric((a.view(), b.view_mut(), Upper));
+        assert!((fingerprint(&b) - -314.45022891879034).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_solve_triangular() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let mut a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+        let b = rt::asarray((get_vec::<f64>('b'), [1024, 1024].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let x = rt::linalg::solve_triangular((b.view(), a.view()));
+        assert!((fingerprint(&x) - -2.6133848012216587).abs() < 1e-8);
+
+        // upper, mutable changes a
+        rt::linalg::solve_triangular((b.view(), a.view_mut(), Upper));
+        assert!((fingerprint(&a) - 5.112256818100785).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_svd() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let (u, s, vt) = rt::linalg::svd(a.view()).into();
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+
+        // full_matrices = false
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -9.144981428076894).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
+
+        // m < n, full_matrices = false
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let (u, s, vt) = rt::linalg::svd((a.view(), false)).into();
+        assert!((fingerprint(&s) - 32.27742168207757).abs() < 1e-8);
+        assert!((fingerprint(&u.abs()) - -3.716931052161584).abs() < 1e-8);
+        assert!((fingerprint(&vt.abs()) - -0.32301437281530243).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_svdvals() {
+        let device = DeviceBLAS::default();
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [1024, 512].c(), &device)).into_dim::<Ix2>();
+
+        // default
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
+
+        // m < n, full_matrices = false
+        let a_vec = get_vec::<f64>('a')[..1024 * 512].to_vec();
+        let a = rt::asarray((a_vec, [512, 1024].c(), &device)).into_dim::<Ix2>();
+        let s = rt::linalg::svdvals(a.view());
+        assert!((fingerprint(&s) - 32.27742168207757).abs() < 1e-8);
+    }
+}

--- a/rstsr-kml/tests/test_linalg_func/func_f64.rs
+++ b/rstsr-kml/tests/test_linalg_func/func_f64.rs
@@ -1,6 +1,6 @@
 use rstsr::prelude::*;
-use rstsr_kml::DeviceKML as DeviceBLAS;
 use rstsr_core::prelude_dev::fingerprint;
+use rstsr_kml::DeviceKML as DeviceBLAS;
 use rstsr_test_manifest::get_vec;
 
 #[cfg(test)]

--- a/rstsr-kml/tests/test_linalg_func/func_validation_c64.py
+++ b/rstsr-kml/tests/test_linalg_func/func_validation_c64.py
@@ -1,0 +1,235 @@
+# # Driver tests in Python
+
+import numpy as np
+import scipy
+
+
+def fingerprint(a):
+    return np.dot(np.cos(np.arange(a.size)), np.asarray(a, order="C").ravel())
+
+
+# Path of npy files in rstsr-test-manifest
+
+root = "../../../rstsr-test-manifest/resources/"
+
+# ## make sure of random generation
+
+a_raw = np.load(f"{root}/a-c64.npy")
+b_raw = np.load(f"{root}/b-c64.npy")
+
+assert np.isclose(fingerprint(a_raw), 191.28900005102915+217.50386287824938j)
+assert np.isclose(fingerprint(b_raw), 267.6279081341384-641.4397224458443j)
+
+# ## tests
+
+# ### cholesky
+
+b = b_raw.copy().reshape(1024, 1024)
+c = np.linalg.cholesky(b)
+assert np.isclose(fingerprint(c), 62.89494065393874-73.47055443374522j)
+fingerprint(c)
+
+b = b_raw.copy().reshape(1024, 1024)
+c = scipy.linalg.cholesky(b, lower=False)
+assert np.isclose(fingerprint(c), 13.720509103165073-1.8066465348490963j)
+fingerprint(c)
+
+# ### eigh
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = np.linalg.eigh(a)
+assert np.isclose(fingerprint(w), -100.79793355894122)
+assert np.isclose(fingerprint(np.abs(v)), -7.450761195788254)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = np.linalg.eigh(a, UPLO="U")
+assert np.isclose(fingerprint(w), -103.99103522434956)
+assert np.isclose(fingerprint(np.abs(v)), -12.184946930165328)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, lower=True)
+assert np.isclose(fingerprint(w), -97.43376763322635)
+assert np.isclose(fingerprint(np.abs(v)), -4.3181177983574255)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, lower=False, type=3)
+assert np.isclose(fingerprint(w), -4656.824753078057)
+assert np.isclose(fingerprint(np.abs(v)), -0.15861903557045487)
+fingerprint(w), fingerprint(np.abs(v))
+
+# ### Tests of eigh (itype, lower)
+
+# 1, lower
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=1, lower=True)
+assert np.isclose(fingerprint(w), -97.43376763322635)
+assert np.isclose(fingerprint(np.abs(v)), -4.3181177983574255)
+fingerprint(w), fingerprint(np.abs(v))
+
+# 1, upper
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=1, lower=False)
+assert np.isclose(fingerprint(w), -54.81859256480441)
+assert np.isclose(fingerprint(np.abs(v)), -1.4841788446757156)
+fingerprint(w), fingerprint(np.abs(v))
+
+# 2, lower
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=2, lower=True)
+assert np.isclose(fingerprint(w), -4967.627482507203)
+assert np.isclose(fingerprint(np.abs(v)), 5.541034627252399)
+fingerprint(w), fingerprint(np.abs(v))
+
+# 2, upper
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=2, lower=False)
+assert np.isclose(fingerprint(w), -4656.824753078057)
+assert np.isclose(fingerprint(np.abs(v)), 1.0609263552377188)
+fingerprint(w), fingerprint(np.abs(v))
+
+# 3, lower
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=3, lower=True)
+assert np.isclose(fingerprint(w), -4967.627482507203)
+assert np.isclose(fingerprint(np.abs(v)), 118.76501084045631)
+fingerprint(w), fingerprint(np.abs(v))
+
+# 3, upper
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, type=3, lower=False)
+assert np.isclose(fingerprint(w), -4656.824753078057)
+assert np.isclose(fingerprint(np.abs(v)), -0.15861903557045487)
+fingerprint(w), fingerprint(np.abs(v))
+
+# ### inv
+
+a = a_raw.copy().reshape(1024, 1024)
+a_inv = np.linalg.inv(a)
+assert np.isclose(fingerprint(a_inv), -11.836382515156183+8.250167298349842j)
+fingerprint(a_inv)
+
+# ### solve_general
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = np.linalg.solve(a, b)
+assert np.isclose(fingerprint(x), 404.1900761036138-258.5602505551204j)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024].copy().reshape(1024)
+x = np.linalg.solve(a, b)
+assert np.isclose(fingerprint(x), -15.070310793269726-1.987917054716041j)
+fingerprint(x)
+
+# ### sovle_symmetric
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="sym", lower=True)
+assert np.isclose(fingerprint(x), 401.05642312535775-805.8028453625365j)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="sym", lower=False)
+assert np.isclose(fingerprint(x), 141.70122084637046-829.609691493499j)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="her", lower=True)
+assert np.isclose(fingerprint(x), -1053.7242100144504-559.2846004618166j)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="her", lower=False)
+assert np.isclose(fingerprint(x), 674.2725854112028-68.55236080351166j)
+fingerprint(x)
+
+# ### sovle_triangular
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+b = b_raw.copy().reshape(1024, 1024)
+x = scipy.linalg.solve(b, a, assume_a="lower triangular")
+assert np.isclose(fingerprint(x), -8.433708003916948+20.578272827017052j)
+fingerprint(x)
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+b = b_raw.copy().reshape(1024, 1024)
+x = scipy.linalg.solve(b, a, assume_a="upper triangular")
+assert np.isclose(fingerprint(x), 0.1778922244846507+11.42463765128442j)
+fingerprint(x)
+
+# ### slogdot
+
+a = a_raw.copy().reshape(1024, 1024)
+sgn, logabsdet = np.linalg.slogdet(a)
+assert np.isclose(sgn, -0.44606842323663365+0.8949988613351316j)
+assert np.isclose(logabsdet, 3393.6720579594585)
+sgn, logabsdet
+
+# ### det
+
+a = a_raw[:25].copy().reshape(5, 5)
+det = np.linalg.det(a)
+assert np.isclose(det, -24.808965756481086+11.800248863799464j)
+det
+
+# ### svd
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+(u, s, vt) = scipy.linalg.svd(a)
+assert np.isclose(fingerprint(np.abs(u)), -15.44133470545584)
+assert np.isclose(fingerprint(s), 46.60343405921802)
+assert np.isclose(fingerprint(np.abs(vt)), 2.1605324161714172)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+(u, s, vt) = scipy.linalg.svd(a, full_matrices=False)
+assert np.isclose(fingerprint(np.abs(u)), -1.9516528722381659)
+assert np.isclose(fingerprint(s), 46.60343405921802)
+assert np.isclose(fingerprint(np.abs(vt)), 2.1605324161714172)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+s = scipy.linalg.svd(a, compute_uv=False)
+assert np.isclose(fingerprint(s), 46.60343405921802)
+fingerprint(s)
+
+a = a_raw[:1024*512].copy().reshape(512, 1024)
+(u, s, vt) = scipy.linalg.svd(a, full_matrices=False)
+assert np.isclose(fingerprint(np.abs(u)), 4.636614351700778)
+assert np.isclose(fingerprint(s), 47.599274835886646)
+assert np.isclose(fingerprint(np.abs(vt)), 1.4497879458575658)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+# ### pinv
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+a_pinv, rank = scipy.linalg.pinv(a, return_rank=True, atol=20, rtol=0.3)
+assert np.isclose(fingerprint(a_pinv), -0.03454885412959018-0.023651876085623254j)
+assert rank == 240
+fingerprint(a_pinv), rank
+
+a = a_raw[:1024*512].copy().reshape(512, 1024)
+a_pinv, rank = scipy.linalg.pinv(a, return_rank=True, atol=20, rtol=0.3)
+assert np.isclose(fingerprint(a_pinv), -0.2814806469687325-0.15198888300458474j)
+assert rank == 240
+fingerprint(a_pinv), rank
+
+

--- a/rstsr-kml/tests/test_linalg_func/func_validation_f64.py
+++ b/rstsr-kml/tests/test_linalg_func/func_validation_f64.py
@@ -1,0 +1,173 @@
+# # Driver tests in Python
+
+import numpy as np
+import scipy
+
+
+def fingerprint(a):
+    return np.dot(np.cos(np.arange(a.size)), np.asarray(a, order="C").ravel())
+
+
+# Path of npy files in rstsr-test-manifest
+
+root = "../../../rstsr-test-manifest/resources/"
+
+# ## make sure of random generation
+
+a_raw = np.load(f"{root}/a-f64.npy")
+b_raw = np.load(f"{root}/b-f64.npy")
+
+assert np.isclose(fingerprint(a_raw), 191.28900005103065)
+assert np.isclose(fingerprint(b_raw), -51.11100342180723)
+
+# ## tests
+
+# ### cholesky
+
+b = b_raw.copy().reshape(1024, 1024)
+c = np.linalg.cholesky(b)
+assert np.isclose(fingerprint(c), 43.21904478556176)
+fingerprint(c)
+
+b = b_raw.copy().reshape(1024, 1024)
+c = scipy.linalg.cholesky(b, lower=False)
+assert np.isclose(fingerprint(c), -25.925655124816647)
+fingerprint(c)
+
+# ### eigh
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = np.linalg.eigh(a)
+assert np.isclose(fingerprint(w), -71.4747209499407)
+assert np.isclose(fingerprint(np.abs(v)), -9.903934930318247)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = np.linalg.eigh(a, UPLO="U")
+assert np.isclose(fingerprint(w), -71.4902453763506)
+assert np.isclose(fingerprint(np.abs(v)), 6.973792268793419)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, lower=True)
+assert np.isclose(fingerprint(w), -89.60433120129908)
+assert np.isclose(fingerprint(np.abs(v)), -5.243112559130817)
+fingerprint(w), fingerprint(np.abs(v))
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw.copy().reshape(1024, 1024)
+w, v = scipy.linalg.eigh(a, b, lower=False, type=3)
+assert np.isclose(fingerprint(w), -2503.84161931662)
+assert np.isclose(fingerprint(np.abs(v)), 152.17700520642055)
+fingerprint(w), fingerprint(np.abs(v))
+
+# ### inv
+
+a = a_raw.copy().reshape(1024, 1024)
+a_inv = np.linalg.inv(a)
+assert np.isclose(fingerprint(a_inv), 143.39005577037764)
+fingerprint(a_inv)
+
+# ### solve_general
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = np.linalg.solve(a, b)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024].copy().reshape(1024)
+x = np.linalg.solve(a, b)
+fingerprint(x)
+
+# ### sovle_symmetric
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="sym", lower=True)
+assert np.isclose(fingerprint(x), -397.1203235513806)
+fingerprint(x)
+
+a = a_raw.copy().reshape(1024, 1024)
+b = b_raw[:1024*512].copy().reshape(1024, 512)
+x = scipy.linalg.solve(a, b, assume_a="sym", lower=False)
+assert np.isclose(fingerprint(x), -314.45022891879034)
+fingerprint(x)
+
+# ### sovle_triangular
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+b = b_raw.copy().reshape(1024, 1024)
+x = scipy.linalg.solve(b, a, assume_a="lower triangular")
+assert np.isclose(fingerprint(x), -2.6133848012216587)
+fingerprint(x)
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+b = b_raw.copy().reshape(1024, 1024)
+x = scipy.linalg.solve(b, a, assume_a="upper triangular")
+assert np.isclose(fingerprint(x), 5.112256818100785)
+fingerprint(x)
+
+# ### slogdot
+
+a = a_raw.copy().reshape(1024, 1024)
+sgn, logabsdet = np.linalg.slogdet(a)
+assert np.isclose(sgn, -1)
+assert np.isclose(logabsdet, 3031.1259211802403)
+sgn, logabsdet
+
+# ### det
+
+a = a_raw[:25].copy().reshape(5, 5)
+det = np.linalg.det(a)
+assert np.isclose(det, 3.9699917597338046)
+det
+
+np.linalg.slogdet(a)
+
+# ### svd
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+(u, s, vt) = scipy.linalg.svd(a)
+assert np.isclose(fingerprint(np.abs(u)), -1.9368850983570982)
+assert np.isclose(fingerprint(s), 33.969339071043095)
+assert np.isclose(fingerprint(np.abs(vt)), 13.465522484136157)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+(u, s, vt) = scipy.linalg.svd(a, full_matrices=False)
+assert np.isclose(fingerprint(np.abs(u)), -9.144981428076894)
+assert np.isclose(fingerprint(s), 33.969339071043095)
+assert np.isclose(fingerprint(np.abs(vt)), 13.465522484136157)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+s = scipy.linalg.svd(a, compute_uv=False)
+assert np.isclose(fingerprint(s), 33.969339071043095)
+fingerprint(s)
+
+a = a_raw[:1024*512].copy().reshape(512, 1024)
+(u, s, vt) = scipy.linalg.svd(a, full_matrices=False)
+assert np.isclose(fingerprint(np.abs(u)), -3.716931052161584)
+assert np.isclose(fingerprint(s), 32.27742168207757)
+assert np.isclose(fingerprint(np.abs(vt)), -0.32301437281530243)
+fingerprint(np.abs(u)), fingerprint(s), fingerprint(np.abs(vt))
+
+# ### pinv
+
+a = a_raw[:1024*512].copy().reshape(1024, 512)
+a_pinv, rank = scipy.linalg.pinv(a, return_rank=True, atol=20, rtol=0.3)
+assert np.isclose(fingerprint(a_pinv), 0.0878262837784408)
+assert rank == 163
+fingerprint(a_pinv), rank
+
+a = a_raw[:1024*512].copy().reshape(512, 1024)
+a_pinv, rank = scipy.linalg.pinv(a, return_rank=True, atol=20, rtol=0.3)
+assert np.isclose(fingerprint(a_pinv), -0.3244041253699862)
+assert rank == 161
+fingerprint(a_pinv), rank
+
+

--- a/rstsr-kml/tests/test_linalg_func/mod.rs
+++ b/rstsr-kml/tests/test_linalg_func/mod.rs
@@ -1,0 +1,2 @@
+mod func_c64;
+mod func_f64;

--- a/rstsr/Cargo.toml
+++ b/rstsr/Cargo.toml
@@ -17,6 +17,7 @@ rstsr-openblas = { workspace = true, optional = true }
 rstsr-mkl = { workspace = true, optional = true }
 rstsr-blis = { workspace = true, optional = true }
 rstsr-aocl = { workspace = true, optional = true }
+rstsr-kml = { workspace = true, optional = true }
 
 [features]
 default = ["rstsr-core/default", "faer", "dynamic_loading"]
@@ -24,7 +25,7 @@ default = ["rstsr-core/default", "faer", "dynamic_loading"]
 # rstsr-core features
 std = ["rstsr-core/std"]
 rayon = ["rstsr-core/rayon"]
-faer = ["rstsr-core/faer", "rstsr-linalg-traits?/faer", "rstsr-sci-traits?/faer", "rstsr-openblas?/faer", "rstsr-mkl?/faer", "rstsr-blis?/faer", "rstsr-aocl?/faer"]
+faer = ["rstsr-core/faer", "rstsr-linalg-traits?/faer", "rstsr-sci-traits?/faer", "rstsr-openblas?/faer", "rstsr-mkl?/faer", "rstsr-blis?/faer", "rstsr-aocl?/faer", "rstsr-kml?/faer"]
 faer_as_default = ["rstsr-core/faer_as_default", "faer"]
 row_major = ["rstsr-core/row_major"]
 col_major = ["rstsr-core/col_major"]
@@ -36,11 +37,12 @@ openblas = ["dep:rstsr-openblas"]
 mkl = ["dep:rstsr-mkl"]
 blis = ["dep:rstsr-blis"]
 aocl = ["dep:rstsr-aocl"]
+kml = ["dep:rstsr-kml"]
 
 # dependencies specification
-linalg = ["dep:rstsr-linalg-traits", "rstsr-openblas?/linalg", "rstsr-mkl?/linalg", "rstsr-blis?/linalg", "rstsr-aocl?/linalg"]
-sci = ["dep:rstsr-sci-traits", "rstsr-openblas?/sci", "rstsr-mkl?/sci", "rstsr-blis?/sci", "rstsr-aocl?/sci"]
+linalg = ["dep:rstsr-linalg-traits", "rstsr-openblas?/linalg", "rstsr-mkl?/linalg", "rstsr-blis?/linalg", "rstsr-aocl?/linalg", "rstsr-kml?/linalg"]
+sci = ["dep:rstsr-sci-traits", "rstsr-openblas?/sci", "rstsr-mkl?/sci", "rstsr-blis?/sci", "rstsr-aocl?/sci", "rstsr-kml?/sci"]
 
 # BLAS configurations
-dynamic_loading = ["rstsr-openblas?/dynamic_loading", "rstsr-mkl?/dynamic_loading", "rstsr-blis?/dynamic_loading", "rstsr-aocl?/dynamic_loading"]
-ilp64 = ["rstsr-openblas?/ilp64", "rstsr-mkl?/ilp64", "rstsr-blis?/ilp64", "rstsr-aocl?/ilp64"]
+dynamic_loading = ["rstsr-openblas?/dynamic_loading", "rstsr-mkl?/dynamic_loading", "rstsr-blis?/dynamic_loading", "rstsr-aocl?/dynamic_loading", "rstsr-kml?/dynamic_loading"]
+ilp64 = ["rstsr-openblas?/ilp64", "rstsr-mkl?/ilp64", "rstsr-blis?/ilp64", "rstsr-aocl?/ilp64", "rstsr-kml?/ilp64"]

--- a/rstsr/src/prelude.rs
+++ b/rstsr/src/prelude.rs
@@ -32,14 +32,46 @@ pub mod rstsr_structs {
     #[cfg(feature = "openblas")]
     pub use rstsr_openblas::DeviceOpenBLAS;
 
-    #[cfg(all(feature = "openblas", not(feature = "mkl"), not(feature = "blis"), not(feature = "aocl")))]
+    #[cfg(all(
+        feature = "openblas",
+        not(feature = "mkl"),
+        not(feature = "blis"),
+        not(feature = "aocl"),
+        not(feature = "kml")
+    ))]
     pub type DeviceBLAS = DeviceOpenBLAS;
-    #[cfg(all(not(feature = "openblas"), feature = "mkl", not(feature = "blis"), not(feature = "aocl")))]
+    #[cfg(all(
+        not(feature = "openblas"),
+        feature = "mkl",
+        not(feature = "blis"),
+        not(feature = "aocl"),
+        not(feature = "kml")
+    ))]
     pub type DeviceBLAS = DeviceMKL;
-    #[cfg(all(not(feature = "openblas"), not(feature = "mkl"), feature = "blis", not(feature = "aocl")))]
+    #[cfg(all(
+        not(feature = "openblas"),
+        not(feature = "mkl"),
+        feature = "blis",
+        not(feature = "aocl"),
+        not(feature = "kml")
+    ))]
     pub type DeviceBLAS = DeviceBLIS;
-    #[cfg(all(not(feature = "openblas"), not(feature = "mkl"), not(feature = "blis"), feature = "aocl"))]
+    #[cfg(all(
+        not(feature = "openblas"),
+        not(feature = "mkl"),
+        not(feature = "blis"),
+        feature = "aocl",
+        not(feature = "kml")
+    ))]
     pub type DeviceBLAS = DeviceAOCL;
+    #[cfg(all(
+        not(feature = "openblas"),
+        not(feature = "mkl"),
+        not(feature = "blis"),
+        not(feature = "aocl"),
+        feature = "kml"
+    ))]
+    pub type DeviceBLAS = rstsr_kml::DeviceKML;
 }
 
 pub mod rstsr_funcs {


### PR DESCRIPTION
KML (Huawei Kunpeng Math Library)

This PR should make most functions work for KML; however, there may have some problems for several functions (or functionalities):
- Threading: To avoid thread blocking, currently we only allow BLAS to be multi-threaded (`BlasSetNumThreadsLocal`), but not allow LAPACK to be multi-threaded (`KmlSetNumThreads`). This is not fully efficient for LAPACK functions.
- `rt::linalg::eigvalsh`: Do not use that for `Complex<f64>` type. Note that result of `rt::linalg::eigvalsh` for `f64`, or `rt::linalg::eigh` for both `f64` and `Complex<f64>` seems correct.
- `DGESVD`: The decomposed U matrix seems not correct when `full_matrices = true` (`JOBU = 'A'`). Note that, RSTSR usually uses `DGESDD` for SVD problems, and result of `DGESDD` is correct. So use `rt::linalg::svd` usually gives correct result. Also, result seems correct when `JOBU = 'S'`.

These problems will be separated into other issues, and we will try to contact KML developers.

This PR also changes the default behavior of `GESDDDriverAPI` implementation. The `IWORK` array will be allocated, before LAPACK query performs. KML does not allow `IWORK` to be nullptr, even when it's a query call.