### PR TITLE
Change Behavior of `DeviceCpuRayon::generate_pool`

### DIFF
--- a/rstsr-core/src/feature_rayon/device.rs
+++ b/rstsr-core/src/feature_rayon/device.rs
@@ -61,7 +61,9 @@ impl DeviceCpuRayon {
     ///   that relates to `RAYON_NUM_THREADS`, but the number of threads of global thread pool
     ///   instead. That is to say, the priority of number of threads is
     ///   - The value you initialized the rayon's global thread pool before calling this function:
-    ///     ```rust,ignore rayon::ThreadPoolBuilder::new().num_threads(xxx).build_global().unwrap()
+    ///
+    ///     ```rust,ignore
+    ///     rayon::ThreadPoolBuilder::new().num_threads(xxx).build_global().unwrap()
     ///     ```
     ///   - The value you have declared in environmental variable `RAYON_NUM_THREADS`.
     fn generate_pool(n: usize) -> Result<ThreadPool> {

--- a/rstsr-core/src/feature_rayon/device.rs
+++ b/rstsr-core/src/feature_rayon/device.rs
@@ -66,6 +66,7 @@ impl DeviceCpuRayon {
     ///     rayon::ThreadPoolBuilder::new().num_threads(xxx).build_global().unwrap()
     ///     ```
     ///   - The value you have declared in environmental variable `RAYON_NUM_THREADS`.
+    ///   - The number of logical CPUs on the machine.
     fn generate_pool(n: usize) -> Result<ThreadPool> {
         let actual_threads = if n == 0 { rayon::current_num_threads() } else { n };
         rayon::ThreadPoolBuilder::new().num_threads(actual_threads).build().map_err(Error::from)

--- a/rstsr-core/src/feature_rayon/device.rs
+++ b/rstsr-core/src/feature_rayon/device.rs
@@ -60,6 +60,8 @@ impl DeviceCpuRayon {
     /// - For input number of threads 0, this function technically **DOES NOT** give thread pool
     ///   that relates to `RAYON_NUM_THREADS`, but the number of threads of global thread pool
     ///   instead. That is to say, the priority of number of threads is
+    ///   - The value of current number of threads, if this function is called inside a user custom
+    ///     thread pool.
     ///   - The value you initialized the rayon's global thread pool before calling this function:
     ///
     ///     ```rust,ignore

--- a/rstsr-core/src/feature_rayon/device.rs
+++ b/rstsr-core/src/feature_rayon/device.rs
@@ -50,8 +50,23 @@ impl DeviceCpuRayon {
         DeviceCpuRayon { num_threads, pool, default_order: FlagOrder::default() }
     }
 
+    /// Generate a new thread pool with the given number of threads.
+    ///
+    /// If the number of threads is 0, the current number of threads will be used.
+    ///
+    /// Notes for developers:
+    /// - This function will still gives number of threads > 1 when inside parallelled rayon thread
+    ///   pool.
+    /// - For input number of threads 0, this function technically **DOES NOT** give thread pool
+    ///   that relates to `RAYON_NUM_THREADS`, but the number of threads of global thread pool
+    ///   instead. That is to say, the priority of number of threads is
+    ///   - The value you initialized the rayon's global thread pool before calling this function:
+    ///     ```rust,ignore rayon::ThreadPoolBuilder::new().num_threads(xxx).build_global().unwrap()
+    ///     ```
+    ///   - The value you have declared in environmental variable `RAYON_NUM_THREADS`.
     fn generate_pool(n: usize) -> Result<ThreadPool> {
-        rayon::ThreadPoolBuilder::new().num_threads(n).build().map_err(Error::from)
+        let actual_threads = if n == 0 { rayon::current_num_threads() } else { n };
+        rayon::ThreadPoolBuilder::new().num_threads(actual_threads).build().map_err(Error::from)
     }
 }
 


### PR DESCRIPTION
This PR changes behavior of `DeviceCpuRayon::generate_pool`.

This function is utilized for device initialization and thread pool generation for all CPU parallel devices. It takes a usize number to indicate number of threads of this generated thread pool.

Before this PR, if input usize number is 0, then following associated function [num_threads](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads), it changes to `RYAON_NUM_THREADS`, if set. It ignores the overrided global thread pool numbers.

Now after this PR, this function will have the priority of number of threads as following. Only preceed to next option if the previous option is not set.
- The value of current number of threads, if this function is called inside a user custom thread pool.
- The value you initialized the rayon's global thread pool before calling this function:
  ```rust,ignore
  rayon::ThreadPoolBuilder::new().num_threads(xxx).build_global().unwrap()
  ```
- The value you have declared in environmental variable `RAYON_NUM_THREADS`.
- The number of logical CPUs on the machine.

This PR should resolve the problem in REST, when `num_threads` properly set in input card `ctrl.in`, but the value `RAYON_NUM_THREADS` is not the same to `num_threads` in input card, causing REST exceeds number of threads when using RSTSR.