### PR TITLE
Bug fix: matmul with broadcast in multiple-dimensions

### DIFF
--- a/crates-device/rstsr-aocl/src/matmul.rs
+++ b/crates-device/rstsr-aocl/src/matmul.rs
@@ -136,94 +136,19 @@ where
     };
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => {
-            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
-            unreachable!()
-        },
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;

--- a/crates-device/rstsr-blis/src/matmul.rs
+++ b/crates-device/rstsr-blis/src/matmul.rs
@@ -136,94 +136,19 @@ where
     };
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => {
-            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
-            unreachable!()
-        },
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;

--- a/crates-device/rstsr-kml/src/matmul.rs
+++ b/crates-device/rstsr-kml/src/matmul.rs
@@ -136,94 +136,19 @@ where
     };
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => {
-            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
-            unreachable!()
-        },
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;

--- a/crates-device/rstsr-mkl/src/matmul.rs
+++ b/crates-device/rstsr-mkl/src/matmul.rs
@@ -136,94 +136,19 @@ where
     };
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => {
-            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
-            unreachable!()
-        },
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;

--- a/crates-device/rstsr-openblas/src/matmul.rs
+++ b/crates-device/rstsr-openblas/src/matmul.rs
@@ -136,94 +136,19 @@ where
     };
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => {
-            rstsr_raise!(InvalidLayout, "This is not valid layout for matmul broadcasting.")?;
-            unreachable!()
-        },
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;
@@ -446,6 +371,33 @@ mod test {
         let c = &a % &a.swapaxes(-1, -2);
         let d = &a % &b.swapaxes(-1, -2);
         assert!(allclose_f64(&c, &d));
+    }
+
+    #[test]
+    fn test_matmul_rule7_broadcast() {
+        // rule 7 with batch broadcasting: the batch (`rest`) dims of A and B
+        // must broadcast against C's batch dims. Previously A/B batch layouts
+        // were not broadcast, so e.g. `[1, M, K] @ [B, K, N]` panicked instead
+        // of producing `[B, M, N]`.
+        let device = DeviceBLAS::default();
+
+        // A broadcasts on the batch axis: [1, M, K] @ [B, K, N] -> [B, M, N]
+        let a = linspace((0.0, 14.0, 15, &device)).into_shape([1, 3, 5]);
+        let b = linspace((0.0, 29.0, 30, &device)).into_shape([2, 5, 3]);
+        let c = &a % &b;
+        assert_eq!(c.shape(), &[2, 3, 3]);
+        let a_big = a.to_broadcast(vec![2, 3, 5]);
+        let c_ref = &a_big % &b;
+        assert!(allclose_f64(&c, &c_ref));
+
+        // B broadcasts on the batch axis: [B, M, K] @ [1, K, N] -> [B, M, N]
+        let a = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        let b = linspace((0.0, 14.0, 15, &device)).into_shape([1, 5, 3]);
+        let c = &a % &b;
+        assert_eq!(c.shape(), &[2, 3, 3]);
+        let b_big = b.to_broadcast(vec![2, 5, 3]);
+        let c_ref = &a % &b_big;
+        assert!(allclose_f64(&c, &c_ref));
     }
 
     #[test]

--- a/rstsr-common/src/layout/matmul.rs
+++ b/rstsr-common/src/layout/matmul.rs
@@ -271,6 +271,155 @@ fn layout_matmul_dyn_row_major(la: &Layout<IxD>, lb: &Layout<IxD>) -> Result<Lay
     }
 }
 
+/// Resolve matmul layouts against a caller-provided `lc`.
+///
+/// Unlike [`layout_matmul_dyn_row_major`], which *constructs* `lc` from `la`
+/// and `lb`, this function takes the real `lc` as the source of truth for the
+/// batch shape (it comes from the caller and may be strided / non-zero-offset)
+/// and derives `la_rest` / `lb_rest` by broadcasting them **to** `lc_rest`.
+/// All returned layouts are split from the real `la` / `lb` / `lc`, so their
+/// strides and offsets are valid for indexing into the actual operand buffers.
+///
+/// This is the canonical entry point used by the `DeviceMatMulAPI`
+/// implementations (faer, BLAS backends, naive CPU); it centralizes the rule
+/// table and the batch-broadcasting so the device drivers only have to dispatch
+/// on [`MatMulType`] and iterate the rest layouts.
+pub fn layout_matmul_dyn_row_major_with_lc(
+    la: &Layout<IxD>,
+    lb: &Layout<IxD>,
+    lc: &Layout<IxD>,
+) -> Result<LayoutMatMulConfig<IxD, IxD>> {
+    let na = la.ndim();
+    let nb = lb.ndim();
+    let nc = lc.ndim();
+    match (na, nb) {
+        (1, 1) => {
+            // rule 1: vector inner dot
+            rstsr_assert_eq!(la.shape(), lb.shape(), InvalidLayout)?;
+            rstsr_assert_eq!(nc, 0, InvalidLayout)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::InnerDot,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.clone(),
+                lb_matmul: lb.clone(),
+                lc_matmul: lc.clone(),
+            })
+        },
+        (2, 2) => {
+            // rule 2: matrix multiplication
+            rstsr_assert_eq!(nc, 2, InvalidLayout)?;
+            rstsr_assert_eq!(la.shape()[1], lb.shape()[0], InvalidLayout)?;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMM22,
+                lc: lc.clone(),
+                la_rest: None,
+                lb_rest: None,
+                lc_rest: None,
+                la_matmul: la.clone(),
+                lb_matmul: lb.clone(),
+                lc_matmul: lc.clone(),
+            })
+        },
+        (1, 2..) => {
+            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
+            rstsr_assert_eq!(nb, nc + 1, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-1)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
+            let la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEVM,
+                lc: lc.clone(),
+                la_rest: Some(la_rest),
+                lb_rest: Some(lb_r),
+                lc_rest: Some(lc_r),
+                la_matmul: la_m.dim_insert(0)?,
+                lb_matmul: lb_m,
+                lc_matmul: lc_m.dim_insert(0)?,
+            })
+        },
+        (2.., 1) => {
+            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
+            rstsr_assert_eq!(na, nc + 1, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
+            let lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMV,
+                lc: lc.clone(),
+                la_rest: Some(la_r),
+                lb_rest: Some(lb_rest),
+                lc_rest: Some(lc_r),
+                la_matmul: la_m,
+                lb_matmul: lb_m.dim_insert(1)?,
+                lc_matmul: lc_m.dim_insert(1)?,
+            })
+        },
+        (2, 3..) => {
+            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
+            rstsr_assert_eq!(nb, nc, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            let la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMM2X,
+                lc: lc.clone(),
+                la_rest: Some(la_rest),
+                lb_rest: Some(lb_r),
+                lc_rest: Some(lc_r),
+                la_matmul: la_m,
+                lb_matmul: lb_m,
+                lc_matmul: lc_m,
+            })
+        },
+        (3.., 2) => {
+            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
+            rstsr_assert_eq!(na, nc, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            let lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMMX2,
+                lc: lc.clone(),
+                la_rest: Some(la_r),
+                lb_rest: Some(lb_rest),
+                lc_rest: Some(lc_r),
+                la_matmul: la_m,
+                lb_matmul: lb_m,
+                lc_matmul: lc_m,
+            })
+        },
+        (3.., 3..) => {
+            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
+            rstsr_assert_eq!(na, nc, InvalidLayout)?;
+            rstsr_assert_eq!(nb, nc, InvalidLayout)?;
+            let (la_r, la_m) = la.dim_split_at(-2)?;
+            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
+            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
+            // both A and B batch dims broadcast against C's batch dims
+            let la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
+            let lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
+            Ok(LayoutMatMulConfig {
+                matmul_type: MatMulType::GEMMXX,
+                lc: lc.clone(),
+                la_rest: Some(la_rest),
+                lb_rest: Some(lb_rest),
+                lc_rest: Some(lc_r),
+                la_matmul: la_m,
+                lb_matmul: lb_m,
+                lc_matmul: lc_m,
+            })
+        },
+        (0, _) | (_, 0) => rstsr_invalid!((na, nb), "In matmul, 0-dim is not allowed."),
+    }
+}
+
 fn layout_matmul_dyn_col_major(la: &Layout<IxD>, lb: &Layout<IxD>) -> Result<LayoutMatMulConfig<IxD, IxD>> {
     // For col-major, we re-use the row-major implementation via the identity
     //     C[t, m, n] = A[t, m, k] @ B[t, k, n]   (row-major)

--- a/rstsr-core/src/device_faer/matmul.rs
+++ b/rstsr-core/src/device_faer/matmul.rs
@@ -131,91 +131,19 @@ where
     }
 
     // handle broadcasted cases
-    // temporary variables
-    let la_matmul;
-    let lb_matmul;
-    let lc_matmul;
-    let la_rest;
-    let lb_rest;
-    let lc_rest;
-
-    match (la.ndim(), lb.ndim(), lc.ndim()) {
-        // we have already handled these cases
-        (1, 1, 0) | (2, 2, 2) => unreachable!(),
-        (1, 2.., _) => {
-            // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-1)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.dim_insert(0)?.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(0)?.into_dim::<Ix2>()?;
-        },
-        (2.., 1, _) => {
-            // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-1)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-1)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.dim_insert(1)?.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.dim_insert(1)?.into_dim::<Ix2>()?;
-        },
-        (2, 3.., _) => {
-            // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = broadcast_layout_to_first(&lc_r, &la_r, RowMajor)?.1;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 2, _) => {
-            // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = broadcast_layout_to_first(&lc_r, &lb_r, RowMajor)?.1;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        (3.., 3.., _) => {
-            // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-            rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-            rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-            let (la_r, la_m) = la.dim_split_at(-2)?;
-            let (lb_r, lb_m) = lb.dim_split_at(-2)?;
-            let (lc_r, lc_m) = lc.dim_split_at(-2)?;
-            la_rest = la_r;
-            lb_rest = lb_r;
-            lc_rest = lc_r;
-            la_matmul = la_m.into_dim::<Ix2>()?;
-            lb_matmul = lb_m.into_dim::<Ix2>()?;
-            lc_matmul = lc_m.into_dim::<Ix2>()?;
-        },
-        _ => todo!(),
-    }
+    let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+    // rules 1 and 2 are handled above as fast paths; only the broadcasted
+    // rules (3..7) reach here.
+    let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+    let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+    let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+    let la_rest = cfg.la_rest.unwrap();
+    let lb_rest = cfg.lb_rest.unwrap();
+    let lc_rest = cfg.lc_rest.unwrap();
     // now, lx_rest should have the same shape, while lx_matmul
     // should be matmulable
     // only parallel matmul when lx_rest is small (larger than
     // 2*nthreads), otherwise parallel matmul anyway
-    rstsr_assert_eq!(la_rest.shape(), lb_rest.shape(), InvalidLayout)?;
-    rstsr_assert_eq!(lb_rest.shape(), lc_rest.shape(), InvalidLayout)?;
     let n_task = la_rest.size();
     let ita_rest = IterLayoutColMajor::new(&la_rest)?;
     let itb_rest = IterLayoutColMajor::new(&lb_rest)?;
@@ -385,5 +313,40 @@ mod test {
         let c = &a % &b;
         println!("{:}", c);
         assert!(c.shape() == &[3, 3, 2]);
+    }
+
+    #[test]
+    fn test_matmul_rule7_broadcast() {
+        // rule 7 with batch broadcasting: the batch (`rest`) dims of A and B
+        // must broadcast against C's batch dims. Previously A/B batch layouts
+        // were not broadcast, so e.g. `[1, M, K] @ [B, K, N]` panicked instead
+        // of producing `[B, M, N]`.
+        let mut device = DeviceFaer::default();
+        device.set_default_order(RowMajor);
+
+        // A broadcasts on the batch axis: [1, M, K] @ [B, K, N] -> [B, M, N]
+        let a = linspace((0.0, 14.0, 15, &device)).into_shape([1, 3, 5]);
+        let b = linspace((0.0, 29.0, 30, &device)).into_shape([2, 5, 3]);
+        let c = &a % &b;
+        assert_eq!(c.shape(), &[2, 3, 3]);
+        let a_big = a.to_broadcast(vec![2, 3, 5]);
+        let c_ref = &a_big % &b;
+        assert!(allclose_f64(&c, &c_ref));
+
+        // B broadcasts on the batch axis: [B, M, K] @ [1, K, N] -> [B, M, N]
+        let a = linspace((0.0, 29.0, 30, &device)).into_shape([2, 3, 5]);
+        let b = linspace((0.0, 14.0, 15, &device)).into_shape([1, 5, 3]);
+        let c = &a % &b;
+        assert_eq!(c.shape(), &[2, 3, 3]);
+        let b_big = b.to_broadcast(vec![2, 5, 3]);
+        let c_ref = &a % &b_big;
+        assert!(allclose_f64(&c, &c_ref));
+
+        // both broadcast: [1, M, K] @ [B, K, 1] is not valid, but
+        // [1, M, K] @ [1, K, N] -> [1, M, N] is a no-op broadcast.
+        let a = linspace((0.0, 14.0, 15, &device)).into_shape([1, 3, 5]);
+        let b = linspace((0.0, 14.0, 15, &device)).into_shape([1, 5, 3]);
+        let c = &a % &b;
+        assert_eq!(c.shape(), &[1, 3, 3]);
     }
 }

--- a/rstsr-native-impl/src/cpu_serial/matmul_naive.rs
+++ b/rstsr-native-impl/src/cpu_serial/matmul_naive.rs
@@ -30,152 +30,47 @@ where
     // for column-major layout, we need to transpose the input:
     // C = A * B  =>  C^T = B^T * A^T
     match (la.ndim(), lb.ndim(), lc.ndim()) {
-            (1, 1, 0) => {
-                // rule 1: vector inner dot
-                let la = &la.clone().into_dim::<Ix1>().unwrap();
-                let lb = &lb.clone().into_dim::<Ix1>().unwrap();
-                let lc = &lc.clone().into_dim::<Ix0>().unwrap();
-                inner_dot_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
-            },
-            (2, 2, 2) => {
-                // rule 2: matrix multiplication
-                let la = &la.clone().into_dim::<Ix2>().unwrap();
-                let lb = &lb.clone().into_dim::<Ix2>().unwrap();
-                let lc = &lc.clone().into_dim::<Ix2>().unwrap();
-                gemm_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
-            },
-            (2, 1, 1) => {
-                // rule 4 special: 2 x 1
-                let la = &la.clone().into_dim::<Ix2>().unwrap();
-                let lb = &lb.clone().into_dim::<Ix1>().unwrap();
-                let lc = &lc.clone().into_dim::<Ix1>().unwrap();
-                gemv_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
-            },
-            (1, 2, 1) => {
-                // rule 3 special: 1 x 2
-                let la = &la.clone().into_dim::<Ix1>().unwrap();
-                let lb = &lb.clone().into_dim::<Ix2>().unwrap();
-                let lc = &lc.clone().into_dim::<Ix1>().unwrap();
-                gevm_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
-            },
-            (1, 2.., _) => {
-                // rule 3: | `        K` | `..., K, N` | `   ..., N` |
-                rstsr_assert_eq!(lb.ndim(), lc.ndim() + 1, InvalidLayout)?;
-                let la = &la.clone().into_dim::<Ix1>().unwrap();
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
-                let lb_matmul = &mut lb_matmul.into_dim::<Ix2>()?;
-                let lc_matmul = &mut lc_matmul.into_dim::<Ix1>()?;
-                let l_rest = translate_to_col_major(&[&lc_rest, &lb_rest], TensorIterOrder::K)?;
-                let (lc_rest, lb_rest) = (&l_rest[0], &l_rest[1]);
-                let itb_rest = IterLayoutColMajor::new(lb_rest)?;
-                let itc_rest = IterLayoutColMajor::new(lc_rest)?;
-                for (ib_rest, ic_rest) in izip!(itb_rest, itc_rest) {
-                    unsafe { lb_matmul.set_offset(ib_rest) };
-                    unsafe { lc_matmul.set_offset(ic_rest) };
-                    gevm_naive_cpu_serial(c, lc_matmul, a, la, b, lb_matmul, alpha.clone(), beta.clone())?;
+        (1, 1, 0) => {
+            // rule 1: vector inner dot
+            let la = &la.clone().into_dim::<Ix1>().unwrap();
+            let lb = &lb.clone().into_dim::<Ix1>().unwrap();
+            let lc = &lc.clone().into_dim::<Ix0>().unwrap();
+            inner_dot_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
+        },
+        (2, 2, 2) => {
+            // rule 2: matrix multiplication
+            let la = &la.clone().into_dim::<Ix2>().unwrap();
+            let lb = &lb.clone().into_dim::<Ix2>().unwrap();
+            let lc = &lc.clone().into_dim::<Ix2>().unwrap();
+            gemm_naive_cpu_serial(c, lc, a, la, b, lb, alpha, beta)?;
+        },
+        _ => {
+            // broadcasted rules 3..7: the config resolves the rule, broadcasts
+            // the batch (`rest`) dims against `lc`, and hands us 2-D matmul
+            // layouts (via `dim_insert` for the vector rules).
+            let cfg = layout_matmul_dyn_row_major_with_lc(&la.to_dim()?, &lb.to_dim()?, &lc.to_dim()?)?;
+            let la_matmul = cfg.la_matmul.into_dim::<Ix2>()?;
+            let lb_matmul = cfg.lb_matmul.into_dim::<Ix2>()?;
+            let lc_matmul = cfg.lc_matmul.into_dim::<Ix2>()?;
+            let la_rest = cfg.la_rest.unwrap();
+            let lb_rest = cfg.lb_rest.unwrap();
+            let lc_rest = cfg.lc_rest.unwrap();
+            let ita_rest = IterLayoutColMajor::new(&la_rest)?;
+            let itb_rest = IterLayoutColMajor::new(&lb_rest)?;
+            let itc_rest = IterLayoutColMajor::new(&lc_rest)?;
+            for (ia_rest, ib_rest, ic_rest) in izip!(ita_rest, itb_rest, itc_rest) {
+                let mut la_m = la_matmul.clone();
+                let mut lb_m = lb_matmul.clone();
+                let mut lc_m = lc_matmul.clone();
+                unsafe {
+                    la_m.set_offset(ia_rest);
+                    lb_m.set_offset(ib_rest);
+                    lc_m.set_offset(ic_rest);
                 }
-            },
-            (2.., 1, _) => {
-                // rule 4: | `..., M, K` | `        K` | `   ..., M` |
-                rstsr_assert_eq!(la.ndim(), lc.ndim() + 1, InvalidLayout)?;
-                let lb = &lb.clone().into_dim::<Ix1>().unwrap();
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-1)?;
-                let la_matmul = &mut la_matmul.into_dim::<Ix2>()?;
-                let lc_matmul = &mut lc_matmul.into_dim::<Ix1>()?;
-                let l_rest = translate_to_col_major(&[&lc_rest, &la_rest], TensorIterOrder::K)?;
-                let (lc_rest, la_rest) = (&l_rest[0], &l_rest[1]);
-                let ita_rest = IterLayoutColMajor::new(la_rest)?;
-                let itc_rest = IterLayoutColMajor::new(lc_rest)?;
-                for (ib_rest, ic_rest) in izip!(ita_rest, itc_rest) {
-                    unsafe { la_matmul.set_offset(ib_rest) };
-                    unsafe { lc_matmul.set_offset(ic_rest) };
-                    gemv_naive_cpu_serial(c, lc_matmul, a, la_matmul, b, lb, alpha.clone(), beta.clone())?;
-                }
-            },
-            (2, 3.., _) => {
-                // rule 5: | `     M, K` | `..., K, N` | `..., M, N` |
-                rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-                let la = &la.clone().into_dim::<Ix2>().unwrap();
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                let lb_matmul = &mut lb_matmul.into_dim::<Ix2>()?;
-                let lc_matmul = &mut lc_matmul.into_dim::<Ix2>()?;
-                let l_rest = translate_to_col_major(&[&lc_rest, &lb_rest], TensorIterOrder::K)?;
-                let (lc_rest, lb_rest) = (&l_rest[0], &l_rest[1]);
-                let itb_rest = IterLayoutColMajor::new(lb_rest)?;
-                let itc_rest = IterLayoutColMajor::new(lc_rest)?;
-                for (ib_rest, ic_rest) in izip!(itb_rest, itc_rest) {
-                    unsafe { lb_matmul.set_offset(ib_rest) };
-                    unsafe { lc_matmul.set_offset(ic_rest) };
-                    gemm_naive_cpu_serial(c, lc_matmul, a, la, b, lb_matmul, alpha.clone(), beta.clone())?;
-                }
-            },
-            (3.., 2, _) => {
-                // rule 6: | `..., M, K` | `     K, N` | `..., M, N` |
-                rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-                let lb = &lb.clone().into_dim::<Ix2>().unwrap();
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                let la_matmul = &mut la_matmul.into_dim::<Ix2>()?;
-                let lc_matmul = &mut lc_matmul.into_dim::<Ix2>()?;
-                let l_rest = translate_to_col_major(&[&lc_rest, &la_rest], TensorIterOrder::K)?;
-                let (lc_rest, la_rest) = (&l_rest[0], &l_rest[1]);
-                let ita_rest = IterLayoutColMajor::new(la_rest)?;
-                let itc_rest = IterLayoutColMajor::new(lc_rest)?;
-                for (ib_rest, ic_rest) in izip!(ita_rest, itc_rest) {
-                    unsafe { la_matmul.set_offset(ib_rest) };
-                    unsafe { lc_matmul.set_offset(ic_rest) };
-                    gemm_naive_cpu_serial(c, lc_matmul, a, la_matmul, b, lb, alpha.clone(), beta.clone())?;
-                }
-            },
-            (3.., 3.., _) => {
-                // rule 7: | `..., M, K` | `..., K, N` | `..., M, N` |
-                rstsr_assert_eq!(la.ndim(), lc.ndim(), InvalidLayout)?;
-                rstsr_assert_eq!(lb.ndim(), lc.ndim(), InvalidLayout)?;
-                let (la_rest, la_matmul) = la.dim_split_at(-2)?;
-                let (lb_rest, lb_matmul) = lb.dim_split_at(-2)?;
-                let (lc_rest, lc_matmul) = lc.dim_split_at(-2)?;
-                let la_matmul = &mut la_matmul.into_dim::<Ix2>()?;
-                let lb_matmul = &mut lb_matmul.into_dim::<Ix2>()?;
-                let lc_matmul = &mut lc_matmul.into_dim::<Ix2>()?;
-                let l_rest =
-                    translate_to_col_major(&[&lc_rest, &la_rest, &lb_rest], TensorIterOrder::K)?;
-                let (lc_rest, la_rest, lb_rest) = (&l_rest[0], &l_rest[1], &l_rest[2]);
-                let ita_rest = IterLayoutColMajor::new(la_rest)?;
-                let itb_rest = IterLayoutColMajor::new(lb_rest)?;
-                let itc_rest = IterLayoutColMajor::new(lc_rest)?;
-                for (ia_rest, ib_rest, ic_rest) in izip!(ita_rest, itb_rest, itc_rest) {
-                    unsafe { la_matmul.set_offset(ia_rest) };
-                    unsafe { lb_matmul.set_offset(ib_rest) };
-                    unsafe { lc_matmul.set_offset(ic_rest) };
-                    gemm_naive_cpu_serial(
-                        c,
-                        lc_matmul,
-                        a,
-                        la_matmul,
-                        b,
-                        lb_matmul,
-                        alpha.clone(),
-                        beta.clone(),
-                    )?;
-                }
-            },
-            // handle other cases
-            (0, _, _) | (_, 0, _) // zero-dimension input
-            | (1, 1, 1..) // rule 1 invalid
-            | (2, 2, 3..) | (2, 2, 0..2) // rule 2 invalid
-            => {
-                rstsr_raise!(
-                    InvalidLayout,
-                    "Invalid ndim for matmul: {}, {}, {}",
-                    la.ndim(),
-                    lb.ndim(),
-                    lc.ndim()
-                )?;
-            },
-        }
+                gemm_naive_cpu_serial(c, &lc_m, a, &la_m, b, &lb_m, alpha.clone(), beta.clone())?;
+            }
+        },
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This PR focus on broadcast matmul like `[1, M, K] * [B, K, N] -> [B, M, N]` (the 7th rule of [matmul broadcasting](https://data-apis.org/array-api/latest/API_specification/generated/array_api.matmul.html)). (this PR description discuss in row-major)

Previously, only `[B, M, K] * [B, K, N] -> [B, M, N]` works (axes after third dimension exactly matches). Now the axes after third dimensions can be broadcasted.

The code also refactored the handling of matmul layouts. Now we added a function `layout_matmul_dyn_row_major_with_lc` in rstsr-common, and let all other devices to call this function when dealing matmul.