### PR TITLE
Set MSRV to 1.84

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,4 +130,8 @@ We do not support autodiff and lazy-evaluation in far future. In this mean time,
 
 ## Miscellaneous
 
+Current MSRV (minimal supported rust version) is
+- 1.84.1: with crate faer built;
+- 1.82.0: other cases (due to crate `half` and rust language usage of `unsafe extern "C"`).
+
 You are welcomed to raise problems or suggestions in github repo issues or discussions.

--- a/rstsr-common/src/layout/reshape.rs
+++ b/rstsr-common/src/layout/reshape.rs
@@ -137,7 +137,7 @@ fn pop_shape_out(
 
     while size != 1 || shape_out.last().is_some_and(|&v| v == 1) {
         let s_out = shape_out.pop().unwrap();
-        if !size.is_multiple_of(s_out) {
+        if size % s_out != 0 {
             return false;
         }
         size /= s_out;

--- a/rstsr-common/src/lib.rs
+++ b/rstsr-common/src/lib.rs
@@ -1,7 +1,11 @@
+#![allow(unknown_lints)]
 #![allow(clippy::needless_return)]
 // Resolution to something like `tensor.slice_mut() += scalar`.
 // This code is not allowed in rust, but `*&mut tensor.slice_mut() += scalar` is allowed.
 #![allow(clippy::deref_addrof)]
+// Allow `a % b == 0` instead of `is_multiple_of`
+// which is only stabilized after rustc 1.89
+#![allow(clippy::manual_is_multiple_of)]
 
 pub mod prelude;
 pub mod prelude_dev;

--- a/rstsr-common/src/pack_array.rs
+++ b/rstsr-common/src/pack_array.rs
@@ -36,7 +36,7 @@ impl<T> PackArrayAPI<T> for Vec<T> {
     fn pack_array_f<const N: usize>(self) -> Result<<Self as PackableArrayAPI<T, N>>::ArrayVec> {
         let len = self.len();
         rstsr_assert!(
-            len.is_multiple_of(N),
+            len % N == 0,
             InvalidValue,
             "Length of Vec<T> {len} must be a multiple to cast into Vec<[T; {N}]>"
         )?;
@@ -69,7 +69,7 @@ impl<T> PackArrayAPI<T> for &[T] {
     fn pack_array_f<const N: usize>(self) -> Result<<Self as PackableArrayAPI<T, N>>::ArrayVec> {
         let len = self.len();
         rstsr_assert!(
-            len.is_multiple_of(N),
+            len % N == 0,
             InvalidValue,
             "Length of &[T] {len} must be a multiple to cast into Vec<[T; {N}]>"
         )?;
@@ -100,7 +100,7 @@ impl<T> PackArrayAPI<T> for &mut [T] {
     fn pack_array_f<const N: usize>(self) -> Result<<Self as PackableArrayAPI<T, N>>::ArrayVec> {
         let len = self.len();
         rstsr_assert!(
-            len.is_multiple_of(N),
+            len % N == 0,
             InvalidValue,
             "Length of &[T] {len} must be a multiple to cast into Vec<[T; {N}]>"
         )?;

--- a/rstsr-core/src/lib.rs
+++ b/rstsr-core/src/lib.rs
@@ -1,10 +1,14 @@
 #![cfg_attr(not(test), no_std)]
 #![doc = include_str!("docs/lib.md")]
+#![allow(unknown_lints)]
 // This option is for myself as python-like developer.
 #![allow(clippy::needless_return)]
 // Resolution to something like `tensor.slice_mut() += scalar`.
 // This code is not allowed in rust, but `*&mut tensor.slice_mut() += scalar` is allowed.
 #![allow(clippy::deref_addrof)]
+// Allow `a % b == 0` instead of `is_multiple_of`
+// which is only stabilized after rustc 1.89
+#![allow(clippy::manual_is_multiple_of)]
 
 // this line is for docs
 #[allow(unused_imports)]

--- a/rstsr-core/src/tensor/pack_array.rs
+++ b/rstsr-core/src/tensor/pack_array.rs
@@ -139,7 +139,7 @@ where
         let axis = axis as usize;
         rstsr_assert_eq!(self.layout().stride()[axis], 1, InvalidLayout, "The axis must be contiguous")?;
         rstsr_assert_eq!(self.layout().shape()[axis], N, InvalidLayout, "The axis length must be a exactly {N}")?;
-        rstsr_assert!(self.layout().offset().is_multiple_of(N), InvalidLayout, "The offset must be a multiple of {N}")?;
+        rstsr_assert!(self.layout().offset() % N == 0, InvalidLayout, "The offset must be a multiple of {N}")?;
 
         let (storage, layout) = self.into_raw_parts();
         let (data, device) = storage.into_raw_parts();


### PR DESCRIPTION
This PR should set MSRV (minimal supported rust version) to
- 1.84.1: with crate faer built;
- 1.82.0: other cases (due to crate `half` and rust language usage of `unsafe extern "C"`).

This PR also revert the usage of [`is_multiple_of`](https://doc.rust-lang.org/std/primitive.usize.html#method.is_multiple_of), which is only stabilized after 1.87, and will be adviced to use for clippy [manual_is_multiple_of](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of) after 1.89.