### PR TITLE
Fix: Let no_std targets work

### DIFF
--- a/.github/workflows/rstsr-no-std-test.yml
+++ b/.github/workflows/rstsr-no-std-test.yml
@@ -1,0 +1,30 @@
+name: rstsr no_std builds
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  # Build the core rstsr crates for bare-metal (no std library) targets.
+  # The facade `-p rstsr` pulls in rstsr-core, rstsr-common, rstsr-dtype-traits
+  # and rstsr-native-impl, so one build covers the whole no_std dependency chain.
+  # `--no-default-features` is required: default features enable std/backtrace
+  # and std-only backends (faer, rayon, openblas).
+  no-std-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - thumbv7em-none-eabi # 32-bit ARM Cortex-M4/M7, soft-float
+          - aarch64-unknown-none # 64-bit ARM, bare-metal
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build rstsr (row-major, no_std)
+        run: cargo build --target ${{ matrix.target }} --package rstsr --no-default-features --features row_major

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ libm = { version = "0.2" }
 derive_builder = { version = "0.20", default-features = false, features = ["alloc"] }
 duplicate = { version = "2.0" }
 rustversion = { version = "1.0" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 # optional dependencies
 rayon = { version = ">=1.10" }
 faer = { version = "0.22", default-features = false, features = ["rayon", "linalg"] }

--- a/rstsr-common/Cargo.toml
+++ b/rstsr-common/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true }
 rstsr-core = { path = "../rstsr-core", default-features = false }
 
 [features]
-std = []
+std = ["serde/std"]
 backtrace = ["std"]
 rayon = ["dep:rayon"]
 

--- a/rstsr-common/src/tensordot_to_einsum.rs
+++ b/rstsr-common/src/tensordot_to_einsum.rs
@@ -11,8 +11,9 @@ use crate::prelude_dev::*;
 ///
 /// # Example
 /// ```
-/// let s = tensordot_to_einsum_str(2, 2, (vec![1], vec![0]));
-/// assert_eq!(s, "ba,ac->bc");  // equivalent to "ik,kj->ij"
+/// # use rstsr_common::tensordot_to_einsum::tensordot_to_einsum_str;
+/// let s = tensordot_to_einsum_str(2, 2, (vec![1], vec![0])).unwrap();
+/// assert_eq!(s, "ba, ac -> bc");  // equivalent to "ik,kj->ij"
 /// ```
 #[allow(clippy::needless_range_loop)]
 pub fn tensordot_to_einsum_str(
@@ -49,10 +50,10 @@ pub fn tensordot_to_einsum_str(
     };
 
     // Axis bounds are already guaranteed by the branches above:
-    //  - `Pair` runs each side through `normalize_axes_index(.., dim, ..)`, which folds negative axes
-    //    and rejects any out-of-range axis with `AxisError`.
-    //  - `Val(n)` constructs `(dim_a - n..dim_a)` / `(0..n)`, both in-bounds because the `n > dim_a ||
-    //    n > dim_b` check above returns `InvalidLayout` first.
+    //  - `Pair` runs each side through `normalize_axes_index(.., dim, ..)`, which folds negative
+    //    axes and rejects any out-of-range axis with `AxisError`.
+    //  - `Val(n)` constructs `(dim_a - n..dim_a)` / `(0..n)`, both in-bounds because the `n > dim_a
+    //    || n > dim_b` check above returns `InvalidLayout` first.
     // The `assert_eq!(axes_a.len(), axes_b.len(), …)` and per-axis bounds asserts
     // that previously lived here were dead defensive code (they could never fire
     // after the validation above) *and* they panicked inside a `Result`-returning

--- a/rstsr-core/src/tensor/operators/op_tri.rs
+++ b/rstsr-core/src/tensor/operators/op_tri.rs
@@ -1,5 +1,5 @@
 use crate::prelude_dev::*;
-use num::ToPrimitive;
+use num::{Float as NumFloat, ToPrimitive};
 
 /* #region pack_tri */
 
@@ -112,7 +112,7 @@ where
                 // check last two dimensions are equal
                 let (lb_rest, lb_inner) = lb.dim_split_at(-1)?;
                 let n_tp: usize = lb_inner.shape()[0];
-                let n: usize = (2 * n_tp).to_f64().unwrap().sqrt().floor().to_usize().unwrap();
+                let n: usize = NumFloat::floor(NumFloat::sqrt((2 * n_tp).to_f64().unwrap())).to_usize().unwrap();
                 rstsr_assert_eq!(
                     n * (n + 1) / 2,
                     n_tp,
@@ -129,7 +129,7 @@ where
                 // check first two dimensions are equal
                 let (lb_inner, lb_rest) = lb.dim_split_at(1)?;
                 let n_tp: usize = lb_inner.shape()[0];
-                let n: usize = (2 * n_tp).to_f64().unwrap().sqrt().floor().to_usize().unwrap();
+                let n: usize = NumFloat::floor(NumFloat::sqrt((2 * n_tp).to_f64().unwrap())).to_usize().unwrap();
                 rstsr_assert_eq!(
                     n * (n + 1) / 2,
                     n_tp,

--- a/rstsr-dtype-traits/src/isclose.rs
+++ b/rstsr-dtype-traits/src/isclose.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use alloc::format;
+use alloc::string::String;
 use core::ops::*;
 use derive_builder::Builder;
 
@@ -15,6 +17,7 @@ use derive_builder::Builder;
 ///
 /// [`isclose`](isclose())
 #[derive(Builder, Clone, PartialEq, Eq, Debug)]
+#[builder(no_std)]
 pub struct IsCloseArgs<TE: 'static> {
     /// Relative tolerance. For type [f64], the default is `1.0e-5`.
     #[builder(default = "default_rtol()?")]

--- a/rstsr-dtype-traits/src/lib.rs
+++ b/rstsr-dtype-traits/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../readme.md")]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
 
 mod ext_float;
 mod ext_num;

--- a/rstsr-dtype-traits/src/val_write.rs
+++ b/rstsr-dtype-traits/src/val_write.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Sets the value of the current object to `val`.
 ///

--- a/rstsr-native-impl/src/cpu_serial/creation.rs
+++ b/rstsr-native-impl/src/cpu_serial/creation.rs
@@ -1,6 +1,6 @@
 use crate::prelude_dev::*;
 use core::ops::*;
-use num::{FromPrimitive, ToPrimitive};
+use num::{Float, FromPrimitive, ToPrimitive};
 
 /* #region arange */
 
@@ -29,7 +29,7 @@ where
     // We just try to convert to isize. We believe it's really rare case that usize is used in arange;
     // and anyway, fallback is always available with efficiency loss.
     let (start_, end_, step_) = (start.to_isize()?, end.to_isize()?, step.to_isize()?);
-    let n = ((end_ - start_) as f64 / step_ as f64).ceil().to_isize()?;
+    let n = Float::ceil((end_ - start_) as f64 / step_ as f64).to_isize()?;
 
     // The unwrap here is probably safe, since start/end/nstep are all checked.
     // `Some(map(option.unwrap).collect())` is much faster than `map(option).collect()` in this case, so
@@ -51,7 +51,7 @@ where
     T: PartialOrd + Clone + Add<Output = T> + ToPrimitive + FromPrimitive,
 {
     let (start_, end_, step_) = (start.to_f64()?, end.to_f64()?, step.to_f64()?);
-    let n = ((end_ - start_) / step_).ceil().to_usize()?;
+    let n = Float::ceil((end_ - start_) / step_).to_usize()?;
     let mut result: Vec<T> = (0..n).map(|i| T::from_f64(start_ + i as f64 * step_).unwrap()).collect();
 
     // the interval may be open on the right, so we need to pop the last element if it's out of range.

--- a/rstsr/src/lib.rs
+++ b/rstsr/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../notes_to_api_doc.md")]
 #![doc = include_str!("../readme.md")]
+#![cfg_attr(not(test), no_std)]
 pub mod prelude;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
This PR will fix current build problem on `no_std`.

Changes:

- Now rstsr should use rstsr-cblas-base v0.1.2, which also fixes its no_std.
- Fixes some float functions that previously uses `std::f64` operations but not `core::f64`. They are now using crate `num`'s trait impl with only core support.
- Fixes some imports that previously use std to core/alloc.
- Add CI for no_std builds.