### PR TITLE
Print tensor enhancement

### DIFF
--- a/rstsr-core/src/format/format_tensor.rs
+++ b/rstsr-core/src/format/format_tensor.rs
@@ -1,4 +1,5 @@
 use crate::prelude_dev::*;
+use core::fmt::{Debug, Display, LowerExp};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 pub static MIN_PRINT: AtomicUsize = AtomicUsize::new(3);
@@ -16,16 +17,17 @@ where
     max_print: usize,
     min_print: usize,
     fmt: &'f1 mut core::fmt::Formatter<'f2>,
+    fmt_elem: fn(&T, &mut core::fmt::Formatter<'_>) -> core::fmt::Result,
 }
 
-/* #region display print */
+/* #region generic print */
 
-pub fn print_vec_with_layout_dfs<T, D>(c: &mut FnPrintVecWithLayout<T, D>) -> core::fmt::Result
+fn print_vec_with_layout_dfs_inner<T, D>(c: &mut FnPrintVecWithLayout<T, D>) -> core::fmt::Result
 where
-    T: Clone + Display,
+    T: Clone,
     D: DimAPI,
 {
-    let FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt } = c;
+    let FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt, fmt_elem } = c;
     let max_print = *max_print;
     let min_print = *min_print;
     let ndim = layout.ndim();
@@ -33,10 +35,11 @@ where
     let len_prev = idx_prev.len();
     let shape = layout.shape().as_ref();
     let stride = layout.stride().as_ref();
+    let fmt_elem = *fmt_elem;
 
     // special case
     if ndim == 0 {
-        return write!(fmt, "{}", vec[layout.offset()]);
+        return fmt_elem(&vec[layout.offset()], fmt);
     }
 
     if idx_prev.last().is_some_and(|&v| v == shape[len_prev - 1]) {
@@ -63,7 +66,7 @@ where
                 let offset = offset + p2 as isize * stride[len_prev - 2];
                 let offset = offset as usize;
                 c.offset = offset;
-                return print_vec_with_layout_dfs(c);
+                return print_vec_with_layout_dfs_inner(c);
             } else {
                 write!(fmt, "{}...\n\n", " ".repeat(len_prev - 1))?;
                 let p2: usize = shape[len_prev - 2] - min_print;
@@ -71,7 +74,7 @@ where
                 let offset = offset + p2 as isize * stride[len_prev - 2];
                 let offset = offset as usize;
                 c.offset = offset;
-                return print_vec_with_layout_dfs(c);
+                return print_vec_with_layout_dfs_inner(c);
             }
         }
     } else {
@@ -79,7 +82,7 @@ where
         if len_prev + 1 != ndim {
             // new index can still be pushed
             idx_prev.push(0);
-            return print_vec_with_layout_dfs(c);
+            return print_vec_with_layout_dfs_inner(c);
         } else {
             // last line
 
@@ -115,20 +118,20 @@ where
                 for i in 0..nlast {
                     let offset_i = (offset as isize + i as isize * stride_last) as usize;
                     write!(fmt, " ")?;
-                    Display::fmt(&vec[offset_i], fmt)?;
+                    fmt_elem(&vec[offset_i], fmt)?;
                 }
             } else {
                 // only print the first/last min_print elements
                 for i in 0..min_print {
                     let offset_i = (offset as isize + i as isize * stride_last) as usize;
                     write!(fmt, " ")?;
-                    Display::fmt(&vec[offset_i], fmt)?;
+                    fmt_elem(&vec[offset_i], fmt)?;
                 }
                 write!(fmt, " ...")?;
                 for i in (nlast - min_print)..nlast {
                     let offset_i = (offset as isize + i as isize * stride_last) as usize;
                     write!(fmt, " ")?;
-                    Display::fmt(&vec[offset_i], fmt)?;
+                    fmt_elem(&vec[offset_i], fmt)?;
                 }
             };
 
@@ -172,7 +175,7 @@ where
                     let offset = offset + p1 as isize * stride[len_prev - 1];
                     let offset = offset as usize;
                     c.offset = offset;
-                    return print_vec_with_layout_dfs(c);
+                    return print_vec_with_layout_dfs_inner(c);
                 } else {
                     writeln!(fmt, "{}...", " ".repeat(len_prev))?;
                     let p1: usize = shape[len_prev - 1] - min_print;
@@ -180,12 +183,34 @@ where
                     let offset = offset + p1 as isize * stride[len_prev - 1];
                     let offset = offset as usize;
                     c.offset = offset;
-                    return print_vec_with_layout_dfs(c);
+                    return print_vec_with_layout_dfs_inner(c);
                 }
             }
         }
     }
 }
+
+fn print_vec_with_layout_generic<T, D>(
+    fmt: &mut core::fmt::Formatter<'_>,
+    vec: &[T],
+    layout: &Layout<D>,
+    max_print: usize,
+    min_print: usize,
+    fmt_elem: fn(&T, &mut core::fmt::Formatter<'_>) -> core::fmt::Result,
+) -> core::fmt::Result
+where
+    T: Clone,
+    D: DimAPI,
+{
+    let idx_prev = vec![];
+    let offset = layout.offset();
+    let mut config = FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt, fmt_elem };
+    print_vec_with_layout_dfs_inner(&mut config)
+}
+
+/* #endregion */
+
+/* #region display print */
 
 pub fn print_vec_with_layout<T, D>(
     fmt: &mut core::fmt::Formatter<'_>,
@@ -198,10 +223,7 @@ where
     T: Clone + Display,
     D: DimAPI,
 {
-    let idx_prev = vec![];
-    let offset = layout.offset();
-    let mut config = FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt };
-    print_vec_with_layout_dfs(&mut config)
+    print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, Display::fmt)
 }
 
 impl<R, T, B, D> Display for TensorAny<R, T, B, D>
@@ -225,173 +247,6 @@ where
 
 /* #region debug print */
 
-pub fn print_vec_with_layout_dfs_debug<T, D>(c: &mut FnPrintVecWithLayout<T, D>) -> core::fmt::Result
-where
-    T: Clone + Debug,
-    D: DimAPI,
-{
-    let FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt } = c;
-    let max_print = *max_print;
-    let min_print = *min_print;
-    let ndim = layout.ndim();
-    let offset = *offset;
-    let len_prev = idx_prev.len();
-    let shape = layout.shape().as_ref();
-    let stride = layout.stride().as_ref();
-
-    // special case
-    if ndim == 0 {
-        return write!(fmt, "{:?}", vec[layout.offset()]);
-    }
-
-    if idx_prev.last().is_some_and(|&v| v == shape[len_prev - 1]) {
-        // hit shape boundary
-
-        // special case: zero shape quick return
-        if idx_prev.last().is_some_and(|&v| v == 0) {
-            return write!(fmt, "[]");
-        }
-
-        // pop last index, increase previous index by 1 or skip
-        if len_prev == 1 {
-            // multiple dimension exit
-            return Ok(());
-        } else {
-            let p1_prev = idx_prev.pop().unwrap();
-            let p2_prev = idx_prev.pop().unwrap();
-            let offset =
-                offset as isize - p1_prev as isize * stride[len_prev - 1] - p2_prev as isize * stride[len_prev - 2];
-            if shape[len_prev - 2] < max_print || p2_prev + min_print >= shape[len_prev - 2] || p2_prev + 1 < min_print
-            {
-                let p2 = p2_prev + 1;
-                idx_prev.push(p2);
-                let offset = offset + p2 as isize * stride[len_prev - 2];
-                let offset = offset as usize;
-                c.offset = offset;
-                return print_vec_with_layout_dfs_debug(c);
-            } else {
-                write!(fmt, "{}...\n\n", " ".repeat(len_prev - 1))?;
-                let p2: usize = shape[len_prev - 2] - min_print;
-                idx_prev.push(p2);
-                let offset = offset + p2 as isize * stride[len_prev - 2];
-                let offset = offset as usize;
-                c.offset = offset;
-                return print_vec_with_layout_dfs_debug(c);
-            }
-        }
-    } else {
-        // not hit shape boundary
-        if len_prev + 1 != ndim {
-            // new index can still be pushed
-            idx_prev.push(0);
-            return print_vec_with_layout_dfs_debug(c);
-        } else {
-            // last line
-
-            // number of last dimension
-            let nlast = *shape.last().unwrap();
-            let stride_last = *stride.last().unwrap();
-
-            // special case: zero shape quick return
-            if nlast == 0 {
-                return write!(fmt, "[]");
-            }
-
-            // prefix: "  [[["
-            // count zeros from last element as numbers of "["
-            if idx_prev.is_empty() {
-                write!(fmt, "[")?;
-            } else {
-                let mut nbra = 1;
-                for &idx in idx_prev.iter().rev() {
-                    if idx == 0 {
-                        nbra += 1;
-                    } else {
-                        break;
-                    }
-                }
-                write!(fmt, "{:}", " ".repeat(ndim - nbra))?;
-                write!(fmt, "{:}", "[".repeat(nbra))?;
-            }
-
-            // values: " 1.23 4.56 ... 7.89 10.11"
-            if nlast <= max_print.max(2 * min_print + 1) {
-                // all elements in last dimension should be printed
-                for i in 0..nlast {
-                    let offset_i = (offset as isize + i as isize * stride_last) as usize;
-                    write!(fmt, " ")?;
-                    Debug::fmt(&vec[offset_i], fmt)?;
-                }
-            } else {
-                // only print the first/last min_print elements
-                for i in 0..min_print {
-                    let offset_i = (offset as isize + i as isize * stride_last) as usize;
-                    write!(fmt, " ")?;
-                    Debug::fmt(&vec[offset_i], fmt)?;
-                }
-                write!(fmt, " ...")?;
-                for i in (nlast - min_print)..nlast {
-                    let offset_i = (offset as isize + i as isize * stride_last) as usize;
-                    write!(fmt, " ")?;
-                    Debug::fmt(&vec[offset_i], fmt)?;
-                }
-            };
-
-            // suffix: "]]]"
-            // count (if index = shape) from last element as numbers of "["
-            if idx_prev.is_empty() {
-                write!(fmt, "]")?;
-            } else {
-                let mut nket = 1;
-                for i in (0..idx_prev.len()).rev() {
-                    if idx_prev[i] == shape[i] - 1 {
-                        nket += 1;
-                    } else {
-                        break;
-                    }
-                }
-                write!(fmt, "{:}", "]".repeat(nket))?;
-                if nket != ndim {
-                    // last line should not add new-line character
-                    if nket > 1 {
-                        writeln!(fmt, "\n")?;
-                    } else {
-                        writeln!(fmt)?;
-                    }
-                }
-            }
-
-            // pop last index, increase previous index by 1 or skip
-            if len_prev == 0 {
-                // one-dimension exit
-                return Ok(());
-            } else {
-                let p1_prev = idx_prev.pop().unwrap();
-                let offset = offset as isize - p1_prev as isize * stride[len_prev - 1];
-                if shape[len_prev - 1] < max_print
-                    || p1_prev + min_print >= shape[len_prev - 1]
-                    || p1_prev + 1 < min_print
-                {
-                    let p1 = p1_prev + 1;
-                    idx_prev.push(p1);
-                    let offset = offset + p1 as isize * stride[len_prev - 1];
-                    let offset = offset as usize;
-                    c.offset = offset;
-                    return print_vec_with_layout_dfs_debug(c);
-                } else {
-                    writeln!(fmt, "{}...", " ".repeat(len_prev))?;
-                    let p1: usize = shape[len_prev - 1] - min_print;
-                    idx_prev.push(p1);
-                    let offset = offset + p1 as isize * stride[len_prev - 1];
-                    let offset = offset as usize;
-                    c.offset = offset;
-                    return print_vec_with_layout_dfs_debug(c);
-                }
-            }
-        }
-    }
-}
-
 pub fn print_vec_with_layout_debug<T, D>(
     fmt: &mut core::fmt::Formatter<'_>,
     vec: &[T],
@@ -403,10 +258,7 @@ where
     T: Clone + Debug,
     D: DimAPI,
 {
-    let idx_prev = vec![];
-    let offset = layout.offset();
-    let mut config = FnPrintVecWithLayout { vec, layout, offset, idx_prev, max_print, min_print, fmt };
-    print_vec_with_layout_dfs_debug(&mut config)
+    print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, Debug::fmt)
 }
 
 impl<R, T, B, D> Debug for TensorAny<R, T, B, D>
@@ -432,6 +284,41 @@ where
         let self_type = core::any::type_name::<Self>();
         writeln!(f, "Type: {self_type}")?;
         writeln!(f, "==========================")
+    }
+}
+
+/* #endregion */
+
+/* #region lower exp print */
+
+pub fn print_vec_with_layout_lower_exp<T, D>(
+    fmt: &mut core::fmt::Formatter<'_>,
+    vec: &[T],
+    layout: &Layout<D>,
+    max_print: usize,
+    min_print: usize,
+) -> core::fmt::Result
+where
+    T: Clone + LowerExp,
+    D: DimAPI,
+{
+    print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, LowerExp::fmt)
+}
+
+impl<R, T, B, D> LowerExp for TensorAny<R, T, B, D>
+where
+    T: Clone + LowerExp,
+    B: DeviceAPI<T>,
+    B::Raw: Clone,
+    D: DimAPI,
+    R: DataCloneAPI<Data = B::Raw>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let vec = self.storage().to_cpu_vec().unwrap();
+        let layout = &self.layout();
+        let max_print = MAX_PRINT.load(Ordering::Relaxed);
+        let min_print = MIN_PRINT.load(Ordering::Relaxed);
+        print_vec_with_layout_lower_exp(f, &vec, layout, max_print, min_print)
     }
 }
 
@@ -463,25 +350,18 @@ mod playground {
 
     #[test]
     fn playground() {
-        let mut s = String::new();
-
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout: Layout<_> = [].into();
         println!("{:?}", VL(vec, layout));
 
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout: Layout<_> = [2, 0, 4].into();
         println!("{:}", VL(vec, layout));
 
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout: Layout<_> = [2, 4, 0].into();
         println!("{:}", VL(vec, layout));
-        println!("{s:}");
 
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout: Layout<Ix2> = [3, 5].into();
         println!("{:}", VL(vec, layout));
@@ -491,7 +371,6 @@ mod playground {
         b = a[4:13].reshape(3, 3)
         c = b.T[::2, ::-1]
         */
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout = Layout::<Ix2>::new([2, 3], [2, -4], 10).unwrap();
         println!("{:}", VL(vec, layout));
@@ -501,7 +380,6 @@ mod playground {
         b = a[2:14].reshape(3, 4)
         c = b.T[:, ::-1]
         */
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout = Layout::<Ix2>::new([4, 3], [1, -4], 10).unwrap();
         println!("{:}", VL(vec, layout));
@@ -511,14 +389,20 @@ mod playground {
         b = a[2:14].reshape(3, 4)
         c = b.T[:, ::-1]
         */
-        s.clear();
         let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let layout = Layout::<Ix2>::new([4, 3], [1, -4], 10).unwrap();
         println!("{:}", VL(vec, layout));
 
-        s.clear();
         let vec = (0..1800).collect::<Vec<usize>>();
         let layout = Layout::<Ix3>::new([15, 12, 10], [1, 150, 15], 0).unwrap();
         println!("{:4}", VL(vec, layout));
+    }
+
+    #[test]
+    fn playground_lowerexp() {
+        use crate::prelude::*;
+        let vec = vec![0.001, 0.01, 0.1, 1., 10., 100., 1000., 10000., 100000., 1000000.];
+        let arr = rt::asarray((vec, [2, 5]));
+        println!("{:14.5e}", arr);
     }
 }

--- a/rstsr-core/src/format/format_tensor.rs
+++ b/rstsr-core/src/format/format_tensor.rs
@@ -256,11 +256,19 @@ where
     print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, Debug::fmt)
 }
 
+/// Debug print for TensorAny (more expansive than Display print).
+///
+/// Please note, for debug print, we force tensor to be copied. Debug print will compliy less trait
+/// bounds, so debugging in other devices can be somehow convenient.
+///
+/// So debug print a very large tensor can be very costly.
+///
+/// For CPU devices, the more appropriate way is to display print; the tensor is not cloned while
+/// printing.
 impl<R, T, B, D> Debug for TensorAny<R, T, B, D>
 where
     T: Clone + Debug,
-    B: DeviceAPI<T> + Debug,
-    B::Raw: Clone,
+    B: DeviceAPI<T, Raw: Clone> + Debug,
     D: DimAPI,
     R: DataCloneAPI<Data = B::Raw>,
 {

--- a/rstsr-core/src/format/format_tensor.rs
+++ b/rstsr-core/src/format/format_tensor.rs
@@ -229,17 +229,25 @@ where
 impl<R, T, B, D> Display for TensorAny<R, T, B, D>
 where
     T: Clone + Display,
-    B: DeviceAPI<T>,
-    B::Raw: Clone,
+    for<'a> B: DeviceAPI<T, Raw: 'a>
+        + DeviceChangeAPI<
+            'a,
+            DeviceCpuSerial,
+            DataRef<'a, <B as DeviceRawAPI<T>>::Raw>,
+            T,
+            D,
+            Repr: DataAPI<Data = Vec<T>>,
+        >,
     D: DimAPI,
-    R: DataCloneAPI<Data = B::Raw>,
+    R: DataAPI<Data = B::Raw>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let vec = self.storage().to_cpu_vec().unwrap();
-        let layout = &self.layout();
+        let tsr = self.view().change_device(&DeviceCpuSerial::default());
+        let slc = tsr.raw();
+        let layout = &tsr.layout();
         let max_print = MAX_PRINT.load(Ordering::Relaxed);
         let min_print = MIN_PRINT.load(Ordering::Relaxed);
-        print_vec_with_layout(f, &vec, layout, max_print, min_print)
+        print_vec_with_layout(f, slc, layout, max_print, min_print)
     }
 }
 

--- a/rstsr-core/src/format/format_tensor.rs
+++ b/rstsr-core/src/format/format_tensor.rs
@@ -1,5 +1,5 @@
 use crate::prelude_dev::*;
-use core::fmt::{Debug, Display, LowerExp};
+use core::fmt::{Debug, Display, LowerExp, UpperExp};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 pub static MIN_PRINT: AtomicUsize = AtomicUsize::new(3);
@@ -210,25 +210,12 @@ where
 
 /* #endregion */
 
-/* #region display print */
+/* #region display/lowerexp/upperexp print */
 
-pub fn print_vec_with_layout<T, D>(
-    fmt: &mut core::fmt::Formatter<'_>,
-    vec: &[T],
-    layout: &Layout<D>,
-    max_print: usize,
-    min_print: usize,
-) -> core::fmt::Result
+#[duplicate_item(Trait; [Display]; [LowerExp]; [UpperExp])]
+impl<R, T, B, D> Trait for TensorAny<R, T, B, D>
 where
-    T: Clone + Display,
-    D: DimAPI,
-{
-    print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, Display::fmt)
-}
-
-impl<R, T, B, D> Display for TensorAny<R, T, B, D>
-where
-    T: Clone + Display,
+    T: Clone + Trait,
     for<'a> B: DeviceAPI<T, Raw: 'a>
         + DeviceChangeAPI<
             'a,
@@ -247,7 +234,7 @@ where
         let layout = &tsr.layout();
         let max_print = MAX_PRINT.load(Ordering::Relaxed);
         let min_print = MIN_PRINT.load(Ordering::Relaxed);
-        print_vec_with_layout(f, slc, layout, max_print, min_print)
+        print_vec_with_layout_generic(f, slc, layout, max_print, min_print, Trait::fmt)
     }
 }
 
@@ -283,7 +270,7 @@ where
         let layout = &self.layout();
         let max_print = MAX_PRINT.load(Ordering::Relaxed);
         let min_print = MIN_PRINT.load(Ordering::Relaxed);
-        print_vec_with_layout_debug(f, &vec, layout, max_print, min_print)?;
+        print_vec_with_layout_generic(f, &vec, layout, max_print, min_print, Debug::fmt)?;
         writeln!(f)?;
         Debug::fmt(&self.device(), f)?;
         writeln!(f)?;
@@ -292,41 +279,6 @@ where
         let self_type = core::any::type_name::<Self>();
         writeln!(f, "Type: {self_type}")?;
         writeln!(f, "==========================")
-    }
-}
-
-/* #endregion */
-
-/* #region lower exp print */
-
-pub fn print_vec_with_layout_lower_exp<T, D>(
-    fmt: &mut core::fmt::Formatter<'_>,
-    vec: &[T],
-    layout: &Layout<D>,
-    max_print: usize,
-    min_print: usize,
-) -> core::fmt::Result
-where
-    T: Clone + LowerExp,
-    D: DimAPI,
-{
-    print_vec_with_layout_generic(fmt, vec, layout, max_print, min_print, LowerExp::fmt)
-}
-
-impl<R, T, B, D> LowerExp for TensorAny<R, T, B, D>
-where
-    T: Clone + LowerExp,
-    B: DeviceAPI<T>,
-    B::Raw: Clone,
-    D: DimAPI,
-    R: DataCloneAPI<Data = B::Raw>,
-{
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let vec = self.storage().to_cpu_vec().unwrap();
-        let layout = &self.layout();
-        let max_print = MAX_PRINT.load(Ordering::Relaxed);
-        let min_print = MIN_PRINT.load(Ordering::Relaxed);
-        print_vec_with_layout_lower_exp(f, &vec, layout, max_print, min_print)
     }
 }
 
@@ -352,7 +304,7 @@ mod playground {
             let layout = &self.1;
             let max_print = MAX_PRINT.load(Ordering::Relaxed);
             let min_print = MIN_PRINT.load(Ordering::Relaxed);
-            print_vec_with_layout(f, vec, layout, max_print, min_print)
+            print_vec_with_layout_generic(f, vec, layout, max_print, min_print, Display::fmt)
         }
     }
 

--- a/rstsr-core/src/tensor/operators/op_unary_common.rs
+++ b/rstsr-core/src/tensor/operators/op_unary_common.rs
@@ -228,7 +228,7 @@ mod test {
     #[test]
     fn test_abs() {
         use num::complex::c32;
-        let a = linspace((c32(1.0, 2.0), c32(5.0, 6.0), 6)).into_shape([2, 3]);
+        let a = linspace((c32(1.0_f32, 2.0_f32), c32(5.0_f32, 6.0_f32), 6)).into_shape([2, 3]);
         let ptr_a = a.raw().as_ptr();
         let b = a.abs();
         let ptr_b = b.raw().as_ptr();
@@ -251,7 +251,7 @@ mod test {
     #[test]
     fn test_hetrogeneous_type() {
         use num::complex::c32;
-        let a = linspace((c32(1.0, 2.0), c32(5.0, 6.0), 6)).into_shape([2, 3]);
+        let a = linspace((c32(1.0_f32, 2.0_f32), c32(5.0_f32, 6.0_f32), 6)).into_shape([2, 3]);
         let b = (&a).imag();
         println!("{b:}");
     }


### PR DESCRIPTION
This PR will

- Allow LowerExp/UpperExp (scientific float print).
- Changes the behavior of Display print, now the tensor will only be referenced when printing at least for CPU devices.

We still make Debug print to copy the whole tensor. In this way, the debug print uses minimal trait bounds, easier for debugging in other devices. This behavior may also change if necessary.