### PR TITLE
rstsr: update agent-workflow references and NumPy tracking headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,10 @@ Cargo.lock
 
 # >>> Code Agent <<< #
 
-# Agent of RSTSR will be maintained in repository `RESTGroup/rstsr-agents`, and you can symlink
-# the related directory/files here.
+# Shared agent workflow (instructions entry, skills, rules) is maintained in repository
+# `RESTGroup/rstsr-agents`; symlink it into place - see its README.md, or simply run
+# `rstsr-agents/skills/agent-setup/scripts/link.sh` (skill `agent-setup`) in this
+# directory. The symlinks below are local-only, not git-tracked.
 
 # Agent directory
 .claude
@@ -61,10 +63,11 @@ Cargo.lock
 .continue/
 .roo/
 
-# Catch-all for local-only files (e.g. *.local.toml, *.local.md)
+# Catch-all for local-only files (e.g. *.local.toml, *.local.md, settings.local.json);
+# see the "Local configuration" section of rstsr-agents/README.md
 *.local*
 
-# CLAUDE.md or AGENTS.md at root directory
-# Developer should customize their own file, and `.claude.rstsr/CLAUDE.md` serves as template
+# CLAUDE.md or AGENTS.md at root directory (normally symlinks into rstsr-agents;
+# replace them with your own file to customize)
 /CLAUDE.md
 /AGENTS.md

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 
 | Resources | Badges |
 |--|--|
-| User Document | [![User Documentation](https://readthedocs.org/projects/rstsr-book/badge/?version=latest)](https://rstsr-book.readthedocs.io/latest/) |
+| User Document | [![User Documentation](https://img.shields.io/badge/docs-github_pages-blue)](https://restgroup.github.io/rstsr-book/) |
 | API Document | [![API Documentation](https://docs.rs/rstsr/badge.svg)](https://docs.rs/rstsr) |
 | Crate | [![Crate](https://img.shields.io/crates/v/rstsr.svg)](https://crates.io/crates/rstsr) |
 
@@ -152,9 +152,7 @@ You are welcomed to raise problems or suggestions in github repo issues or discu
 
 ## For AI Code Agents
 
-Shared coding-agent instructions live in `.claude.rstsr/` (`CLAUDE.md`, with `AGENTS.md` symlinked to it). Local agent state and per-developer configs are gitignored; see `.claude.rstsr/README.md` for details.
+Shared coding-agent instructions (instructions entry, skills, rules) live in the sibling repository [rstsr-agents](https://github.com/RESTGroup/rstsr-agents) and are consumed through symlinks (`.claude`, `.agents`, `CLAUDE.md`, `AGENTS.md`). Local agent state and per-developer configurations are gitignored (the `*.local` convention); setup is documented in the `README.md` of rstsr-agents.
 
-Following tasks are important for code-agent setup, and these will not git tracked.
-- You can symlink `.claude.rstsr` to `.claude` or `.agents` for your need.
-- You can symlink `.claude.rstsr/CLAUDE.md` to `AGENTS.md` at project root for your need.
+The symlinks are not git-tracked. In the standard pack layout (rstsr, rstsr-book, rstsr-ffi, rstsr-agents as sibling directories), run `../rstsr-agents/skills/agent-setup/scripts/link.sh` in this directory once (the `agent-setup` skill). Standalone checkouts and per-agent notes are covered by the same README.
 

--- a/rstsr-core/tests/tracking/numpy_coverage.csv
+++ b/rstsr-core/tests/tracking/numpy_coverage.csv
@@ -1,5 +1,5 @@
 # NumPy coverage checklist (rstsr-core) — full core_func surface.
-# Pinned NumPy: v2.5.2 · Checkout: ../other-repos/numpy (tag v2.5.2)
+# Pinned NumPy: v2.5.2 · local checkout expected at tag v2.5.2 (location is per-developer: AGENTS.local.md / skill core-numpy-sync)
 # status: transferred | partial | todo | not-applicable
 # numpy_source_hash = sha256[:12] of the NumPy test function source at the pinned
 #   version (recompute via `python3 sync_numpy.py <numpy_root>`). Changed hash on a

--- a/rstsr-core/tests/tracking/sync_numpy.py
+++ b/rstsr-core/tests/tracking/sync_numpy.py
@@ -13,6 +13,10 @@ Usage:
 The tracked surface (manipulation) is embedded in SURFACE below. To extend
 coverage to another rstsr category, add (relpath, class, method) tuples and
 their METADATA.
+
+The checkout location is per-developer (recorded in AGENTS.local.md, see the
+core-numpy-sync skill); this script takes it as an argument and never writes it
+into committed files. The CSV/diff headers are maintained by hand (skill step 6).
 """
 
 import argparse
@@ -257,6 +261,22 @@ def _index_file(tree, source):
     return out
 
 
+def _warn_on_tag_mismatch(root, pinned):
+    """Warn (stderr) if the checkout is not exactly at the pinned version tag."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "describe", "--tags", "--exact-match"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return
+    tag = out.stdout.strip()
+    if out.returncode == 0 and tag and tag != pinned:
+        print(f"warning: checkout tag {tag!r} != PINNED_VERSION {pinned!r}; "
+              f"results reflect the checkout, not the pin", file=sys.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("numpy_root")
@@ -264,6 +284,7 @@ def main():
                     help="print only path::class::method line sha256")
     args = ap.parse_args()
     root = Path(args.numpy_root)
+    _warn_on_tag_mismatch(root, PINNED_VERSION)
 
     # group surface by file to parse each once
     by_file = {}


### PR DESCRIPTION
# Summary

Update agent-workflow references to the shared `rstsr-agents` workflow, and make the NumPy tracking headers machine-independent. Companion to the `rstsr-agents` workflow upgrade (branch of the same name).

# Changes

## Feature improvements or changes

- `readme.md`: "For AI Code Agents" now describes the `rstsr-agents` workflow (`agent-setup` skill); the retired `.claude.rstsr` section is removed.
- `.gitignore`: Code Agent comment block points to the `rstsr-agents` setup and the `*.local` convention.
- `tests/tracking/numpy_coverage.csv`: header records the pinned version and expected tag only; the checkout location is per-developer (`AGENTS.local.md`), no longer hardcoded `../other-repos/numpy`.
- `tests/tracking/sync_numpy.py`: wire the previously unused `PINNED_VERSION` into a checkout-tag mismatch warning (stderr); document that the checkout location is per-developer and never written to committed files.

---

PR summarized by
- Agent: Claude Code
- Model: glm-5.3-flash[1m]
