### PR TITLE
Enhance rstsr-common API and add serialization for flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ libm = { version = "0.2" }
 derive_builder = { version = "0.20", default-features = false, features = ["alloc"] }
 duplicate = { version = "2.0" }
 rustversion = { version = "1.0" }
+serde = { version = "1.0", features = ["derive"] }
 # optional dependencies
 rayon = { version = ">=1.10" }
 faer = { version = "0.22", default-features = false, features = ["rayon", "linalg"] }

--- a/rstsr-blas-traits/src/blas3/syhemm.rs
+++ b/rstsr-blas-traits/src/blas3/syhemm.rs
@@ -64,7 +64,7 @@ where
         let order = get_output_order(&[order, order_c], &[], default_order);
         if order == ColMajor {
             let (uplo, a_cow) = match (HERMI, a.f_prefer()) {
-                (false, false) => (uplo.flip()?, a.to_contig_f(ColMajor)?),
+                (false, false) => (uplo.flip(), a.to_contig_f(ColMajor)?),
                 _ => (uplo, a.to_contig_f(ColMajor)?),
             };
             let b_cow = b.to_contig_f(ColMajor)?;
@@ -72,7 +72,7 @@ where
             obj.internal_run()
         } else {
             let (uplo, a_cow) = match (HERMI, a.c_prefer()) {
-                (false, false) => (uplo.flip()?, a.to_contig_f(RowMajor)?),
+                (false, false) => (uplo.flip(), a.to_contig_f(RowMajor)?),
                 _ => (uplo, a.to_contig_f(RowMajor)?),
             };
             let b_cow = b.to_contig_f(RowMajor)?;
@@ -82,8 +82,8 @@ where
                 c: c.map(|c| c.into_reverse_axes()),
                 alpha,
                 beta,
-                side: side.flip()?,
-                uplo: uplo.flip()?,
+                side: side.flip(),
+                uplo: uplo.flip(),
                 order: Some(ColMajor),
             };
             Ok(obj.internal_run()?.into_reverse_axes())

--- a/rstsr-blas-traits/src/blas3/trsm.rs
+++ b/rstsr-blas-traits/src/blas3/trsm.rs
@@ -68,7 +68,7 @@ where
         let order = get_output_order(&[order, Some(order_b)], &[], default_order);
         if order == ColMajor {
             let (transa_new, a_cow) = flip_trans(ColMajor, transa, a, false)?;
-            let uplo = if transa_new != transa { uplo.flip()? } else { uplo };
+            let uplo = if transa_new != transa { uplo.flip() } else { uplo };
             let obj = TRSM_ {
                 a: a_cow.view(),
                 b,
@@ -82,13 +82,13 @@ where
             obj.internal_run()
         } else {
             let (transa_new, a_cow) = flip_trans(RowMajor, transa, a, false)?;
-            let uplo = if transa_new != transa { uplo.flip()? } else { uplo };
+            let uplo = if transa_new != transa { uplo.flip() } else { uplo };
             let obj = TRSM_ {
                 a: a_cow.t(),
                 b: b.into_reverse_axes(),
                 alpha,
-                side: side.flip()?,
-                uplo: Some(uplo.flip()?),
+                side: side.flip(),
+                uplo: Some(uplo.flip()),
                 transa: transa_new,
                 diag,
                 order: Some(ColMajor),

--- a/rstsr-common/Cargo.toml
+++ b/rstsr-common/Cargo.toml
@@ -16,6 +16,7 @@ num = { workspace = true }
 derive_builder = { workspace = true }
 rayon = { workspace = true, optional = true }
 rstsr-cblas-base = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 rstsr-core = { path = "../rstsr-core", default-features = false }

--- a/rstsr-common/src/flags.rs
+++ b/rstsr-common/src/flags.rs
@@ -3,6 +3,7 @@
 use crate::prelude_dev::*;
 use core::ffi::c_char;
 use rstsr_cblas_base::*;
+use serde::{Deserialize, Serialize};
 
 /* #region changeable default */
 
@@ -57,11 +58,13 @@ macro_rules! impl_changeable_default {
 /// F-prefer is not a stable feature currently! We develop only in C-prefer
 /// currently.
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagOrder {
     /// row-major order.
+    #[serde(rename = "RowMajor")]
     C = 101,
     /// column-major order.
+    #[serde(rename = "ColMajor")]
     F = 102,
 }
 
@@ -87,15 +90,17 @@ impl Default for FlagOrder {
 /* #region TensorIterOrder */
 
 /// The policy of the tensor iterator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TensorIterOrder {
     /// Row-major order.
     ///
     /// - absolute safe for array iteration
+    #[serde(rename = "RowMajor")]
     C,
     /// Column-major order.
     ///
     /// - absolute safe for array iteration
+    #[serde(rename = "ColMajor")]
     F,
     /// Automatically choose row/col-major order.
     ///
@@ -105,22 +110,26 @@ pub enum TensorIterOrder {
     ///
     /// - safe for multi-array iteration like `get_iter(a, b)`
     /// - not safe for cases like `a.iter().zip(b.iter())`
+    #[serde(rename = "Auto")]
     A,
     /// Greedy when possible (reorder layouts during iteration).
     ///
     /// - safe for multi-array iteration like `get_iter(a, b)`
     /// - not safe for cases like `a.iter().zip(b.iter())`
     /// - if it is used to create a new array, the stride of new array will be in K order
+    #[serde(rename = "Greedy")]
     K,
     /// Greedy when possible (reset dimension to 1 if axis is broadcasted).
     ///
     /// - not safe for multi-array iteration like `get_iter(a, b)`
     /// - this is useful for inplace-assign broadcasted array.
+    #[serde(rename = "GreedyInplace")]
     G,
     /// Sequential buffer.
     ///
     /// - not safe for multi-array iteration like `get_iter(a, b)`
     /// - this is useful for reshaping or all-contiguous cases.
+    #[serde(rename = "Sequential")]
     B,
 }
 
@@ -154,42 +163,52 @@ pub mod TensorCopyPolicy {
 /* #region blas-flags */
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagTrans {
     /// No transpose
+    #[serde(rename = "NoTrans")]
     N = 111,
     /// Transpose
+    #[serde(rename = "Trans")]
     T = 112,
     /// Conjugate transpose
+    #[serde(rename = "ConjTrans")]
     C = 113,
     // Conjuate only
+    #[serde(rename = "Conj")]
     CN = 114,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagSide {
     /// Left side
+    #[serde(rename = "Left")]
     L = 141,
     /// Right side
+    #[serde(rename = "Right")]
     R = 142,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagUpLo {
     /// Upper triangle
+    #[serde(rename = "Upper")]
     U = 121,
     /// Lower triangle
+    #[serde(rename = "Lower")]
     L = 122,
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagDiag {
     /// Non-unit diagonal
+    #[serde(rename = "NonUnit")]
     N = 131,
     /// Unit diagonal
+    #[serde(rename = "Unit")]
     U = 132,
 }
 
@@ -197,17 +216,22 @@ pub enum FlagDiag {
 
 /* #region symm-flags */
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlagSymm {
     /// Symmetric matrix
+    #[serde(rename = "Symmetric")]
     Sy,
     /// Hermitian matrix
+    #[serde(rename = "Hermitian")]
     He,
     /// Anti-symmetric matrix
+    #[serde(rename = "AntiSymmetric")]
     Ay,
     /// Anti-Hermitian matrix
+    #[serde(rename = "AntiHermitian")]
     Ah,
     /// Non-symmetric matrix
+    #[serde(rename = "NonSymmetric")]
     N,
 }
 

--- a/rstsr-common/src/flags.rs
+++ b/rstsr-common/src/flags.rs
@@ -521,19 +521,19 @@ impl FlagTrans {
 }
 
 impl FlagSide {
-    pub fn flip(&self) -> Result<Self> {
+    pub fn flip(&self) -> Self {
         match self {
-            FlagSide::L => Ok(FlagSide::R),
-            FlagSide::R => Ok(FlagSide::L),
+            FlagSide::L => FlagSide::R,
+            FlagSide::R => FlagSide::L,
         }
     }
 }
 
 impl FlagUpLo {
-    pub fn flip(&self) -> Result<Self> {
+    pub fn flip(&self) -> Self {
         match self {
-            FlagUpLo::U => Ok(FlagUpLo::L),
-            FlagUpLo::L => Ok(FlagUpLo::U),
+            FlagUpLo::U => FlagUpLo::L,
+            FlagUpLo::L => FlagUpLo::U,
         }
     }
 }

--- a/rstsr-core/src/device_cpu_serial/operators/op_tri.rs
+++ b/rstsr-core/src/device_cpu_serial/operators/op_tri.rs
@@ -19,7 +19,7 @@ where
             ColMajor => {
                 let la = la.reverse_axes();
                 let lb = lb.reverse_axes();
-                let uplo = uplo.flip()?;
+                let uplo = uplo.flip();
                 pack_tri_cpu_serial(a, &la, b, &lb, uplo)
             },
         }
@@ -45,7 +45,7 @@ where
             ColMajor => {
                 let la = la.reverse_axes();
                 let lb = lb.reverse_axes();
-                let uplo = uplo.flip()?;
+                let uplo = uplo.flip();
                 unpack_tri_cpu_serial(a, &la, b, &lb, uplo, symm)
             },
         }

--- a/rstsr-core/src/feature_rayon/auto_impl/op_tri.rs
+++ b/rstsr-core/src/feature_rayon/auto_impl/op_tri.rs
@@ -20,7 +20,7 @@ where
             ColMajor => {
                 let la = la.reverse_axes();
                 let lb = lb.reverse_axes();
-                let uplo = uplo.flip()?;
+                let uplo = uplo.flip();
                 pack_tri_cpu_rayon(a, &la, b, &lb, uplo, pool)
             },
         }
@@ -47,7 +47,7 @@ where
             ColMajor => {
                 let la = la.reverse_axes();
                 let lb = lb.reverse_axes();
-                let uplo = uplo.flip()?;
+                let uplo = uplo.flip();
                 unpack_tri_cpu_rayon(a, &la, b, &lb, uplo, symm, pool)
             },
         }

--- a/rstsr/CHANGELOG.md
+++ b/rstsr/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/rstsr/Cargo.toml
+++ b/rstsr/Cargo.toml
@@ -15,6 +15,7 @@ rstsr-core = { workspace = true }
 rstsr-common = { workspace = true }
 rstsr-dtype-traits = { workspace = true }
 rstsr-linalg-traits = { workspace = true, optional = true }
+rstsr-blas-traits = { workspace = true, optional = true }
 rstsr-sci-traits = { workspace = true, optional = true }
 # API document dependencies
 num = { workspace = true }
@@ -44,11 +45,12 @@ aligned_alloc = ["rstsr-core/aligned_alloc"]
 dispatch_dim_layout_iter = ["rstsr-core/dispatch_dim_layout_iter"]
 
 # rstsr BLAS device features
-openblas = ["dep:rstsr-openblas"]
-mkl = ["dep:rstsr-mkl"]
-blis = ["dep:rstsr-blis"]
-aocl = ["dep:rstsr-aocl"]
-kml = ["dep:rstsr-kml"]
+use_blas_traits = ["dep:rstsr-blas-traits"]
+openblas = ["dep:rstsr-openblas", "use_blas_traits"]
+mkl = ["dep:rstsr-mkl", "use_blas_traits"]
+blis = ["dep:rstsr-blis", "use_blas_traits"]
+aocl = ["dep:rstsr-aocl", "use_blas_traits"]
+kml = ["dep:rstsr-kml", "use_blas_traits"]
 
 # dependencies specification
 linalg = ["dep:rstsr-linalg-traits", "rstsr-openblas?/linalg", "rstsr-mkl?/linalg", "rstsr-blis?/linalg", "rstsr-aocl?/linalg", "rstsr-kml?/linalg"]

--- a/rstsr/src/prelude.rs
+++ b/rstsr/src/prelude.rs
@@ -149,5 +149,8 @@ pub mod rt {
     #[cfg(feature = "tblis")]
     pub use super::tblis;
 
+    #[cfg(feature = "use_blas_traits")]
+    pub use rstsr_blas_traits::prelude as blas;
+
     pub use rstsr_core::prelude::rt::{Error, Result};
 }


### PR DESCRIPTION
## API breaking changes

- Refactored the `flip` methods for `FlagSide` and `FlagUpLo` enums to return the flipped value directly instead of a `Result`, since the operation cannot fail. Updated all call sites to remove unnecessary `?` error propagation.

## Enhancements

- Re-exported the BLAS traits prelude under the new feature in `rstsr/src/prelude.rs` for easier access.
- Made all BLAS flag enums (`FlagOrder`, `TensorIterOrder`, `FlagTrans`, `FlagSide`, `FlagUpLo`, `FlagDiag`, `FlagSymm`) derive `Serialize` and `Deserialize`, and added Serde `rename` attributes for better control over their string representations.

## Crate structure

- Added `serde` as a dependency in the relevant `Cargo.toml` files and imported the necessary traits in `flags.rs`.
- Symlinked `CHANGELOG.md` to rstsr crate directory.

(Partially summarized by Copilot)