### PR TITLE
rstsr-common (refactor): introduce AxisError and IndexError error types

### DIFF
--- a/rstsr-common/src/axis_index.rs
+++ b/rstsr-common/src/axis_index.rs
@@ -386,26 +386,14 @@ pub fn normalize_axes_index(
     let vec = match axes {
         AxesIndex::None => rstsr_raise!(InvalidValue, "Axes argument cannot be None for this operation.")?,
         AxesIndex::Val(axis) => {
-            let axis = if axis < 0 { (ndim as isize) + axis } else { axis };
-            rstsr_pattern!(
-                axis,
-                0..(ndim as isize),
-                InvalidValue,
-                "Axis index {axis} is out of bounds for tensor with {ndim} dimensions."
-            )?;
-            vec![axis]
+            let axis = rstsr_check_axis!(axis, ndim)?;
+            vec![axis as isize]
         },
         AxesIndex::Vec(axes) => {
             let mut normalized_axes = Vec::with_capacity(axes.len());
             for &axis in axes.iter() {
-                let norm_axis = if axis < 0 { (ndim as isize) + axis } else { axis };
-                rstsr_pattern!(
-                    norm_axis,
-                    0..(ndim as isize),
-                    InvalidValue,
-                    "Axis index {axis} is out of bounds for tensor with {ndim} dimensions."
-                )?;
-                normalized_axes.push(norm_axis);
+                let norm_axis = rstsr_check_axis!(axis, ndim)?;
+                normalized_axes.push(norm_axis as isize);
             }
             if sort {
                 normalized_axes.sort();

--- a/rstsr-common/src/error.rs
+++ b/rstsr-common/src/error.rs
@@ -16,6 +16,16 @@ pub enum RSTSRError {
     ValueOutOfRange(String),
     InvalidValue(String),
     InvalidLayout(String),
+
+    /// An axis argument is out of bounds for a tensor's number of dimensions.
+    /// Structured (NumPy `AxisError`-like) so a caller may match and recover.
+    /// `axis` keeps the original, possibly-negative input the caller passed.
+    AxisError { axis: isize, ndim: usize },
+
+    /// An element index (or slice bound) is out of range along an axis.
+    /// Message-only (Python `IndexError`-like): a programmer bug, not recoverable.
+    IndexError(String),
+
     RuntimeError(String),
     DeviceMismatch(String),
     UnImplemented(String),
@@ -323,6 +333,66 @@ macro_rules! rstsr_raise {
         write!(s, " : ").unwrap();
         write!(s, $($arg)*).unwrap();
         Err(Error{ inner: RSTSRError::$errtype(s), backtrace: rstsr_backtrace() })
+    }};
+}
+
+/// Validate an axis argument against a tensor's `ndim`, folding a negative axis
+/// (counted from the end, `-1` == last axis) before the bounds check.
+///
+/// Returns the normalized non-negative axis (`Ok(usize)`), or
+/// `Err(AxisError { axis: <original>, ndim })` when out of range. The `axis`
+/// field preserves the original (possibly negative) input so a caller can match
+/// and recover. Collapses the negative-fold-plus-bounds-check that was
+/// copy-pasted across the layout code.
+#[macro_export]
+macro_rules! rstsr_check_axis {
+    ($axis:expr, $ndim:expr) => {{
+        let axis: isize = $axis;
+        let ndim: usize = $ndim;
+        let norm = if axis < 0 { (ndim as isize) + axis } else { axis };
+        if norm >= 0 && (norm as usize) < ndim {
+            core::result::Result::Ok(norm as usize)
+        } else {
+            core::result::Result::Err($crate::error::Error {
+                inner: $crate::error::RSTSRError::AxisError { axis, ndim },
+                backtrace: $crate::error::rstsr_backtrace(),
+            })
+        }
+    }};
+}
+
+/// Like [`rstsr_check_axis!`], but the upper bound is `0..=ndim` (inclusive)
+/// rather than `0..ndim`. Used by operations that *insert* a new axis and so
+/// accept an axis position one beyond the current last: `dim_insert`, `stack`,
+/// `into_unpack_array`.
+#[macro_export]
+macro_rules! rstsr_check_axis_insert {
+    ($axis:expr, $ndim:expr) => {{
+        let axis: isize = $axis;
+        let ndim: usize = $ndim;
+        // insert positions fold as `ndim + axis + 1` so that `-1` inserts at the end.
+        let norm = if axis < 0 { (ndim as isize) + axis + 1 } else { axis };
+        if norm >= 0 && (norm as usize) <= ndim {
+            core::result::Result::Ok(norm as usize)
+        } else {
+            core::result::Result::Err($crate::error::Error {
+                inner: $crate::error::RSTSRError::AxisError { axis, ndim },
+                backtrace: $crate::error::rstsr_backtrace(),
+            })
+        }
+    }};
+}
+
+/// Construct an `AxisError` unconditionally (without validating). Use when a
+/// site has already determined the axis is invalid, or when raising for a
+/// related reason where the `(axis, ndim)` pair is still the right payload.
+#[macro_export]
+macro_rules! rstsr_axis_error {
+    ($axis:expr, $ndim:expr) => {{
+        $crate::error::Error {
+            inner: $crate::error::RSTSRError::AxisError { axis: $axis, ndim: $ndim },
+            backtrace: $crate::error::rstsr_backtrace(),
+        }
     }};
 }
 

--- a/rstsr-common/src/error.rs
+++ b/rstsr-common/src/error.rs
@@ -20,7 +20,10 @@ pub enum RSTSRError {
     /// An axis argument is out of bounds for a tensor's number of dimensions.
     /// Structured (NumPy `AxisError`-like) so a caller may match and recover.
     /// `axis` keeps the original, possibly-negative input the caller passed.
-    AxisError { axis: isize, ndim: usize },
+    AxisError {
+        axis: isize,
+        ndim: usize,
+    },
 
     /// An element index (or slice bound) is out of range along an axis.
     /// Message-only (Python `IndexError`-like): a programmer bug, not recoverable.

--- a/rstsr-common/src/layout/indexer.rs
+++ b/rstsr-common/src/layout/indexer.rs
@@ -119,9 +119,7 @@ where
 {
     fn dim_narrow(&self, axis: isize, slice: SliceI) -> Result<Self> {
         // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, self.ndim())?;
 
         // get essential information
         let mut shape = self.shape().clone();
@@ -227,9 +225,7 @@ where
 
     fn dim_select(&self, axis: isize, index: isize) -> Result<Layout<Self::DOut>> {
         // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, self.ndim())?;
 
         // get essential information
         let shape = self.shape();
@@ -243,7 +239,7 @@ where
             if i == axis {
                 // dimension to be selected
                 let idx = if index < 0 { d as isize + index } else { index };
-                rstsr_pattern!(idx, 0..d as isize, ValueOutOfRange)?;
+                rstsr_pattern!(idx, 0..d as isize, IndexError)?;
                 offset += s * idx;
             } else {
                 // other dimensions
@@ -259,9 +255,7 @@ where
 
     fn dim_eliminate(&self, axis: isize) -> Result<Layout<Self::DOut>> {
         // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, self.ndim())?;
 
         // get essential information
         let mut shape = self.shape().as_ref().to_vec();
@@ -281,9 +275,7 @@ where
 
     fn dim_chop(&self, axis: isize) -> Result<Layout<Self::DOut>> {
         // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, self.ndim())?;
 
         // get essential information
         let mut shape = self.shape().as_ref().to_vec();
@@ -314,10 +306,8 @@ where
     type DOut = <D as DimLargerOneAPI>::LargerOne;
 
     fn dim_insert(&self, axis: isize) -> Result<Layout<Self::DOut>> {
-        // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis + 1 } else { axis };
-        rstsr_pattern!(axis, 0..(self.ndim() + 1) as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        // dimension check (insert positions accept 0..=ndim, i.e. one past the last axis)
+        let axis = rstsr_check_axis_insert!(axis, self.ndim())?;
 
         // get essential information
         let is_f_prefer = self.f_prefer();
@@ -441,9 +431,11 @@ where
     fn dim_split_at(&self, axis: isize) -> Result<(Layout<IxD>, Layout<IxD>)> {
         // dimension check
         // this functions allows [-n, n], not previous functions [-n, n)
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..=self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let norm = if axis < 0 { self.ndim() as isize + axis } else { axis };
+        if !(norm >= 0 && norm <= self.ndim() as isize) {
+            return Err(rstsr_axis_error!(axis, self.ndim()));
+        }
+        let axis = norm as usize;
 
         // split layouts
         let shape = self.shape().as_ref().to_vec();

--- a/rstsr-common/src/layout/layoutbase.rs
+++ b/rstsr-common/src/layout/layoutbase.rs
@@ -214,7 +214,7 @@ where
 
         for (&idx, &shp, &strd) in izip!(index.iter(), shape.iter(), stride.iter()) {
             let idx = if idx < 0 { idx + shp as isize } else { idx };
-            rstsr_pattern!(idx, 0..(shp as isize), ValueOutOfRange)?;
+            rstsr_pattern!(idx, 0..(shp as isize), IndexError)?;
             pos += strd * idx;
         }
         rstsr_pattern!(pos, 0.., ValueOutOfRange)?;
@@ -334,12 +334,8 @@ where
         let offset = offset.unwrap_or(0);
         let axis1 = axis1.unwrap_or(0);
         let axis2 = axis2.unwrap_or(1);
-        let axis1 = if axis1 < 0 { self.ndim() as isize + axis1 } else { axis1 };
-        let axis2 = if axis2 < 0 { self.ndim() as isize + axis2 } else { axis2 };
-        rstsr_pattern!(axis1, 0..self.ndim() as isize, ValueOutOfRange)?;
-        rstsr_pattern!(axis2, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis1 = axis1 as usize;
-        let axis2 = axis2 as usize;
+        let axis1 = rstsr_check_axis!(axis1, self.ndim())?;
+        let axis2 = rstsr_check_axis!(axis2, self.ndim())?;
 
         // shape and strides of last two dimensions
         let d1 = self.shape()[axis1] as isize;
@@ -491,13 +487,8 @@ where
 
     /// Swap axes of layout.
     pub fn swapaxes(&self, axis1: isize, axis2: isize) -> Result<Self> {
-        let axis1 = if axis1 < 0 { self.ndim() as isize + axis1 } else { axis1 };
-        rstsr_pattern!(axis1, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis1 = axis1 as usize;
-
-        let axis2 = if axis2 < 0 { self.ndim() as isize + axis2 } else { axis2 };
-        rstsr_pattern!(axis2, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis2 = axis2 as usize;
+        let axis1 = rstsr_check_axis!(axis1, self.ndim())?;
+        let axis2 = rstsr_check_axis!(axis2, self.ndim())?;
 
         let mut shape = self.shape().clone();
         let mut stride = self.stride().clone();

--- a/rstsr-common/src/prelude_dev.rs
+++ b/rstsr-common/src/prelude_dev.rs
@@ -30,6 +30,6 @@ pub use crate::par_iter::*;
 pub use rayon::ThreadPool;
 
 pub use crate::{
-    impl_from_tuple_to_axes_index, rstsr_assert, rstsr_assert_eq, rstsr_errcode, rstsr_error, rstsr_invalid,
-    rstsr_pattern, rstsr_raise, s, slice,
+    impl_from_tuple_to_axes_index, rstsr_assert, rstsr_assert_eq, rstsr_axis_error, rstsr_check_axis,
+    rstsr_check_axis_insert, rstsr_errcode, rstsr_error, rstsr_invalid, rstsr_pattern, rstsr_raise, s, slice,
 };

--- a/rstsr-common/src/tensordot_to_einsum.rs
+++ b/rstsr-common/src/tensordot_to_einsum.rs
@@ -49,10 +49,10 @@ pub fn tensordot_to_einsum_str(
     };
 
     // Axis bounds are already guaranteed by the branches above:
-    //  - `Pair` runs each side through `normalize_axes_index(.., dim, ..)`, which
-    //    folds negative axes and rejects any out-of-range axis with `AxisError`.
-    //  - `Val(n)` constructs `(dim_a - n..dim_a)` / `(0..n)`, both in-bounds because
-    //    the `n > dim_a || n > dim_b` check above returns `InvalidLayout` first.
+    //  - `Pair` runs each side through `normalize_axes_index(.., dim, ..)`, which folds negative axes
+    //    and rejects any out-of-range axis with `AxisError`.
+    //  - `Val(n)` constructs `(dim_a - n..dim_a)` / `(0..n)`, both in-bounds because the `n > dim_a ||
+    //    n > dim_b` check above returns `InvalidLayout` first.
     // The `assert_eq!(axes_a.len(), axes_b.len(), …)` and per-axis bounds asserts
     // that previously lived here were dead defensive code (they could never fire
     // after the validation above) *and* they panicked inside a `Result`-returning

--- a/rstsr-common/src/tensordot_to_einsum.rs
+++ b/rstsr-common/src/tensordot_to_einsum.rs
@@ -48,15 +48,15 @@ pub fn tensordot_to_einsum_str(
         },
     };
 
-    assert_eq!(axes_a.len(), axes_b.len(), "axes must have same length");
-
-    // Validate axis indices
-    for &i in &axes_a {
-        assert!(i < dim_a, "axis {} out of bounds for tensor A", i);
-    }
-    for &j in &axes_b {
-        assert!(j < dim_b, "axis {} out of bounds for tensor B", j);
-    }
+    // Axis bounds are already guaranteed by the branches above:
+    //  - `Pair` runs each side through `normalize_axes_index(.., dim, ..)`, which
+    //    folds negative axes and rejects any out-of-range axis with `AxisError`.
+    //  - `Val(n)` constructs `(dim_a - n..dim_a)` / `(0..n)`, both in-bounds because
+    //    the `n > dim_a || n > dim_b` check above returns `InvalidLayout` first.
+    // The `assert_eq!(axes_a.len(), axes_b.len(), …)` and per-axis bounds asserts
+    // that previously lived here were dead defensive code (they could never fire
+    // after the validation above) *and* they panicked inside a `Result`-returning
+    // function, masking a genuine axis error behind a crash. Removed.
 
     // Label generator: a..z then A..Z (enough for most practical uses)
     let mut label_gen = (b'a'..=b'z').chain(b'A'..=b'Z').map(|c| c as char);

--- a/rstsr-core/src/tensor/adv_indexing.rs
+++ b/rstsr-core/src/tensor/adv_indexing.rs
@@ -20,9 +20,7 @@ where
     let tensor_layout = tensor.layout();
     let ndim = tensor_layout.ndim();
     // check axis and index
-    let axis = if axis < 0 { ndim as isize + axis } else { axis };
-    rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "Invalid axis that exceeds ndim.")?;
-    let axis = axis as usize;
+    let axis = rstsr_check_axis!(axis, ndim)?;
     let nshape: usize = tensor_layout.shape()[axis];
     let indices = indices.try_into().map_err(Into::into)?;
     let indices = indices
@@ -30,13 +28,7 @@ where
         .iter()
         .map(|&i| -> Result<usize> {
             let i = if i < 0 { nshape as isize + i } else { i };
-            rstsr_pattern!(
-                i,
-                0..nshape as isize,
-                InvalidLayout,
-                "Invalid index that exceeds shape length at axis {}.",
-                axis
-            )?;
+            rstsr_pattern!(i, 0..nshape as isize, IndexError, "Invalid index that exceeds shape length at axis {}.", axis)?;
             Ok(i as usize)
         })
         .collect::<Result<Vec<usize>>>()?;

--- a/rstsr-core/src/tensor/adv_indexing.rs
+++ b/rstsr-core/src/tensor/adv_indexing.rs
@@ -28,7 +28,13 @@ where
         .iter()
         .map(|&i| -> Result<usize> {
             let i = if i < 0 { nshape as isize + i } else { i };
-            rstsr_pattern!(i, 0..nshape as isize, IndexError, "Invalid index that exceeds shape length at axis {}.", axis)?;
+            rstsr_pattern!(
+                i,
+                0..nshape as isize,
+                IndexError,
+                "Invalid index that exceeds shape length at axis {}.",
+                axis
+            )?;
             Ok(i as usize)
         })
         .collect::<Result<Vec<usize>>>()?;

--- a/rstsr-core/src/tensor/creation_from_tensor.rs
+++ b/rstsr-core/src/tensor/creation_from_tensor.rs
@@ -349,9 +349,7 @@ where
         })?;
 
         // check and make axis positive
-        let axis = if axis < 0 { ndim as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "axis out of bounds")?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, ndim)?;
 
         // - check shape compatibility (dimension other than axis must match)
         // - calculate the new shape
@@ -670,10 +668,8 @@ where
             Ok(())
         })?;
 
-        // check and make axis positive
-        let axis = if axis < 0 { ndim as isize + axis + 1 } else { axis };
-        rstsr_pattern!(axis, 0..=ndim as isize, InvalidLayout, "axis out of bounds")?;
-        let axis = axis as usize;
+        // check and make axis positive (stack inserts a new axis, so 0..=ndim is valid)
+        let axis = rstsr_check_axis_insert!(axis, ndim)?;
 
         // expand the shape of each tensor
         let tensors = tensors.into_iter().map(|tensor| tensor.into_expand_dims_f(axis)).collect::<Result<Vec<_>>>()?;
@@ -800,9 +796,7 @@ where
 
         // check axis
         let ndim = tensor.ndim();
-        let axis = if axis < 0 { ndim as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..ndim as isize, InvalidLayout, "axis out of bounds")?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, ndim)?;
 
         (0..tensor.layout().shape()[axis])
             .map(|i| {

--- a/rstsr-core/src/tensor/pack_array.rs
+++ b/rstsr-core/src/tensor/pack_array.rs
@@ -134,9 +134,7 @@ where
     {
         // check if the axis is valid
         // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis } else { axis };
-        rstsr_pattern!(axis, 0..self.ndim() as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        let axis = rstsr_check_axis!(axis, self.ndim())?;
         rstsr_assert_eq!(self.layout().stride()[axis], 1, InvalidLayout, "The axis must be contiguous")?;
         rstsr_assert_eq!(self.layout().shape()[axis], N, InvalidLayout, "The axis length must be a exactly {N}")?;
         rstsr_assert!(self.layout().offset() % N == 0, InvalidLayout, "The offset must be a multiple of {N}")?;
@@ -193,10 +191,8 @@ where
         ROut: DataAPI<Data = <B as DeviceRawAPI<T>>::Raw>,
         B: DeviceAPI<T>,
     {
-        // dimension check
-        let axis = if axis < 0 { self.ndim() as isize + axis + 1 } else { axis };
-        rstsr_pattern!(axis, 0..(self.ndim() + 1) as isize, ValueOutOfRange)?;
-        let axis = axis as usize;
+        // dimension check (insert positions accept 0..=ndim)
+        let axis = rstsr_check_axis_insert!(axis, self.ndim())?;
 
         let (storage, layout) = self.into_raw_parts();
         let (data, device) = storage.into_raw_parts();

--- a/rstsr-native-impl/src/cpu_rayon/adv_indexing.rs
+++ b/rstsr-native-impl/src/cpu_rayon/adv_indexing.rs
@@ -22,9 +22,9 @@ where
     // basic check
     let ndim = lc.ndim();
     rstsr_assert_eq!(ndim, la.ndim(), InvalidLayout, "Input and output ndim should same.")?;
-    rstsr_pattern!(axis, 0..ndim, InvalidLayout, "Invalid axis that exceeds ndim.")?;
+    rstsr_check_axis!(axis as isize, ndim)?;
     rstsr_assert_eq!(lc.shape()[axis], indices.len(), InvalidLayout, "Invalid index length.")?;
-    rstsr_pattern!(*indices.iter().max().unwrap_or(&0), 0..la.shape()[axis], InvalidLayout, "Index out of range.",)?;
+    rstsr_pattern!(*indices.iter().max().unwrap_or(&0), 0..la.shape()[axis], IndexError, "Index out of range.")?;
 
     // determine how iteration should be performed
     let axis_contig_c = lc.stride()[axis] == 1;

--- a/rstsr-native-impl/src/cpu_serial/adv_indexing.rs
+++ b/rstsr-native-impl/src/cpu_serial/adv_indexing.rs
@@ -27,9 +27,9 @@ where
     // basic check
     let ndim = lc.ndim();
     rstsr_assert_eq!(ndim, la.ndim(), InvalidLayout, "Input and output ndim should same.")?;
-    rstsr_pattern!(axis, 0..ndim, InvalidLayout, "Invalid axis that exceeds ndim.")?;
+    rstsr_check_axis!(axis as isize, ndim)?;
     rstsr_assert_eq!(lc.shape()[axis], indices.len(), InvalidLayout, "Invalid index length.")?;
-    rstsr_pattern!(*indices.iter().max().unwrap_or(&0), 0..la.shape()[axis], InvalidLayout, "Index out of range.",)?;
+    rstsr_pattern!(*indices.iter().max().unwrap_or(&0), 0..la.shape()[axis], IndexError, "Index out of range.")?;
 
     // determine how iteration should be performed
     let axis_contig_c = lc.stride()[axis] == 1;


### PR DESCRIPTION
Add structured `AxisError { axis, ndim }` and message-only `IndexError` variants to `RSTSRError`, migrating axis-selection and element-index sites off the generic variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)