### PR TITLE
Revert to non-default for dynamic loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,11 @@ rstsr-sci-traits = { path = "./rstsr-sci-traits", default-features = false, vers
 rstsr-test-manifest = { path = "./rstsr-test-manifest", default-features = false }
 # ffi dependencies
 rstsr-cblas-base = { version = "0.1" }
-rstsr-openblas-ffi = { version = "0.4", default-features = false, features = ["blas", "cblas", "lapack"] }
-rstsr-mkl-ffi = { version = "0.1", default-features = false, features = ["blas", "cblas", "lapack"] }
-rstsr-blis-ffi = { version = "0.1", default-features = false, features = ["lapack"] }
-rstsr-aocl-ffi = { version = "0.1", default-features = false, features = ["blis", "lapack"] }
-rstsr-kml-ffi = { version = "0.0.2", default-features = false, features = ["kblas", "lapack"] }
+rstsr-openblas-ffi = { version = "0.5", default-features = false, features = ["blas", "cblas", "lapack"] }
+rstsr-mkl-ffi = { version = "0.2", default-features = false, features = ["blas", "cblas", "lapack"] }
+rstsr-blis-ffi = { version = "0.2", default-features = false, features = ["lapack"] }
+rstsr-aocl-ffi = { version = "0.2", default-features = false, features = ["blis", "lapack"] }
+rstsr-kml-ffi = { version = "0.2", default-features = false, features = ["kblas", "lapack"] }
 # basic dependencies
 num = { version = "0.4" }
 itertools = { version = "0.13" }

--- a/rstsr-aocl/Cargo.toml
+++ b/rstsr-aocl/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["aocl", "lina
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading"]
+default = ["linalg"]
 dynamic_loading = ["rstsr-aocl-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-aocl-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr-blis/Cargo.toml
+++ b/rstsr-blis/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["blis", "lina
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading"]
+default = ["linalg"]
 dynamic_loading = ["rstsr-blis-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-blis-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr-kml/Cargo.toml
+++ b/rstsr-kml/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["kml", "linal
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading"]
+default = ["linalg"]
 dynamic_loading = ["rstsr-kml-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-kml-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr-mkl/Cargo.toml
+++ b/rstsr-mkl/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["mkl", "linal
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading"]
+default = ["linalg"]
 dynamic_loading = ["rstsr-mkl-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-mkl-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr-openblas/Cargo.toml
+++ b/rstsr-openblas/Cargo.toml
@@ -27,7 +27,7 @@ rstsr = { path = "../rstsr", default-features = false, features = ["openblas", "
 rstsr-test-manifest = { workspace = true }
 
 [features]
-default = ["linalg", "dynamic_loading"]
+default = ["linalg"]
 dynamic_loading = ["rstsr-openblas-ffi/dynamic_loading"]
 faer = ["rstsr-core/faer"]
 ilp64 = ["rstsr-openblas-ffi/ilp64", "rstsr-blas-traits/ilp64"]

--- a/rstsr/Cargo.toml
+++ b/rstsr/Cargo.toml
@@ -20,7 +20,7 @@ rstsr-aocl = { workspace = true, optional = true }
 rstsr-kml = { workspace = true, optional = true }
 
 [features]
-default = ["rstsr-core/default", "faer", "dynamic_loading"]
+default = ["rstsr-core/default", "faer"]
 
 # rstsr-core features
 std = ["rstsr-core/std"]


### PR DESCRIPTION
Also see https://github.com/RESTGroup/rstsr-ffi/pull/9

This API breaking PR will remove cargo feature `dynamic_loading` from default for many crates.

Although dynamic loading have many benefits, and is the default feature of cudarc; however, enabling dynamic loading for LAPACK can hugely increase compile time and disk usage, if not configured properly.
This is mostly because LAPACK (and LAPACKE) is very large library, containing huge function signatures, comared to cudarc (cublas/cusolver about 500 functions per lib), ort (onnx about 350 functions).

Advice is: **Using conventional shared-library linking is more friendly to developers. Only use dynamic-loading if dynamic-loading when deploying and distributing to end-users.**

We revert to the status to not using dynamic loading by default.