### PR TITLE
Update to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.4.1 -- 2025-08-05
+
+Enhancements:
+
+- Added CPU devices (backends) MKL ([#48](https://github.com/RESTGroup/rstsr/pull/48)), BLIS ([#49](https://github.com/RESTGroup/rstsr/pull/49)), AOCL ([#51](https://github.com/RESTGroup/rstsr/pull/51)), KML ([#53](https://github.com/RESTGroup/rstsr/pull/53))
+
+Possible API breaking change:
+
+- For conversion between CBLAS flags and RSTSR flags (defined in crate rstsr-common), previously CBLAS flags are in crate rstsr-lapack-ffi. Now those flags are defined in rstsr-cblas-base, and been applied in all FFI crates (at [RESTGroup/rstsr-ffi](https://github.com/RESTGroup/rstsr-ffi)).
+
+Actions:
+
+- Added ARM support ([#52](https://github.com/RESTGroup/rstsr/pull/52))
+
 ## v0.4.0 -- 2025-07-25
 
 API breaking change: Supporting dynamic loading for OpenBLAS ([#47](https://github.com/RESTGroup/rstsr/pull/47))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "An n-Dimension Rust Tensor Toolkit"
 repository = "https://github.com/RESTGroup/rstsr"
@@ -25,20 +25,20 @@ categories = ["science"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.4.0" }
+rstsr-core = { path = "./rstsr-core", default-features = false, version = "0.4.1" }
 # members without core
-rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.4.0" }
-rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.4.0" }
-rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.4.0" }
+rstsr-common = { path = "./rstsr-common", default-features = false, version = "0.4.1" }
+rstsr-dtype-traits = { path = "./rstsr-dtype-traits", default-features = false, version = "0.4.1" }
+rstsr-native-impl = { path = "./rstsr-native-impl", default-features = false, version = "0.4.1" }
 # members
-rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.4.0" }
-rstsr-mkl = { path = "./rstsr-mkl", default-features = false, version = "0.4.0" }
-rstsr-blis = { path = "./rstsr-blis", default-features = false, version = "0.4.0" }
-rstsr-aocl = { path = "./rstsr-aocl", default-features = false, version = "0.4.0" }
-rstsr-kml = { path = "./rstsr-kml", default-features = false, version = "0.4.0" }
-rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.4.0" }
-rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.4.0" }
-rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, version = "0.4.0" }
+rstsr-openblas = { path = "./rstsr-openblas", default-features = false, version = "0.4.1" }
+rstsr-mkl = { path = "./rstsr-mkl", default-features = false, version = "0.4.1" }
+rstsr-blis = { path = "./rstsr-blis", default-features = false, version = "0.4.1" }
+rstsr-aocl = { path = "./rstsr-aocl", default-features = false, version = "0.4.1" }
+rstsr-kml = { path = "./rstsr-kml", default-features = false, version = "0.4.1" }
+rstsr-blas-traits = { path = "./rstsr-blas-traits", default-features = false, version = "0.4.1" }
+rstsr-linalg-traits = { path = "./rstsr-linalg-traits", default-features = false, version = "0.4.1" }
+rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, version = "0.4.1" }
 # develop dependencies that should not publish
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies

--- a/rstsr-aocl/readme.md
+++ b/rstsr-aocl/readme.md
@@ -1,3 +1,5 @@
 # RSTSR AOCL device
 
-This crate enables AOCL device.
+This crate enables AMD AOCL device.
+
+For more information of AMD AOCL and its usage, we refer to [document of rstsr-aocl-ffi](https://docs.rs/rstsr-aocl-ffi/).

--- a/rstsr-blis/readme.md
+++ b/rstsr-blis/readme.md
@@ -1,3 +1,5 @@
 # RSTSR BLIS/FLAME device
 
 This crate enables BLIS/FLAME device.
+
+For more information of BLIS and its usage, we refer to [document of rstsr-blis-ffi](https://docs.rs/rstsr-blis-ffi/).

--- a/rstsr-kml/readme.md
+++ b/rstsr-kml/readme.md
@@ -1,3 +1,5 @@
 # RSTSR KML device
 
 This crate enables KML device.
+
+For more information of KML and its usage, we refer to [document of rstsr-kml-ffi](https://docs.rs/rstsr-kml-ffi).

--- a/rstsr-kml/src/lib.rs
+++ b/rstsr-kml/src/lib.rs
@@ -14,6 +14,8 @@ pub mod threading;
 pub mod driver_impl;
 #[cfg(feature = "linalg")]
 pub mod linalg_auto_impl;
+#[cfg(feature = "linalg")]
+pub mod linalg_spec_impl;
 
 #[cfg(feature = "sci")]
 pub mod sci_auto_impl;

--- a/rstsr-kml/src/linalg_auto_impl/eigvalsh.rs
+++ b/rstsr-kml/src/linalg_auto_impl/eigvalsh.rs
@@ -1,1 +1,0 @@
-../../../rstsr-linalg-traits/src/blas_impl/eigvalsh.rs

--- a/rstsr-kml/src/linalg_auto_impl/mod.rs
+++ b/rstsr-kml/src/linalg_auto_impl/mod.rs
@@ -1,7 +1,6 @@
 pub mod cholesky;
 pub mod det;
 pub mod eigh;
-pub mod eigvalsh;
 pub mod inv;
 pub mod pinv;
 pub mod slogdet;

--- a/rstsr-kml/src/linalg_spec_impl/eigvalsh.rs
+++ b/rstsr-kml/src/linalg_spec_impl/eigvalsh.rs
@@ -1,0 +1,213 @@
+use crate::DeviceBLAS;
+use rstsr_blas_traits::prelude::*;
+use rstsr_core::prelude_dev::*;
+use rstsr_linalg_traits::prelude_dev::*;
+
+/* #region simple eigh */
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceBLAS, D>];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for (Tr, FlagUpLo)
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let (a, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let eigh_args = EighArgs::default().a(a_view).uplo(uplo).build()?;
+        let (vals, _) = ref_impl_eigh_simple_f(eigh_args)?;
+        let vals = vals.into_dim::<IxD>().into_dim::<D::SmallerOne>();
+        return Ok(vals);
+    }
+}
+
+#[duplicate_item(
+    ImplType                          Tr                               ;
+   [T, D, R: DataAPI<Data = Vec<T>>] [&TensorAny<R, T, DeviceBLAS, D> ];
+   [T, D                           ] [TensorView<'_, T, DeviceBLAS, D>];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for Tr
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let a = self;
+        let uplo = match a.device().default_order() {
+            RowMajor => Lower,
+            ColMajor => Upper,
+        };
+        EigvalshAPI::<DeviceBLAS>::eigvalsh_f((a, uplo))
+    }
+}
+
+#[duplicate_item(
+    ImplType   Tr                              ;
+   ['a, T, D] [TensorMut<'a, T, DeviceBLAS, D>];
+   [    T, D] [Tensor<T, DeviceBLAS, D>       ];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for (Tr, FlagUpLo)
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let (mut a, uplo) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        let a_view = a.view_mut().into_dim::<Ix2>();
+        let eigh_args = EighArgs::default().a(a_view).uplo(uplo).build()?;
+        let (vals, _) = ref_impl_eigh_simple_f(eigh_args)?;
+        let vals = vals.into_dim::<IxD>().into_dim::<D::SmallerOne>();
+        return Ok(vals);
+    }
+}
+
+#[duplicate_item(
+    ImplType   Tr                              ;
+   ['a, T, D] [TensorMut<'a, T, DeviceBLAS, D>];
+   [    T, D] [Tensor<T, DeviceBLAS, D>       ];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for Tr
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let a = self;
+        let uplo = match a.device().default_order() {
+            RowMajor => Lower,
+            ColMajor => Upper,
+        };
+        EigvalshAPI::<DeviceBLAS>::eigvalsh_f((a, uplo))
+    }
+}
+
+/* #endregion */
+
+/* #region general eigh */
+
+#[duplicate_item(
+    ImplType                                                       TrA                                TrB                              ;
+   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
+   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for (TrA, TrB, FlagUpLo, i32)
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let (a, b, uplo, eig_type) = self;
+        rstsr_assert_eq!(a.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_assert_eq!(b.ndim(), 2, InvalidLayout, "Currently we can only handle 2-D matrix.")?;
+        rstsr_pattern!(eig_type, 1..=3, InvalidLayout, "Only eig_type = 1, 2, or 3 allowed.")?;
+        let a_view = a.view().into_dim::<Ix2>();
+        let b_view = b.view().into_dim::<Ix2>();
+        let eigh_args = EighArgs::default().a(a_view).b(b_view).uplo(uplo).eig_type(eig_type).build()?;
+        let (vals, _) = ref_impl_eigh_simple_f(eigh_args)?;
+        let vals = vals.into_dim::<IxD>().into_dim::<D::SmallerOne>();
+        return Ok(vals);
+    }
+}
+
+#[duplicate_item(
+    ImplType                                                       TrA                                TrB                              ;
+   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
+   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for (TrA, TrB, FlagUpLo)
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let (a, b, uplo) = self;
+        EigvalshAPI::<DeviceBLAS>::eigvalsh_f((a, b, uplo, 1))
+    }
+}
+
+#[duplicate_item(
+    ImplType                                                       TrA                                TrB                              ;
+   [T, D, Ra: DataAPI<Data = Vec<T>>, Rb: DataAPI<Data = Vec<T>>] [&TensorAny<Ra, T, DeviceBLAS, D>] [&TensorAny<Rb, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [&TensorAny<R, T, DeviceBLAS, D> ] [TensorView<'_, T, DeviceBLAS, D>];
+   [T, D, R: DataAPI<Data = Vec<T>>                             ] [TensorView<'_, T, DeviceBLAS, D>] [&TensorAny<R, T, DeviceBLAS, D> ];
+   [T, D,                                                       ] [TensorView<'_, T, DeviceBLAS, D>] [TensorView<'_, T, DeviceBLAS, D>];
+)]
+impl<ImplType> EigvalshAPI<DeviceBLAS> for (TrA, TrB)
+where
+    T: BlasFloat,
+    D: DimAPI + DimSmallerOneAPI,
+    D::SmallerOne: DimAPI,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, D::SmallerOne>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let (a, b) = self;
+        let uplo = match a.device().default_order() {
+            RowMajor => Lower,
+            ColMajor => Upper,
+        };
+        EigvalshAPI::<DeviceBLAS>::eigvalsh_f((a, b, uplo, 1))
+    }
+}
+
+/* #endregion */
+
+/* #region EighArgs implementation */
+
+impl<'a, 'b, T> EigvalshAPI<DeviceBLAS> for EighArgs<'a, 'b, DeviceBLAS, T>
+where
+    T: BlasFloat,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, Ix1>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let args = self.build()?;
+        rstsr_assert!(args.eigvals_only, InvalidValue, "Eigvalsh only supports eigvals_only = true.")?;
+        let (vals, _) = ref_impl_eigh_simple_f(args)?;
+        Ok(vals)
+    }
+}
+
+impl<'a, 'b, T> EigvalshAPI<DeviceBLAS> for EighArgs_<'a, 'b, DeviceBLAS, T>
+where
+    T: BlasFloat,
+    DeviceBLAS: LapackDriverAPI<T>,
+{
+    type Out = Tensor<T::Real, DeviceBLAS, Ix1>;
+    fn eigvalsh_f(self) -> Result<Self::Out> {
+        let args = self;
+        rstsr_assert!(args.eigvals_only, InvalidValue, "Eigvalsh only supports eigvals_only = true.")?;
+        let (vals, _) = ref_impl_eigh_simple_f(args)?;
+        Ok(vals)
+    }
+}
+
+/* #endregion */

--- a/rstsr-kml/src/linalg_spec_impl/mod.rs
+++ b/rstsr-kml/src/linalg_spec_impl/mod.rs
@@ -1,0 +1,1 @@
+pub mod eigvalsh;

--- a/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
@@ -16,7 +16,7 @@ mod test {
 
         // default
         let driver = DGESVD::default().a(a.view()).build().unwrap();
-        if let (s, Some(u), Some(vt), _) = driver.run().unwrap() {
+        if let (s, _, Some(vt), _) = driver.run().unwrap() {
             assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
             // the following check will be skipped, since in U is not unique in zero singular value
             // see also https://github.com/ajz34/issue-kml/tree/master/issue-dgesvd-full

--- a/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
+++ b/rstsr-kml/tests/test_driver_impl/lapack_svd_f64.rs
@@ -18,8 +18,10 @@ mod test {
         let driver = DGESVD::default().a(a.view()).build().unwrap();
         if let (s, Some(u), Some(vt), _) = driver.run().unwrap() {
             assert!((fingerprint(&s) - 33.969339071043095).abs() < 1e-8);
-            println!("fingerprint(u) = {}", fingerprint(&(&u).abs())); // 8.932956543614006
-            assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
+            // the following check will be skipped, since in U is not unique in zero singular value
+            // see also https://github.com/ajz34/issue-kml/tree/master/issue-dgesvd-full
+            // println!("fingerprint(u) = {}", fingerprint(&(&u).abs())); // 8.932956543614006
+            // assert!((fingerprint(&u.abs()) - -1.9368850983570982).abs() < 1e-8);
             assert!((fingerprint(&vt.abs()) - 13.465522484136157).abs() < 1e-8);
         } else {
             panic!("DGESVD did not return expected output");

--- a/rstsr-mkl/readme.md
+++ b/rstsr-mkl/readme.md
@@ -1,3 +1,5 @@
 # RSTSR oneAPI MKL device
 
 This crate enables oneAPI MKL device.
+
+For more information of oneAPI MKL and its usage, we refer to [document of rstsr-mkl-ffi](https://docs.rs/rstsr-mkl-ffi/).

--- a/rstsr-openblas/readme.md
+++ b/rstsr-openblas/readme.md
@@ -2,6 +2,8 @@
 
 This crate enables OpenBLAS device.
 
+For more information of OpenBLAS and its usage, we refer to [document of rstsr-openblas-ffi](https://docs.rs/rstsr-openblas-ffi/).
+
 ## Usage
 
 ```rust


### PR DESCRIPTION
## v0.4.1 -- 2025-08-05

Enhancements:

- Added CPU devices (backends) MKL ([#48](https://github.com/RESTGroup/rstsr/pull/48)), BLIS ([#49](https://github.com/RESTGroup/rstsr/pull/49)), AOCL ([#51](https://github.com/RESTGroup/rstsr/pull/51)), KML ([#53](https://github.com/RESTGroup/rstsr/pull/53))

Possible API breaking change:

- For conversion between CBLAS flags and RSTSR flags (defined in crate rstsr-common), previously CBLAS flags are in crate rstsr-lapack-ffi. Now those flags are defined in rstsr-cblas-base, and been applied in all FFI crates (at [RESTGroup/rstsr-ffi](https://github.com/RESTGroup/rstsr-ffi)).

Actions:

- Added ARM support ([#52](https://github.com/RESTGroup/rstsr/pull/52))