### PR TITLE
Apply type promotion rules

### DIFF
--- a/crates-device/rstsr-aocl/src/device.rs
+++ b/crates-device/rstsr-aocl/src/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 impl DeviceBLAS {
     pub fn new(num_threads: usize) -> Self {
@@ -118,8 +119,8 @@ impl<T> DeviceAPI<T> for DeviceBLAS {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/crates-device/rstsr-blis/src/device.rs
+++ b/crates-device/rstsr-blis/src/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 impl DeviceBLAS {
     pub fn new(num_threads: usize) -> Self {
@@ -118,8 +119,8 @@ impl<T> DeviceAPI<T> for DeviceBLAS {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/crates-device/rstsr-kml/src/device.rs
+++ b/crates-device/rstsr-kml/src/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 impl DeviceBLAS {
     pub fn new(num_threads: usize) -> Self {
@@ -118,8 +119,8 @@ impl<T> DeviceAPI<T> for DeviceBLAS {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/crates-device/rstsr-mkl/src/device.rs
+++ b/crates-device/rstsr-mkl/src/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 impl DeviceBLAS {
     pub fn new(num_threads: usize) -> Self {
@@ -118,8 +119,8 @@ impl<T> DeviceAPI<T> for DeviceBLAS {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/crates-device/rstsr-openblas/src/device.rs
+++ b/crates-device/rstsr-openblas/src/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 impl DeviceBLAS {
     pub fn new(num_threads: usize) -> Self {
@@ -118,8 +119,8 @@ impl<T> DeviceAPI<T> for DeviceBLAS {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceBLAS
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/rstsr-blas-traits/src/blas_scalar.rs
+++ b/rstsr-blas-traits/src/blas_scalar.rs
@@ -1,7 +1,7 @@
 use half::{bf16, f16};
 use num::complex::ComplexFloat;
 use num::{Complex, Num};
-use rstsr_dtype_traits::{ExtNum, ExtReal};
+use rstsr_dtype_traits::{ExtNum, ExtReal, PromotionSpecialAPI};
 use std::ffi::c_void;
 use std::ops::*;
 
@@ -42,7 +42,8 @@ impl BlasScalar for bf16 {
 
 pub trait BlasFloat:
     BlasScalar
-    + ComplexFloat<Real: ExtReal>
+    + PromotionSpecialAPI<FloatType = Self>
+    + ComplexFloat<Real: ExtReal + PromotionSpecialAPI<FloatType = Self::Real>>
     + Send
     + Sync
     + Div<Self::Real, Output = Self>

--- a/rstsr-core/src/device_cpu_serial/device.rs
+++ b/rstsr-core/src/device_cpu_serial/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 #[derive(Clone, Debug, Default)]
 pub struct DeviceCpuSerial {
@@ -87,7 +88,8 @@ impl<T> DeviceAPI<T> for DeviceCpuSerial {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceCpuSerial
 where
-    T: ComplexFloat,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T>,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real>,
     D: DimAPI,
 {
 }

--- a/rstsr-core/src/device_cpu_serial/operators/op_binary_common.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/op_binary_common.rs
@@ -1,55 +1,91 @@
 use crate::prelude_dev::*;
 use core::ops::Div;
 use num::complex::ComplexFloat;
-use num::{Float, Num, Signed};
-use rstsr_dtype_traits::ExtNum;
+use num::{Float, Signed};
+use rstsr_dtype_traits::{ExtNum, PromotionSpecialAPI};
 
 // TODO: log1p
 
 /* #region same type */
 
 #[duplicate_item(
-     DeviceOpAPI           NumTrait       func                                         func_inplace                                                         ;
-    [DeviceAcosAPI      ] [ComplexFloat] [|a, b| { a.write(b.acos()             ); }] [|a| unsafe { a.write(a.assume_init_read().acos()                ); }];
-    [DeviceAcoshAPI     ] [ComplexFloat] [|a, b| { a.write(b.acosh()            ); }] [|a| unsafe { a.write(a.assume_init_read().acosh()               ); }];
-    [DeviceAsinAPI      ] [ComplexFloat] [|a, b| { a.write(b.asin()             ); }] [|a| unsafe { a.write(a.assume_init_read().asin()                ); }];
-    [DeviceAsinhAPI     ] [ComplexFloat] [|a, b| { a.write(b.asinh()            ); }] [|a| unsafe { a.write(a.assume_init_read().asinh()               ); }];
-    [DeviceAtanAPI      ] [ComplexFloat] [|a, b| { a.write(b.atan()             ); }] [|a| unsafe { a.write(a.assume_init_read().atan()                ); }];
-    [DeviceAtanhAPI     ] [ComplexFloat] [|a, b| { a.write(b.atanh()            ); }] [|a| unsafe { a.write(a.assume_init_read().atanh()               ); }];
-    [DeviceCeilAPI      ] [Float       ] [|a, b| { a.write(b.ceil()             ); }] [|a| unsafe { a.write(a.assume_init_read().ceil()                ); }];
-    [DeviceConjAPI      ] [ComplexFloat] [|a, b| { a.write(b.conj()             ); }] [|a| unsafe { a.write(a.assume_init_read().conj()                ); }];
-    [DeviceCosAPI       ] [ComplexFloat] [|a, b| { a.write(b.cos()              ); }] [|a| unsafe { a.write(a.assume_init_read().cos()                 ); }];
-    [DeviceCoshAPI      ] [ComplexFloat] [|a, b| { a.write(b.cosh()             ); }] [|a| unsafe { a.write(a.assume_init_read().cosh()                ); }];
-    [DeviceExpAPI       ] [ComplexFloat] [|a, b| { a.write(b.exp()              ); }] [|a| unsafe { a.write(a.assume_init_read().exp()                 ); }];
-    [DeviceExpm1API     ] [Float       ] [|a, b| { a.write(b.exp_m1()           ); }] [|a| unsafe { a.write(a.assume_init_read().exp_m1()              ); }];
-    [DeviceFloorAPI     ] [Float       ] [|a, b| { a.write(b.floor()            ); }] [|a| unsafe { a.write(a.assume_init_read().floor()               ); }];
-    [DeviceInvAPI       ] [ComplexFloat] [|a, b| { a.write(b.recip()            ); }] [|a| unsafe { a.write(a.assume_init_read().recip()               ); }];
-    [DeviceLogAPI       ] [ComplexFloat] [|a, b| { a.write(b.ln()               ); }] [|a| unsafe { a.write(a.assume_init_read().ln()                  ); }];
-    [DeviceLog2API      ] [ComplexFloat] [|a, b| { a.write(b.log2()             ); }] [|a| unsafe { a.write(a.assume_init_read().log2()                ); }];
-    [DeviceLog10API     ] [ComplexFloat] [|a, b| { a.write(b.log10()            ); }] [|a| unsafe { a.write(a.assume_init_read().log10()               ); }];
-    [DeviceReciprocalAPI] [ComplexFloat] [|a, b| { a.write(b.recip()            ); }] [|a| unsafe { a.write(a.assume_init_read().recip()               ); }];
-    [DeviceRoundAPI     ] [Float       ] [|a, b| { a.write(b.round()            ); }] [|a| unsafe { a.write(a.assume_init_read().round()               ); }];
-    [DeviceSinAPI       ] [ComplexFloat] [|a, b| { a.write(b.sin()              ); }] [|a| unsafe { a.write(a.assume_init_read().sin()                 ); }];
-    [DeviceSinhAPI      ] [ComplexFloat] [|a, b| { a.write(b.sinh()             ); }] [|a| unsafe { a.write(a.assume_init_read().sinh()                ); }];
-    [DeviceSqrtAPI      ] [ComplexFloat] [|a, b| { a.write(b.sqrt()             ); }] [|a| unsafe { a.write(a.assume_init_read().sqrt()                ); }];
-    [DeviceSquareAPI    ] [Num         ] [|a, b| { a.write(b.clone() * b.clone()); }] [|a| unsafe { a.write(a.assume_init_read() * a.assume_init_read()); }];
-    [DeviceTanAPI       ] [ComplexFloat] [|a, b| { a.write(b.tan()              ); }] [|a| unsafe { a.write(a.assume_init_read().tan()                 ); }];
-    [DeviceTanhAPI      ] [ComplexFloat] [|a, b| { a.write(b.tanh()             ); }] [|a| unsafe { a.write(a.assume_init_read().tanh()                ); }];
-    [DeviceTruncAPI     ] [Float       ] [|a, b| { a.write(b.trunc()            ); }] [|a| unsafe { a.write(a.assume_init_read().trunc()               ); }];
+     DeviceOpAPI           NumTrait       func_inner;
+    [DeviceAcosAPI      ] [ComplexFloat] [b.acos()  ];
+    [DeviceAcoshAPI     ] [ComplexFloat] [b.acosh() ];
+    [DeviceAsinAPI      ] [ComplexFloat] [b.asin()  ];
+    [DeviceAsinhAPI     ] [ComplexFloat] [b.asinh() ];
+    [DeviceAtanAPI      ] [ComplexFloat] [b.atan()  ];
+    [DeviceAtanhAPI     ] [ComplexFloat] [b.atanh() ];
+    [DeviceCeilAPI      ] [Float       ] [b.ceil()  ];
+    [DeviceConjAPI      ] [ComplexFloat] [b.conj()  ];
+    [DeviceCosAPI       ] [ComplexFloat] [b.cos()   ];
+    [DeviceCoshAPI      ] [ComplexFloat] [b.cosh()  ];
+    [DeviceExpAPI       ] [ComplexFloat] [b.exp()   ];
+    [DeviceExpm1API     ] [Float       ] [b.exp_m1()];
+    [DeviceFloorAPI     ] [Float       ] [b.floor() ];
+    [DeviceInvAPI       ] [ComplexFloat] [b.recip() ];
+    [DeviceLogAPI       ] [ComplexFloat] [b.ln()    ];
+    [DeviceLog2API      ] [ComplexFloat] [b.log2()  ];
+    [DeviceLog10API     ] [ComplexFloat] [b.log10() ];
+    [DeviceReciprocalAPI] [ComplexFloat] [b.recip() ];
+    [DeviceRoundAPI     ] [Float       ] [b.round() ];
+    [DeviceSinAPI       ] [ComplexFloat] [b.sin()   ];
+    [DeviceSinhAPI      ] [ComplexFloat] [b.sinh()  ];
+    [DeviceSqrtAPI      ] [ComplexFloat] [b.sqrt()  ];
+    [DeviceTanAPI       ] [ComplexFloat] [b.tan()   ];
+    [DeviceTanhAPI      ] [ComplexFloat] [b.tanh()  ];
+    [DeviceTruncAPI     ] [Float       ] [b.trunc() ];
 )]
 impl<T, D> DeviceOpAPI<T, D> for DeviceCpuSerial
 where
-    T: Clone + NumTrait,
+    T: Clone + PromotionSpecialAPI<FloatType: NumTrait>,
+    D: DimAPI,
+{
+    type TOut = T::FloatType;
+
+    fn op_muta_refb(
+        &self,
+        a: &mut Vec<MaybeUninit<Self::TOut>>,
+        la: &Layout<D>,
+        b: &Vec<T>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<Self::TOut>, b: &T| {
+            let b = b.clone().to_float_type();
+            a.write(func_inner);
+        };
+        self.op_muta_refb_func(a, la, b, lb, &mut func)
+    }
+
+    fn op_muta(&self, a: &mut Vec<MaybeUninit<Self::TOut>>, la: &Layout<D>) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<Self::TOut>| {
+            let b = unsafe { a.assume_init_read() };
+            a.write(func_inner);
+        };
+        self.op_muta_func(a, la, &mut func)
+    }
+}
+
+impl<T, D> DeviceSquareAPI<T, D> for DeviceCpuSerial
+where
+    T: Clone + Mul<Output = T>,
     D: DimAPI,
 {
     type TOut = T;
 
     fn op_muta_refb(&self, a: &mut Vec<MaybeUninit<T>>, la: &Layout<D>, b: &Vec<T>, lb: &Layout<D>) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<T>, b: &T| {
+            a.write(b.clone() * b.clone());
+        };
         self.op_muta_refb_func(a, la, b, lb, &mut func)
     }
 
     fn op_muta(&self, a: &mut Vec<MaybeUninit<T>>, la: &Layout<D>) -> Result<()> {
-        self.op_muta_func(a, la, &mut func_inplace)
+        let mut func = |a: &mut MaybeUninit<T>| {
+            let b = unsafe { a.assume_init_read() };
+            a.write(b.clone() * b);
+        };
+        self.op_muta_func(a, la, &mut func)
     }
 }
 

--- a/rstsr-core/src/device_cpu_serial/operators/op_ternary_common.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/op_ternary_common.rs
@@ -146,7 +146,7 @@ where
     TA::Output: Clone,
     D: DimAPI,
 {
-    type TOut = <TA as Pow<TB>>::Output;
+    type TOut = TA::Output;
 
     fn op_mutc_refa_refb(
         &self,

--- a/rstsr-core/src/device_cpu_serial/operators/op_ternary_common.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/op_ternary_common.rs
@@ -1,67 +1,143 @@
 use crate::prelude_dev::*;
 use num::complex::ComplexFloat;
 use num::{pow::Pow, Float};
-use rstsr_dtype_traits::{ExtFloat, ExtReal};
+use rstsr_dtype_traits::{ExtFloat, ExtReal, PromotionAPI, PromotionSpecialAPI};
 
+// output with special promotion
 #[duplicate_item(
-     DeviceOpAPI             TO     TraitT           func;
-    [DeviceATan2API       ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.atan2(b)                           ); }];
-    [DeviceCopySignAPI    ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.copysign(b)                        ); }];
-    [DeviceEqualAPI       ] [bool] [PartialEq     ] [|c,  a,  b| { c.write(a == b                               ); }];
-    [DeviceGreaterAPI     ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a > b                                ); }];
-    [DeviceGreaterEqualAPI] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a >= b                               ); }];
-    [DeviceHypotAPI       ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.hypot(b)                           ); }];
-    [DeviceLessAPI        ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a < b                                ); }];
-    [DeviceLessEqualAPI   ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a <= b                               ); }];
-    [DeviceLogAddExpAPI   ] [T   ] [ComplexFloat  ] [|c, &a, &b| { c.write((a.exp() + b.exp()).ln()             ); }];
-    [DeviceMaximumAPI     ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_max(b.clone())         ); }];
-    [DeviceMinimumAPI     ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_min(b.clone())         ); }];
-    [DeviceNotEqualAPI    ] [bool] [PartialEq     ] [|c,  a,  b| { c.write(a != b                               ); }];
-    [DeviceFloorDivideAPI ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_floor_divide(b.clone())); }];
-    [DeviceNextAfterAPI   ] [T   ] [ExtFloat      ] [|c,  a,  b| { c.write(a.clone().ext_nextafter(b.clone())   ); }];
+     DeviceOpAPI             TraitT           func_inner;
+    [DeviceATan2API       ] [Float         ] [Float::atan2(a, b)            ];
+    [DeviceCopySignAPI    ] [Float         ] [Float::copysign(a, b)         ];
+    [DeviceHypotAPI       ] [Float         ] [Float::hypot(a, b)            ];
+    [DeviceNextAfterAPI   ] [ExtFloat      ] [ExtFloat::ext_nextafter(a, b) ];
+    [DeviceLogAddExpAPI   ] [ComplexFloat  ] [(a.exp() + b.exp()).ln()      ];
 )]
-impl<T, D> DeviceOpAPI<T, T, D> for DeviceCpuSerial
+impl<TA, TB, D> DeviceOpAPI<TA, TB, D> for DeviceCpuSerial
 where
-    T: Clone + TraitT,
+    TA: Clone + PromotionAPI<TB, Res: PromotionSpecialAPI<FloatType: TraitT>>,
+    TB: Clone,
+    D: DimAPI,
+{
+    type TOut = <TA::Res as PromotionSpecialAPI>::FloatType;
+
+    fn op_mutc_refa_refb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: &Vec<TA>,
+        la: &Layout<D>,
+        b: &Vec<TB>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_refa_refb_func(c, lc, a, la, b, lb, &mut func)
+    }
+
+    fn op_mutc_refa_numb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: &Vec<TA>,
+        la: &Layout<D>,
+        b: TB,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_refa_numb_func(c, lc, a, la, b, &mut func)
+    }
+
+    fn op_mutc_numa_refb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: TA,
+        b: &Vec<TB>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_numa_refb_func(c, lc, a, b, lb, &mut func)
+    }
+}
+
+// general promotion
+#[duplicate_item(
+     DeviceOpAPI             TO        TraitT           func_inner;
+    [DeviceMaximumAPI     ] [TA::Res] [ExtReal       ] [ExtReal::ext_max(a, b)         ];
+    [DeviceMinimumAPI     ] [TA::Res] [ExtReal       ] [ExtReal::ext_min(a, b)         ];
+    [DeviceFloorDivideAPI ] [TA::Res] [ExtReal       ] [ExtReal::ext_floor_divide(a, b)];
+    [DeviceEqualAPI       ] [bool   ] [PartialEq     ] [a == b                         ];
+    [DeviceGreaterAPI     ] [bool   ] [PartialOrd    ] [a > b                          ];
+    [DeviceGreaterEqualAPI] [bool   ] [PartialOrd    ] [a >= b                         ];
+    [DeviceLessAPI        ] [bool   ] [PartialOrd    ] [a < b                          ];
+    [DeviceLessEqualAPI   ] [bool   ] [PartialOrd    ] [a <= b                         ];
+)]
+impl<TA, TB, D> DeviceOpAPI<TA, TB, D> for DeviceCpuSerial
+where
+    TA: Clone + PromotionAPI<TB, Res: TraitT>,
+    TB: Clone,
     D: DimAPI,
 {
     type TOut = TO;
 
     fn op_mutc_refa_refb(
         &self,
-        c: &mut Vec<MaybeUninit<TO>>,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: &Vec<T>,
+        a: &Vec<TA>,
         la: &Layout<D>,
-        b: &Vec<T>,
+        b: &Vec<TB>,
         lb: &Layout<D>,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_refa_refb_func(c, lc, a, la, b, lb, &mut func)
     }
 
     fn op_mutc_refa_numb(
         &self,
-        c: &mut Vec<MaybeUninit<TO>>,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: &Vec<T>,
+        a: &Vec<TA>,
         la: &Layout<D>,
-        b: T,
+        b: TB,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_refa_numb_func(c, lc, a, la, b, &mut func)
     }
 
     fn op_mutc_numa_refb(
         &self,
-        c: &mut Vec<MaybeUninit<TO>>,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: T,
-        b: &Vec<T>,
+        a: TA,
+        b: &Vec<TB>,
         lb: &Layout<D>,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_numa_refb_func(c, lc, a, b, lb, &mut func)
     }
 }
 
+// Special case for pow
 impl<TA, TB, D> DevicePowAPI<TA, TB, D> for DeviceCpuSerial
 where
     TA: Clone,

--- a/rstsr-core/src/device_faer/device.rs
+++ b/rstsr-core/src/device_faer/device.rs
@@ -1,5 +1,6 @@
 use crate::prelude_dev::*;
 use num::{complex::ComplexFloat, Num};
+use rstsr_dtype_traits::PromotionSpecialAPI;
 
 #[derive(Clone, Debug)]
 pub struct DeviceFaer {
@@ -125,8 +126,8 @@ impl<T> DeviceAPI<T> for DeviceFaer {}
 
 impl<T, D> DeviceComplexFloatAPI<T, D> for DeviceFaer
 where
-    T: ComplexFloat + Send + Sync,
-    T::Real: Send + Sync,
+    T: ComplexFloat + PromotionSpecialAPI<FloatType = T> + Send + Sync,
+    T::Real: PromotionSpecialAPI<FloatType = T::Real> + Send + Sync,
     D: DimAPI,
 {
 }

--- a/rstsr-core/src/docs/array_api_standard.md
+++ b/rstsr-core/src/docs/array_api_standard.md
@@ -144,16 +144,20 @@ Dropped support
 
 ### Data Type Functions
 
+Data type promotion rules are handled by devices instead of core functions (you can implement your promotion rule for your device).
+
+The reference implementation (as in [`DeviceCpuSerial`] and [`DeviceFaer`]), follows two kinds of promotion rules:
+- The rule from operator itself: this affects most functions that comes with intrinsic operator (+, -, *, /, &, |, ...), as well as some functions ([`abs`], [`real`], [`imag`], [`pow`], etc.); also see crate [`num`].
+- The rule from promotion rule (the same rule of [NumPy's](https://numpy.org/doc/stable/reference/arrays.promotion.html)): this affects most common functions ([`sin`], [`greater`], [`sqrt`], to list a few).
+
 | status | implementation | Python API | description |
 |-|-|-|-|
-| T | [`num`] crate | `astype` | Copies an array to a specified data type irrespective of Type Promotion Rules rules. |
-| T | [`num`] crate | `can_cast` | Determines if one data type can be cast to another data type according Type Promotion Rules rules. |
-| T | [`num`] crate | `finfo` | Machine limits for floating-point data types. |
-| T | [`num`] crate | `iinfo` | Machine limits for integer data types. |
-| T | [`core::any::type_name`] | `isdtype` | Returns a boolean indicating whether a provided dtype is of a specified data type "kind". |
-| T | [`num`] crate | `result_type` | Returns the dtype that results from applying the type promotion rules (see Type Promotion Rules) to the arguments. |
-
-For this part, we refer to [`num`] crate, where data type conversion and promotion are regularized by trait bounds.
+| T | Rust type cast [`as`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions)<br>[`PromotionAPI::promote_astype`]<br>[`num::ToPrimitive`] | `astype` | Copies an array to a specified data type irrespective of Type Promotion Rules rules. |
+| T | [`PromotionAPI::CAN_CAST_SELF`]<br>[`PromotionAPI::CAN_CAST_OTHER`]<br>operator trait definition | `can_cast` | Determines if one data type can be cast to another data type according Type Promotion Rules rules. |
+| T | [`num::Float`] | `finfo` | Machine limits for floating-point data types. |
+| T | [`num::Integer`] | `iinfo` | Machine limits for integer data types. |
+| T | [`core::any::TypeId`] | `isdtype` | Returns a boolean indicating whether a provided dtype is of a specified data type "kind". |
+| T | [`PromotionAPI::Res`] | `result_type` | Returns the dtype that results from applying the type promotion rules (see Type Promotion Rules) to the arguments. |
 
 ### Data Type Categories
 

--- a/rstsr-core/src/feature_rayon/auto_impl/op_binary_common.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/op_binary_common.rs
@@ -1,55 +1,91 @@
 use crate::prelude_dev::*;
 use core::ops::Div;
 use num::complex::ComplexFloat;
-use num::{Float, Num, Signed};
-use rstsr_dtype_traits::ExtNum;
+use num::{Float, Signed};
+use rstsr_dtype_traits::{ExtNum, PromotionSpecialAPI};
 
 // TODO: log1p
 
 /* #region same type */
 
 #[duplicate_item(
-     DeviceOpAPI           NumTrait       func                                         func_inplace                                                         ;
-    [DeviceAcosAPI      ] [ComplexFloat] [|a, b| { a.write(b.acos()             ); }] [|a| unsafe { a.write(a.assume_init_read().acos()                ); }];
-    [DeviceAcoshAPI     ] [ComplexFloat] [|a, b| { a.write(b.acosh()            ); }] [|a| unsafe { a.write(a.assume_init_read().acosh()               ); }];
-    [DeviceAsinAPI      ] [ComplexFloat] [|a, b| { a.write(b.asin()             ); }] [|a| unsafe { a.write(a.assume_init_read().asin()                ); }];
-    [DeviceAsinhAPI     ] [ComplexFloat] [|a, b| { a.write(b.asinh()            ); }] [|a| unsafe { a.write(a.assume_init_read().asinh()               ); }];
-    [DeviceAtanAPI      ] [ComplexFloat] [|a, b| { a.write(b.atan()             ); }] [|a| unsafe { a.write(a.assume_init_read().atan()                ); }];
-    [DeviceAtanhAPI     ] [ComplexFloat] [|a, b| { a.write(b.atanh()            ); }] [|a| unsafe { a.write(a.assume_init_read().atanh()               ); }];
-    [DeviceCeilAPI      ] [Float       ] [|a, b| { a.write(b.ceil()             ); }] [|a| unsafe { a.write(a.assume_init_read().ceil()                ); }];
-    [DeviceConjAPI      ] [ComplexFloat] [|a, b| { a.write(b.conj()             ); }] [|a| unsafe { a.write(a.assume_init_read().conj()                ); }];
-    [DeviceCosAPI       ] [ComplexFloat] [|a, b| { a.write(b.cos()              ); }] [|a| unsafe { a.write(a.assume_init_read().cos()                 ); }];
-    [DeviceCoshAPI      ] [ComplexFloat] [|a, b| { a.write(b.cosh()             ); }] [|a| unsafe { a.write(a.assume_init_read().cosh()                ); }];
-    [DeviceExpAPI       ] [ComplexFloat] [|a, b| { a.write(b.exp()              ); }] [|a| unsafe { a.write(a.assume_init_read().exp()                 ); }];
-    [DeviceExpm1API     ] [Float       ] [|a, b| { a.write(b.exp_m1()           ); }] [|a| unsafe { a.write(a.assume_init_read().exp_m1()              ); }];
-    [DeviceFloorAPI     ] [Float       ] [|a, b| { a.write(b.floor()            ); }] [|a| unsafe { a.write(a.assume_init_read().floor()               ); }];
-    [DeviceInvAPI       ] [ComplexFloat] [|a, b| { a.write(b.recip()            ); }] [|a| unsafe { a.write(a.assume_init_read().recip()               ); }];
-    [DeviceLogAPI       ] [ComplexFloat] [|a, b| { a.write(b.ln()               ); }] [|a| unsafe { a.write(a.assume_init_read().ln()                  ); }];
-    [DeviceLog2API      ] [ComplexFloat] [|a, b| { a.write(b.log2()             ); }] [|a| unsafe { a.write(a.assume_init_read().log2()                ); }];
-    [DeviceLog10API     ] [ComplexFloat] [|a, b| { a.write(b.log10()            ); }] [|a| unsafe { a.write(a.assume_init_read().log10()               ); }];
-    [DeviceReciprocalAPI] [ComplexFloat] [|a, b| { a.write(b.recip()            ); }] [|a| unsafe { a.write(a.assume_init_read().recip()               ); }];
-    [DeviceRoundAPI     ] [Float       ] [|a, b| { a.write(b.round()            ); }] [|a| unsafe { a.write(a.assume_init_read().round()               ); }];
-    [DeviceSinAPI       ] [ComplexFloat] [|a, b| { a.write(b.sin()              ); }] [|a| unsafe { a.write(a.assume_init_read().sin()                 ); }];
-    [DeviceSinhAPI      ] [ComplexFloat] [|a, b| { a.write(b.sinh()             ); }] [|a| unsafe { a.write(a.assume_init_read().sinh()                ); }];
-    [DeviceSqrtAPI      ] [ComplexFloat] [|a, b| { a.write(b.sqrt()             ); }] [|a| unsafe { a.write(a.assume_init_read().sqrt()                ); }];
-    [DeviceSquareAPI    ] [Num         ] [|a, b| { a.write(b.clone() * b.clone()); }] [|a| unsafe { a.write(a.assume_init_read() * a.assume_init_read()); }];
-    [DeviceTanAPI       ] [ComplexFloat] [|a, b| { a.write(b.tan()              ); }] [|a| unsafe { a.write(a.assume_init_read().tan()                 ); }];
-    [DeviceTanhAPI      ] [ComplexFloat] [|a, b| { a.write(b.tanh()             ); }] [|a| unsafe { a.write(a.assume_init_read().tanh()                ); }];
-    [DeviceTruncAPI     ] [Float       ] [|a, b| { a.write(b.trunc()            ); }] [|a| unsafe { a.write(a.assume_init_read().trunc()               ); }];
+     DeviceOpAPI           NumTrait       func_inner;
+    [DeviceAcosAPI      ] [ComplexFloat] [b.acos()  ];
+    [DeviceAcoshAPI     ] [ComplexFloat] [b.acosh() ];
+    [DeviceAsinAPI      ] [ComplexFloat] [b.asin()  ];
+    [DeviceAsinhAPI     ] [ComplexFloat] [b.asinh() ];
+    [DeviceAtanAPI      ] [ComplexFloat] [b.atan()  ];
+    [DeviceAtanhAPI     ] [ComplexFloat] [b.atanh() ];
+    [DeviceCeilAPI      ] [Float       ] [b.ceil()  ];
+    [DeviceConjAPI      ] [ComplexFloat] [b.conj()  ];
+    [DeviceCosAPI       ] [ComplexFloat] [b.cos()   ];
+    [DeviceCoshAPI      ] [ComplexFloat] [b.cosh()  ];
+    [DeviceExpAPI       ] [ComplexFloat] [b.exp()   ];
+    [DeviceExpm1API     ] [Float       ] [b.exp_m1()];
+    [DeviceFloorAPI     ] [Float       ] [b.floor() ];
+    [DeviceInvAPI       ] [ComplexFloat] [b.recip() ];
+    [DeviceLogAPI       ] [ComplexFloat] [b.ln()    ];
+    [DeviceLog2API      ] [ComplexFloat] [b.log2()  ];
+    [DeviceLog10API     ] [ComplexFloat] [b.log10() ];
+    [DeviceReciprocalAPI] [ComplexFloat] [b.recip() ];
+    [DeviceRoundAPI     ] [Float       ] [b.round() ];
+    [DeviceSinAPI       ] [ComplexFloat] [b.sin()   ];
+    [DeviceSinhAPI      ] [ComplexFloat] [b.sinh()  ];
+    [DeviceSqrtAPI      ] [ComplexFloat] [b.sqrt()  ];
+    [DeviceTanAPI       ] [ComplexFloat] [b.tan()   ];
+    [DeviceTanhAPI      ] [ComplexFloat] [b.tanh()  ];
+    [DeviceTruncAPI     ] [Float       ] [b.trunc() ];
 )]
 impl<T, D> DeviceOpAPI<T, D> for DeviceRayonAutoImpl
 where
-    T: Clone + Send + Sync + NumTrait,
+    T: Clone + Send + Sync + PromotionSpecialAPI<FloatType: NumTrait + Send + Sync>,
+    D: DimAPI,
+{
+    type TOut = T::FloatType;
+
+    fn op_muta_refb(
+        &self,
+        a: &mut Vec<MaybeUninit<Self::TOut>>,
+        la: &Layout<D>,
+        b: &Vec<T>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<Self::TOut>, b: &T| {
+            let b = b.clone().to_float_type();
+            a.write(func_inner);
+        };
+        self.op_muta_refb_func(a, la, b, lb, &mut func)
+    }
+
+    fn op_muta(&self, a: &mut Vec<MaybeUninit<Self::TOut>>, la: &Layout<D>) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<Self::TOut>| {
+            let b = unsafe { a.assume_init_read() };
+            a.write(func_inner);
+        };
+        self.op_muta_func(a, la, &mut func)
+    }
+}
+
+impl<T, D> DeviceSquareAPI<T, D> for DeviceRayonAutoImpl
+where
+    T: Clone + Send + Sync + Mul<Output = T>,
     D: DimAPI,
 {
     type TOut = T;
 
     fn op_muta_refb(&self, a: &mut Vec<MaybeUninit<T>>, la: &Layout<D>, b: &Vec<T>, lb: &Layout<D>) -> Result<()> {
+        let mut func = |a: &mut MaybeUninit<T>, b: &T| {
+            a.write(b.clone() * b.clone());
+        };
         self.op_muta_refb_func(a, la, b, lb, &mut func)
     }
 
     fn op_muta(&self, a: &mut Vec<MaybeUninit<T>>, la: &Layout<D>) -> Result<()> {
-        self.op_muta_func(a, la, &mut func_inplace)
+        let mut func = |a: &mut MaybeUninit<T>| {
+            let b = unsafe { a.assume_init_read() };
+            a.write(b.clone() * b);
+        };
+        self.op_muta_func(a, la, &mut func)
     }
 }
 
@@ -58,15 +94,15 @@ where
 /* #region boolean output */
 
 #[duplicate_item(
-     DeviceOpAPI         NumTrait       func                        ;
-    [DeviceSignBitAPI ] [Signed      ] [|a, b| { a.write(b.is_positive()); }];
-    [DeviceIsFiniteAPI] [ComplexFloat] [|a, b| { a.write(b.is_finite()  ); }];
-    [DeviceIsInfAPI   ] [ComplexFloat] [|a, b| { a.write(b.is_infinite()); }];
-    [DeviceIsNanAPI   ] [ComplexFloat] [|a, b| { a.write(b.is_nan()     ); }];
+     DeviceOpAPI         NumTrait       func                         ;
+    [DeviceSignBitAPI ] [Signed      ] [|a, b| { a.write(b.is_positive()); } ];
+    [DeviceIsFiniteAPI] [ComplexFloat] [|a, b| { a.write(b.is_finite()  ); } ];
+    [DeviceIsInfAPI   ] [ComplexFloat] [|a, b| { a.write(b.is_infinite()); } ];
+    [DeviceIsNanAPI   ] [ComplexFloat] [|a, b| { a.write(b.is_nan()     ); } ];
 )]
 impl<T, D> DeviceOpAPI<T, D> for DeviceRayonAutoImpl
 where
-    T: Clone + Send + Sync + NumTrait,
+    T: Clone + NumTrait + Send + Sync,
     D: DimAPI,
 {
     type TOut = bool;

--- a/rstsr-core/src/feature_rayon/auto_impl/op_ternary_common.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/op_ternary_common.rs
@@ -1,67 +1,143 @@
 use crate::prelude_dev::*;
 use num::complex::ComplexFloat;
 use num::{pow::Pow, Float};
-use rstsr_dtype_traits::{ExtFloat, ExtReal};
+use rstsr_dtype_traits::{ExtFloat, ExtReal, PromotionAPI, PromotionSpecialAPI};
 
+// output with special promotion
 #[duplicate_item(
-     DeviceOpAPI             TO     TraitT           func;
-    [DeviceATan2API       ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.atan2(b)                           ); }];
-    [DeviceCopySignAPI    ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.copysign(b)                        ); }];
-    [DeviceEqualAPI       ] [bool] [PartialEq     ] [|c,  a,  b| { c.write(a == b                               ); }];
-    [DeviceGreaterAPI     ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a > b                                ); }];
-    [DeviceGreaterEqualAPI] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a >= b                               ); }];
-    [DeviceHypotAPI       ] [T   ] [Float         ] [|c, &a, &b| { c.write(a.hypot(b)                           ); }];
-    [DeviceLessAPI        ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a < b                                ); }];
-    [DeviceLessEqualAPI   ] [bool] [PartialOrd    ] [|c,  a,  b| { c.write(a <= b                               ); }];
-    [DeviceLogAddExpAPI   ] [T   ] [ComplexFloat  ] [|c, &a, &b| { c.write((a.exp() + b.exp()).ln()             ); }];
-    [DeviceMaximumAPI     ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_max(b.clone())         ); }];
-    [DeviceMinimumAPI     ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_min(b.clone())         ); }];
-    [DeviceNotEqualAPI    ] [bool] [PartialEq     ] [|c,  a,  b| { c.write(a != b                               ); }];
-    [DeviceFloorDivideAPI ] [T   ] [ExtReal       ] [|c,  a,  b| { c.write(a.clone().ext_floor_divide(b.clone())); }];
-    [DeviceNextAfterAPI   ] [T   ] [ExtFloat      ] [|c,  a,  b| { c.write(a.clone().ext_nextafter(b.clone())   ); }];
+     DeviceOpAPI             TraitT           func_inner;
+    [DeviceATan2API       ] [Float         ] [Float::atan2(a, b)            ];
+    [DeviceCopySignAPI    ] [Float         ] [Float::copysign(a, b)         ];
+    [DeviceHypotAPI       ] [Float         ] [Float::hypot(a, b)            ];
+    [DeviceNextAfterAPI   ] [ExtFloat      ] [ExtFloat::ext_nextafter(a, b) ];
+    [DeviceLogAddExpAPI   ] [ComplexFloat  ] [(a.exp() + b.exp()).ln()      ];
 )]
-impl<T, D> DeviceOpAPI<T, T, D> for DeviceRayonAutoImpl
+impl<TA, TB, D> DeviceOpAPI<TA, TB, D> for DeviceRayonAutoImpl
 where
-    T: Clone + Send + Sync + TraitT,
+    TA: Clone + Send + Sync + PromotionAPI<TB, Res: PromotionSpecialAPI<FloatType: TraitT + Send + Sync>>,
+    TB: Clone + Send + Sync,
+    D: DimAPI,
+{
+    type TOut = <TA::Res as PromotionSpecialAPI>::FloatType;
+
+    fn op_mutc_refa_refb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: &Vec<TA>,
+        la: &Layout<D>,
+        b: &Vec<TB>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_refa_refb_func(c, lc, a, la, b, lb, &mut func)
+    }
+
+    fn op_mutc_refa_numb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: &Vec<TA>,
+        la: &Layout<D>,
+        b: TB,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_refa_numb_func(c, lc, a, la, b, &mut func)
+    }
+
+    fn op_mutc_numa_refb(
+        &self,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        lc: &Layout<D>,
+        a: TA,
+        b: &Vec<TB>,
+        lb: &Layout<D>,
+    ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            let (a, b) = (a.to_float_type(), b.to_float_type());
+            c.write(func_inner);
+        };
+        self.op_mutc_numa_refb_func(c, lc, a, b, lb, &mut func)
+    }
+}
+
+// general promotion
+#[duplicate_item(
+     DeviceOpAPI             TO        TraitT           func_inner;
+    [DeviceMaximumAPI     ] [TA::Res] [ExtReal       ] [ExtReal::ext_max(a, b)         ];
+    [DeviceMinimumAPI     ] [TA::Res] [ExtReal       ] [ExtReal::ext_min(a, b)         ];
+    [DeviceFloorDivideAPI ] [TA::Res] [ExtReal       ] [ExtReal::ext_floor_divide(a, b)];
+    [DeviceEqualAPI       ] [bool   ] [PartialEq     ] [a == b                         ];
+    [DeviceGreaterAPI     ] [bool   ] [PartialOrd    ] [a > b                          ];
+    [DeviceGreaterEqualAPI] [bool   ] [PartialOrd    ] [a >= b                         ];
+    [DeviceLessAPI        ] [bool   ] [PartialOrd    ] [a < b                          ];
+    [DeviceLessEqualAPI   ] [bool   ] [PartialOrd    ] [a <= b                         ];
+)]
+impl<TA, TB, D> DeviceOpAPI<TA, TB, D> for DeviceRayonAutoImpl
+where
+    TA: Clone + Send + Sync + PromotionAPI<TB, Res: TraitT + Send + Sync>,
+    TB: Clone + Send + Sync,
     D: DimAPI,
 {
     type TOut = TO;
 
     fn op_mutc_refa_refb(
         &self,
-        c: &mut Vec<MaybeUninit<TO>>,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: &Vec<T>,
+        a: &Vec<TA>,
         la: &Layout<D>,
-        b: &Vec<T>,
+        b: &Vec<TB>,
         lb: &Layout<D>,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_refa_refb_func(c, lc, a, la, b, lb, &mut func)
     }
 
     fn op_mutc_refa_numb(
         &self,
-        c: &mut Vec<MaybeUninit<TO>>,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: &Vec<T>,
+        a: &Vec<TA>,
         la: &Layout<D>,
-        b: T,
+        b: TB,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_refa_numb_func(c, lc, a, la, b, &mut func)
     }
 
     fn op_mutc_numa_refb(
         &self,
-        c: &mut <Self as DeviceRawAPI<MaybeUninit<TO>>>::Raw,
+        c: &mut Vec<MaybeUninit<Self::TOut>>,
         lc: &Layout<D>,
-        a: T,
-        b: &<Self as DeviceRawAPI<T>>::Raw,
+        a: TA,
+        b: &Vec<TB>,
         lb: &Layout<D>,
     ) -> Result<()> {
+        let mut func = |c: &mut MaybeUninit<Self::TOut>, a: &TA, b: &TB| {
+            let (a, b) = TA::promote_pair(a.clone(), b.clone());
+            c.write(func_inner);
+        };
         self.op_mutc_numa_refb_func(c, lc, a, b, lb, &mut func)
     }
 }
 
+// Special case for pow
 impl<TA, TB, D> DevicePowAPI<TA, TB, D> for DeviceRayonAutoImpl
 where
     TA: Clone + Send + Sync,
@@ -70,7 +146,7 @@ where
     TA::Output: Clone + Send + Sync,
     D: DimAPI,
 {
-    type TOut = <TA as Pow<TB>>::Output;
+    type TOut = TA::Output;
 
     fn op_mutc_refa_refb(
         &self,
@@ -88,9 +164,9 @@ where
 
     fn op_mutc_refa_numb(
         &self,
-        c: &mut Vec<MaybeUninit<Self::TOut>>,
+        c: &mut <Self as DeviceRawAPI<MaybeUninit<Self::TOut>>>::Raw,
         lc: &Layout<D>,
-        a: &Vec<TA>,
+        a: &<Self as DeviceRawAPI<TA>>::Raw,
         la: &Layout<D>,
         b: TB,
     ) -> Result<()> {

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -313,11 +313,11 @@ mod test {
     fn test_floor_divide() {
         #[cfg(not(feature = "col_major"))]
         {
-            let a = arange(6u32).into_shape([2, 3]);
-            let b = asarray(vec![1, 2, 2]);
-            let c = a.floor_divide(&b);
+            let a = arange(6u32).into_shape([2, 3]); // u32
+            let b = asarray(vec![1, 2, 2]); // i32
+            let c = a.floor_divide(&b); // i64
             println!("{c:?}");
-            assert_eq!(c.reshape([6]).to_vec(), vec![0, 0, 1, 3, 2, 2]);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0_i64, 0, 1, 3, 2, 2]);
 
             let a = arange(6.0).into_shape([2, 3]);
 
@@ -333,11 +333,11 @@ mod test {
         #[cfg(feature = "col_major")]
         {
             // [3, 2] + [3]
-            let a = arange(6u32).into_shape([3, 2]);
-            let b = asarray(vec![1, 2, 2]);
-            let c = a.floor_divide(&b);
+            let a = arange(6u32).into_shape([3, 2]); // u32
+            let b = asarray(vec![1, 2, 2]); // i32
+            let c = a.floor_divide(&b); // i64
             println!("{c:?}");
-            assert_eq!(c.reshape([6]).to_vec(), vec![0, 0, 1, 3, 2, 2]);
+            assert_eq!(c.reshape([6]).to_vec(), vec![0_i64, 0, 1, 3, 2, 2]);
 
             let a = arange(6.0).into_shape([3, 2]);
 

--- a/rstsr-core/src/tensor/operators/op_binary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_binary_common.rs
@@ -314,7 +314,7 @@ mod test {
         #[cfg(not(feature = "col_major"))]
         {
             let a = arange(6u32).into_shape([2, 3]); // u32
-            let b = asarray(vec![1, 2, 2]); // i32
+            let b = asarray(vec![1_i32, 2, 2]); // i32
             let c = a.floor_divide(&b); // i64
             println!("{c:?}");
             assert_eq!(c.reshape([6]).to_vec(), vec![0_i64, 0, 1, 3, 2, 2]);
@@ -334,7 +334,7 @@ mod test {
         {
             // [3, 2] + [3]
             let a = arange(6u32).into_shape([3, 2]); // u32
-            let b = asarray(vec![1, 2, 2]); // i32
+            let b = asarray(vec![1_i32, 2, 2]); // i32
             let c = a.floor_divide(&b); // i64
             println!("{c:?}");
             assert_eq!(c.reshape([6]).to_vec(), vec![0_i64, 0, 1, 3, 2, 2]);

--- a/rstsr-dtype-traits/src/lib.rs
+++ b/rstsr-dtype-traits/src/lib.rs
@@ -3,9 +3,11 @@
 mod ext_float;
 mod ext_num;
 mod ext_real;
+mod promotion;
 mod val_write;
 
 pub use ext_float::*;
 pub use ext_num::*;
 pub use ext_real::*;
+pub use promotion::*;
 pub use val_write::*;

--- a/rstsr-dtype-traits/src/promotion.rs
+++ b/rstsr-dtype-traits/src/promotion.rs
@@ -94,9 +94,11 @@ where
 impl PromotionSpecialAPI for T {
     type FloatType = f64;
     type SumType = u64;
+    #[inline]
     fn to_float_type(self) -> Self::FloatType {
         self as _
     }
+    #[inline]
     fn to_sum_type(self) -> Self::SumType {
         self as _
     }
@@ -106,9 +108,11 @@ impl PromotionSpecialAPI for T {
 impl PromotionSpecialAPI for T {
     type FloatType = f64;
     type SumType = i64;
+    #[inline]
     fn to_float_type(self) -> Self::FloatType {
         self as _
     }
+    #[inline]
     fn to_sum_type(self) -> Self::SumType {
         self as _
     }
@@ -118,9 +122,26 @@ impl PromotionSpecialAPI for T {
 impl PromotionSpecialAPI for T {
     type FloatType = T;
     type SumType = T;
+    #[inline]
     fn to_float_type(self) -> Self::FloatType {
         self
     }
+    #[inline]
+    fn to_sum_type(self) -> Self::SumType {
+        self
+    }
+}
+
+#[cfg(feature = "half")]
+#[duplicate_item(T; [half::f16]; [half::bf16];)]
+impl PromotionSpecialAPI for T {
+    type FloatType = T;
+    type SumType = T;
+    #[inline]
+    fn to_float_type(self) -> Self::FloatType {
+        self
+    }
+    #[inline]
     fn to_sum_type(self) -> Self::SumType {
         self
     }
@@ -129,9 +150,11 @@ impl PromotionSpecialAPI for T {
 impl PromotionSpecialAPI for usize {
     type FloatType = f64;
     type SumType = usize;
+    #[inline]
     fn to_float_type(self) -> Self::FloatType {
         self as _
     }
+    #[inline]
     fn to_sum_type(self) -> Self::SumType {
         self
     }
@@ -140,9 +163,11 @@ impl PromotionSpecialAPI for usize {
 impl PromotionSpecialAPI for isize {
     type FloatType = f64;
     type SumType = isize;
+    #[inline]
     fn to_float_type(self) -> Self::FloatType {
         self as _
     }
+    #[inline]
     fn to_sum_type(self) -> Self::SumType {
         self
     }

--- a/rstsr-dtype-traits/src/promotion.rs
+++ b/rstsr-dtype-traits/src/promotion.rs
@@ -500,7 +500,7 @@ macro_rules! impl_promotion_primitive_complex_cast_other {
             type Res = Complex<$ResComp>;
             const CAN_CAST_SELF: bool = $can_cast_self;
             const CAN_CAST_OTHER: bool = $can_cast_other;
-            const CAN_ASTYPE: bool = false;
+            const CAN_ASTYPE: bool = true;
             #[inline]
             fn promote_self(self) -> Self::Res {
                 Self::Res::new(self as _, 0 as _)
@@ -523,7 +523,7 @@ macro_rules! impl_promotion_primitive_complex_nocast_other {
             type Res = Complex<$ResComp>;
             const CAN_CAST_SELF: bool = $can_cast_self;
             const CAN_CAST_OTHER: bool = $can_cast_other;
-            const CAN_ASTYPE: bool = false;
+            const CAN_ASTYPE: bool = true;
             #[inline]
             fn promote_self(self) -> Self::Res {
                 Self::Res::new(self as _, 0 as _)

--- a/rstsr-dtype-traits/src/promotion.rs
+++ b/rstsr-dtype-traits/src/promotion.rs
@@ -1,0 +1,587 @@
+//! Data type promotion traits.
+//!
+//! This follows NumPy's convention:
+//! <https://numpy.org/doc/stable/reference/arrays.promotion.html>
+
+#![allow(non_camel_case_types)]
+
+/* #region trait definition and basic implementation */
+
+type c32 = num::complex::Complex<f32>;
+type c64 = num::complex::Complex<f64>;
+use duplicate::duplicate_item;
+use num::Complex;
+use num::{One, Zero};
+
+pub trait PromotionSpecialAPI {
+    type FloatType;
+    type SumType;
+    fn to_float_type(self) -> Self::FloatType;
+    fn to_sum_type(self) -> Self::SumType;
+}
+
+pub trait PromotionAPI<T: Clone> {
+    type Res;
+    const SAME_TYPE: bool = false;
+    const CAN_CAST_SELF: bool = false;
+    const CAN_CAST_OTHER: bool = false;
+    const CAN_ASTYPE: bool = false;
+    fn promote_self(self) -> Self::Res;
+    fn promote_other(val: T) -> Self::Res;
+    fn promote_astype(self) -> T;
+    #[inline]
+    fn promote_pair(self, val: T) -> (Self::Res, Self::Res)
+    where
+        Self: Sized,
+    {
+        (self.promote_self(), Self::promote_other(val))
+    }
+}
+
+impl<T: Clone> PromotionAPI<T> for T {
+    type Res = T;
+    const SAME_TYPE: bool = true;
+    const CAN_CAST_SELF: bool = true;
+    const CAN_CAST_OTHER: bool = true;
+    const CAN_ASTYPE: bool = true;
+    #[inline]
+    fn promote_self(self) -> Self::Res {
+        self
+    }
+    #[inline]
+    fn promote_other(val: T) -> Self::Res {
+        val
+    }
+    #[inline]
+    fn promote_astype(self) -> T {
+        self
+    }
+}
+
+pub trait PromotionValAPI {
+    fn promote<P: Clone>(self) -> Self::Res
+    where
+        Self: PromotionAPI<P>;
+    fn astype<P: Clone>(self) -> P
+    where
+        Self: PromotionAPI<P>;
+}
+
+impl<T> PromotionValAPI for T
+where
+    T: Clone,
+{
+    fn promote<P: Clone>(self) -> <T as PromotionAPI<P>>::Res
+    where
+        Self: PromotionAPI<P>,
+    {
+        self.promote_self()
+    }
+
+    fn astype<P: Clone>(self) -> P
+    where
+        Self: PromotionAPI<P>,
+    {
+        self.promote_astype()
+    }
+}
+
+/* #endregion */
+
+/* #region PromotionSpecialAPI */
+
+#[duplicate_item(T; [u8]; [u16]; [u32]; [u64];)]
+impl PromotionSpecialAPI for T {
+    type FloatType = f64;
+    type SumType = u64;
+    fn to_float_type(self) -> Self::FloatType {
+        self as _
+    }
+    fn to_sum_type(self) -> Self::SumType {
+        self as _
+    }
+}
+
+#[duplicate_item(T; [i8]; [i16]; [i32]; [i64];)]
+impl PromotionSpecialAPI for T {
+    type FloatType = f64;
+    type SumType = i64;
+    fn to_float_type(self) -> Self::FloatType {
+        self as _
+    }
+    fn to_sum_type(self) -> Self::SumType {
+        self as _
+    }
+}
+
+#[duplicate_item(T; [f32]; [f64]; [c32]; [c64];)]
+impl PromotionSpecialAPI for T {
+    type FloatType = T;
+    type SumType = T;
+    fn to_float_type(self) -> Self::FloatType {
+        self
+    }
+    fn to_sum_type(self) -> Self::SumType {
+        self
+    }
+}
+
+impl PromotionSpecialAPI for usize {
+    type FloatType = f64;
+    type SumType = usize;
+    fn to_float_type(self) -> Self::FloatType {
+        self as _
+    }
+    fn to_sum_type(self) -> Self::SumType {
+        self
+    }
+}
+
+impl PromotionSpecialAPI for isize {
+    type FloatType = f64;
+    type SumType = isize;
+    fn to_float_type(self) -> Self::FloatType {
+        self as _
+    }
+    fn to_sum_type(self) -> Self::SumType {
+        self
+    }
+}
+
+/* #endregion */
+
+/* #region rule bool<T> */
+
+macro_rules! impl_promotion_bool_T {
+    ($T:ty) => {
+        impl PromotionAPI<$T> for bool {
+            type Res = $T;
+            const CAN_CAST_OTHER: bool = true;
+            const CAN_ASTYPE: bool = true;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                if self {
+                    <$T>::one()
+                } else {
+                    <$T>::zero()
+                }
+            }
+            #[inline]
+            fn promote_other(val: $T) -> Self::Res {
+                val
+            }
+            #[inline]
+            fn promote_astype(self) -> $T {
+                if self {
+                    <$T>::one()
+                } else {
+                    <$T>::zero()
+                }
+            }
+        }
+
+        impl PromotionAPI<bool> for $T {
+            type Res = $T;
+            const CAN_CAST_SELF: bool = true;
+            const CAN_ASTYPE: bool = true;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                self
+            }
+            #[inline]
+            fn promote_other(val: bool) -> Self::Res {
+                if val {
+                    <$T>::one()
+                } else {
+                    <$T>::zero()
+                }
+            }
+            #[inline]
+            fn promote_astype(self) -> bool {
+                self != <$T>::zero()
+            }
+        }
+    };
+}
+
+// internal type
+impl_promotion_bool_T!(u8);
+impl_promotion_bool_T!(u16);
+impl_promotion_bool_T!(u32);
+impl_promotion_bool_T!(u64);
+impl_promotion_bool_T!(i8);
+impl_promotion_bool_T!(i16);
+impl_promotion_bool_T!(i32);
+impl_promotion_bool_T!(i64);
+impl_promotion_bool_T!(f32);
+impl_promotion_bool_T!(f64);
+// external type
+impl_promotion_bool_T!(usize);
+impl_promotion_bool_T!(isize);
+#[cfg(feature = "half")]
+impl_promotion_bool_T!(half::f16);
+#[cfg(feature = "half")]
+impl_promotion_bool_T!(half::bf16);
+// complex float
+impl_promotion_bool_T!(c32);
+impl_promotion_bool_T!(c64);
+
+/* #endregion */
+
+/* #region as-able primitive types */
+
+macro_rules! impl_promotion_asable {
+    ($T1:ty, $T2:ty, $can_cast_self: ident, $can_cast_other: ident, $Res:ty) => {
+        impl PromotionAPI<$T2> for $T1 {
+            type Res = $Res;
+            const CAN_CAST_SELF: bool = $can_cast_self;
+            const CAN_CAST_OTHER: bool = $can_cast_other;
+            const CAN_ASTYPE: bool = true;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                self as $Res
+            }
+            #[inline]
+            fn promote_other(val: $T2) -> Self::Res {
+                val as $Res
+            }
+            #[inline]
+            fn promote_astype(self) -> $T2 {
+                self as $T2
+            }
+        }
+    };
+}
+
+// internal typeimpl_promotion_asable!(i8, i16, false, true, i16);
+impl_promotion_asable!(i8, i32, false, true, i32);
+impl_promotion_asable!(i8, i64, false, true, i64);
+impl_promotion_asable!(i8, u8, false, false, i16);
+impl_promotion_asable!(i8, u16, false, false, i32);
+impl_promotion_asable!(i8, u32, false, false, i64);
+impl_promotion_asable!(i8, u64, false, false, f64);
+impl_promotion_asable!(i8, f32, false, true, f32);
+impl_promotion_asable!(i8, f64, false, true, f64);
+impl_promotion_asable!(i16, i8, true, false, i16);
+impl_promotion_asable!(i16, i32, false, true, i32);
+impl_promotion_asable!(i16, i64, false, true, i64);
+impl_promotion_asable!(i16, u8, true, false, i16);
+impl_promotion_asable!(i16, u16, false, false, i32);
+impl_promotion_asable!(i16, u32, false, false, i64);
+impl_promotion_asable!(i16, u64, false, false, f64);
+impl_promotion_asable!(i16, f32, false, true, f32);
+impl_promotion_asable!(i16, f64, false, true, f64);
+impl_promotion_asable!(i32, i8, true, false, i32);
+impl_promotion_asable!(i32, i16, true, false, i32);
+impl_promotion_asable!(i32, i64, false, true, i64);
+impl_promotion_asable!(i32, u8, true, false, i32);
+impl_promotion_asable!(i32, u16, true, false, i32);
+impl_promotion_asable!(i32, u32, false, false, i64);
+impl_promotion_asable!(i32, u64, false, false, f64);
+impl_promotion_asable!(i32, f32, false, false, f64);
+impl_promotion_asable!(i32, f64, false, true, f64);
+impl_promotion_asable!(i64, i8, true, false, i64);
+impl_promotion_asable!(i64, i16, true, false, i64);
+impl_promotion_asable!(i64, i32, true, false, i64);
+impl_promotion_asable!(i64, u8, true, false, i64);
+impl_promotion_asable!(i64, u16, true, false, i64);
+impl_promotion_asable!(i64, u32, true, false, i64);
+impl_promotion_asable!(i64, u64, false, false, f64);
+impl_promotion_asable!(i64, f32, false, false, f64);
+impl_promotion_asable!(i64, f64, false, true, f64);
+impl_promotion_asable!(u8, i8, false, false, i16);
+impl_promotion_asable!(u8, i16, false, true, i16);
+impl_promotion_asable!(u8, i32, false, true, i32);
+impl_promotion_asable!(u8, i64, false, true, i64);
+impl_promotion_asable!(u8, u16, false, true, u16);
+impl_promotion_asable!(u8, u32, false, true, u32);
+impl_promotion_asable!(u8, u64, false, true, u64);
+impl_promotion_asable!(u8, f32, false, true, f32);
+impl_promotion_asable!(u8, f64, false, true, f64);
+impl_promotion_asable!(u16, i8, false, false, i32);
+impl_promotion_asable!(u16, i16, false, false, i32);
+impl_promotion_asable!(u16, i32, false, true, i32);
+impl_promotion_asable!(u16, i64, false, true, i64);
+impl_promotion_asable!(u16, u8, true, false, u16);
+impl_promotion_asable!(u16, u32, false, true, u32);
+impl_promotion_asable!(u16, u64, false, true, u64);
+impl_promotion_asable!(u16, f32, false, true, f32);
+impl_promotion_asable!(u16, f64, false, true, f64);
+impl_promotion_asable!(u32, i8, false, false, i64);
+impl_promotion_asable!(u32, i16, false, false, i64);
+impl_promotion_asable!(u32, i32, false, false, i64);
+impl_promotion_asable!(u32, i64, false, true, i64);
+impl_promotion_asable!(u32, u8, true, false, u32);
+impl_promotion_asable!(u32, u16, true, false, u32);
+impl_promotion_asable!(u32, u64, false, true, u64);
+impl_promotion_asable!(u32, f32, false, false, f64);
+impl_promotion_asable!(u32, f64, false, true, f64);
+impl_promotion_asable!(u64, i8, false, false, f64);
+impl_promotion_asable!(u64, i16, false, false, f64);
+impl_promotion_asable!(u64, i32, false, false, f64);
+impl_promotion_asable!(u64, i64, false, false, f64);
+impl_promotion_asable!(u64, u8, true, false, u64);
+impl_promotion_asable!(u64, u16, true, false, u64);
+impl_promotion_asable!(u64, u32, true, false, u64);
+impl_promotion_asable!(u64, f32, false, false, f64);
+impl_promotion_asable!(u64, f64, false, true, f64);
+impl_promotion_asable!(f32, i8, true, false, f32);
+impl_promotion_asable!(f32, i16, true, false, f32);
+impl_promotion_asable!(f32, i32, false, false, f64);
+impl_promotion_asable!(f32, i64, false, false, f64);
+impl_promotion_asable!(f32, u8, true, false, f32);
+impl_promotion_asable!(f32, u16, true, false, f32);
+impl_promotion_asable!(f32, u32, false, false, f64);
+impl_promotion_asable!(f32, u64, false, false, f64);
+impl_promotion_asable!(f32, f64, false, true, f64);
+impl_promotion_asable!(f64, i8, true, false, f64);
+impl_promotion_asable!(f64, i16, true, false, f64);
+impl_promotion_asable!(f64, i32, true, false, f64);
+impl_promotion_asable!(f64, i64, true, false, f64);
+impl_promotion_asable!(f64, u8, true, false, f64);
+impl_promotion_asable!(f64, u16, true, false, f64);
+impl_promotion_asable!(f64, u32, true, false, f64);
+impl_promotion_asable!(f64, u64, true, false, f64);
+impl_promotion_asable!(f64, f32, true, false, f64);
+
+// external type: isize
+impl_promotion_asable!(isize, i8, true, false, isize);
+impl_promotion_asable!(isize, i16, true, false, isize);
+impl_promotion_asable!(isize, i32, true, false, isize);
+impl_promotion_asable!(isize, i64, true, true, isize);
+impl_promotion_asable!(isize, u8, true, false, isize);
+impl_promotion_asable!(isize, u16, true, false, isize);
+impl_promotion_asable!(isize, u32, true, false, isize);
+impl_promotion_asable!(isize, u64, false, false, f64);
+impl_promotion_asable!(isize, f32, false, false, f64);
+impl_promotion_asable!(isize, f64, false, true, f64);
+impl_promotion_asable!(i8, isize, false, true, isize);
+impl_promotion_asable!(i16, isize, false, true, isize);
+impl_promotion_asable!(i32, isize, false, true, isize);
+impl_promotion_asable!(i64, isize, true, true, isize);
+impl_promotion_asable!(u8, isize, false, true, isize);
+impl_promotion_asable!(u16, isize, false, true, isize);
+impl_promotion_asable!(u32, isize, false, true, isize);
+impl_promotion_asable!(u64, isize, false, false, f64);
+impl_promotion_asable!(f32, isize, false, false, f64);
+impl_promotion_asable!(f64, isize, true, false, f64);
+
+// external type: usize
+impl_promotion_asable!(usize, i8, false, false, f64);
+impl_promotion_asable!(usize, i16, false, false, f64);
+impl_promotion_asable!(usize, i32, false, false, f64);
+impl_promotion_asable!(usize, i64, false, false, f64);
+impl_promotion_asable!(usize, u8, true, false, usize);
+impl_promotion_asable!(usize, u16, true, false, usize);
+impl_promotion_asable!(usize, u32, true, false, usize);
+impl_promotion_asable!(usize, u64, true, true, usize);
+impl_promotion_asable!(usize, f32, false, false, f64);
+impl_promotion_asable!(usize, f64, false, true, f64);
+impl_promotion_asable!(i8, usize, false, false, f64);
+impl_promotion_asable!(i16, usize, false, false, f64);
+impl_promotion_asable!(i32, usize, false, false, f64);
+impl_promotion_asable!(i64, usize, false, false, f64);
+impl_promotion_asable!(u8, usize, false, true, usize);
+impl_promotion_asable!(u16, usize, false, true, usize);
+impl_promotion_asable!(u32, usize, false, true, usize);
+impl_promotion_asable!(u64, usize, true, true, usize);
+impl_promotion_asable!(f32, usize, false, false, f64);
+impl_promotion_asable!(f64, usize, true, false, f64);
+
+/* #endregion */
+
+/* #region complex to primitive */
+
+macro_rules! impl_promotion_complex_primitive_cast_self {
+    ($TComp:ty, $TPrim:ty, $can_cast_self:ident, $can_cast_other:ident, $ResComp:ty) => {
+        impl PromotionAPI<$TPrim> for Complex<$TComp> {
+            type Res = Complex<$ResComp>;
+            const CAN_CAST_SELF: bool = $can_cast_self;
+            const CAN_CAST_OTHER: bool = $can_cast_other;
+            const CAN_ASTYPE: bool = false;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                self
+            }
+            #[inline]
+            fn promote_other(val: $TPrim) -> Self::Res {
+                Self::Res::new(val as _, 0 as _)
+            }
+            #[inline]
+            fn promote_astype(self) -> $TPrim {
+                panic!("Cannot cast complex to primitive type.");
+            }
+        }
+    };
+}
+
+macro_rules! impl_promotion_complex_primitive_no_cast_self {
+    ($TComp:ty, $TPrim:ty, $can_cast_self:ident, $can_cast_other:ident, $ResComp:ty) => {
+        impl PromotionAPI<$TPrim> for Complex<$TComp> {
+            type Res = Complex<$ResComp>;
+            const CAN_CAST_SELF: bool = $can_cast_self;
+            const CAN_CAST_OTHER: bool = $can_cast_other;
+            const CAN_ASTYPE: bool = false;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                Self::Res::new(self.re as _, self.im as _)
+            }
+            #[inline]
+            fn promote_other(val: $TPrim) -> Self::Res {
+                Self::Res::new(val as _, 0 as _)
+            }
+            #[inline]
+            fn promote_astype(self) -> $TPrim {
+                panic!("Cannot cast complex to primitive type.");
+            }
+        }
+    };
+}
+
+impl_promotion_complex_primitive_cast_self!(f32, i8, true, false, f32);
+impl_promotion_complex_primitive_cast_self!(f32, i16, true, false, f32);
+impl_promotion_complex_primitive_cast_self!(f32, u8, true, false, f32);
+impl_promotion_complex_primitive_cast_self!(f32, u16, true, false, f32);
+impl_promotion_complex_primitive_cast_self!(f32, f32, true, false, f32);
+
+impl_promotion_complex_primitive_cast_self!(f64, i8, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, i16, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, i32, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, i64, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, isize, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, u8, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, u16, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, u32, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, u64, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, usize, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, f32, true, false, f64);
+impl_promotion_complex_primitive_cast_self!(f64, f64, true, false, f64);
+
+impl_promotion_complex_primitive_no_cast_self!(f32, i32, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, i64, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, isize, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, u32, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, u64, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, usize, false, false, f64);
+impl_promotion_complex_primitive_no_cast_self!(f32, f64, false, false, f64);
+
+/* #endregion */
+
+/* #region primitive to complex */
+
+macro_rules! impl_promotion_primitive_complex_cast_other {
+    ($TComp:ty, $TPrim:ty, $can_cast_self:ident, $can_cast_other:ident, $ResComp:ty) => {
+        impl PromotionAPI<Complex<$TComp>> for $TPrim {
+            type Res = Complex<$ResComp>;
+            const CAN_CAST_SELF: bool = $can_cast_self;
+            const CAN_CAST_OTHER: bool = $can_cast_other;
+            const CAN_ASTYPE: bool = false;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                Self::Res::new(self as _, 0 as _)
+            }
+            #[inline]
+            fn promote_other(val: Complex<$TComp>) -> Self::Res {
+                val
+            }
+            #[inline]
+            fn promote_astype(self) -> Complex<$TComp> {
+                Complex::<$TComp>::new(self as _, 0 as _)
+            }
+        }
+    };
+}
+
+macro_rules! impl_promotion_primitive_complex_nocast_other {
+    ($TComp:ty, $TPrim:ty, $can_cast_self:ident, $can_cast_other:ident, $ResComp:ty) => {
+        impl PromotionAPI<Complex<$TComp>> for $TPrim {
+            type Res = Complex<$ResComp>;
+            const CAN_CAST_SELF: bool = $can_cast_self;
+            const CAN_CAST_OTHER: bool = $can_cast_other;
+            const CAN_ASTYPE: bool = false;
+            #[inline]
+            fn promote_self(self) -> Self::Res {
+                Self::Res::new(self as _, 0 as _)
+            }
+            #[inline]
+            fn promote_other(val: Complex<$TComp>) -> Self::Res {
+                Self::Res::new(val.re as _, val.im as _)
+            }
+            #[inline]
+            fn promote_astype(self) -> Complex<$TComp> {
+                Complex::<$TComp>::new(self as _, 0 as _)
+            }
+        }
+    };
+}
+
+impl_promotion_primitive_complex_cast_other!(f32, i8, false, true, f32);
+impl_promotion_primitive_complex_cast_other!(f32, i16, false, true, f32);
+impl_promotion_primitive_complex_cast_other!(f32, u8, false, true, f32);
+impl_promotion_primitive_complex_cast_other!(f32, u16, false, true, f32);
+impl_promotion_primitive_complex_cast_other!(f32, f32, false, true, f32);
+
+impl_promotion_primitive_complex_nocast_other!(f64, i8, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, i16, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, i32, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, i64, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, isize, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, u8, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, u16, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, u32, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, u64, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, usize, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, f32, false, true, f64);
+impl_promotion_primitive_complex_nocast_other!(f64, f64, false, true, f64);
+
+impl_promotion_primitive_complex_nocast_other!(f32, i32, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, i64, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, isize, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, u32, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, u64, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, usize, false, false, f64);
+impl_promotion_primitive_complex_nocast_other!(f32, f64, false, false, f64);
+
+/* #endregion */
+
+/* #region complex to complex */
+
+impl PromotionAPI<c32> for c64 {
+    type Res = c64;
+    const CAN_CAST_SELF: bool = true;
+    const CAN_CAST_OTHER: bool = false;
+    const CAN_ASTYPE: bool = true;
+    #[inline]
+    fn promote_self(self) -> Self::Res {
+        self
+    }
+    #[inline]
+    fn promote_other(val: c32) -> Self::Res {
+        c64::new(val.re as f64, val.im as f64)
+    }
+    #[inline]
+    fn promote_astype(self) -> c32 {
+        c32::new(self.re as f32, self.im as f32)
+    }
+}
+
+impl PromotionAPI<c64> for c32 {
+    type Res = c64;
+    const CAN_CAST_SELF: bool = false;
+    const CAN_CAST_OTHER: bool = true;
+    const CAN_ASTYPE: bool = true;
+    #[inline]
+    fn promote_self(self) -> Self::Res {
+        c64::new(self.re as f64, self.im as f64)
+    }
+    #[inline]
+    fn promote_other(val: c64) -> Self::Res {
+        val
+    }
+    #[inline]
+    fn promote_astype(self) -> c64 {
+        c64::new(self.re as f64, self.im as f64)
+    }
+}
+
+/* #endregion */


### PR DESCRIPTION
This PR featuring type promotion rules.

- [x] Implement type promotion trait, where rules comes from NumPy
- [x] Implement several common functions (sin, greater, etc.) with type promotion (making comparasion of different types, or sin to integer list be evaluatable).

This is API breaking change, that affects several trait definitions (`BlasFloat`, `DeviceComplexFloatAPI`); trait bound of many device implementations of common functions also changes (loosen to integers, but more strict to unknown types).